### PR TITLE
First refactor train

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -41,5 +41,3 @@ class TrainingArguments(transformers.TrainingArguments):
         default=False,
         metadata={"help": "Packing to be enabled in SFT Trainer, default is False"},
     )
-    
-    

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -30,7 +30,11 @@ class DataArguments:
 
 @dataclass
 class TrainingArguments(transformers.TrainingArguments):
-    peft_method: str = "lora"  # None, pt
+    peft_method: Optional[str] = field(
+        default="lora",
+        metadata={"help": "pt, lora or None. PEFT method to use while tuning. \
+                  Either pt for prompt tuning or lora; or None for fine tuning "},
+    )
     cache_dir: Optional[str] = field(default=None)
     # optim: str = field(default=DEFAULT_OPTIMIZER)
     model_max_length: int = field(

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -30,11 +30,6 @@ class DataArguments:
 
 @dataclass
 class TrainingArguments(transformers.TrainingArguments):
-    peft_method: Optional[str] = field(
-        default="lora",
-        metadata={"help": "pt, lora or None. PEFT method to use while tuning. \
-                  Either pt for prompt tuning or lora; or None for fine tuning "},
-    )
     cache_dir: Optional[str] = field(default=None)
     # optim: str = field(default=DEFAULT_OPTIMIZER)
     model_max_length: int = field(

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -19,7 +19,7 @@ class ModelArguments:
         default=True,
         metadata={"help": "Use Flash attention v2 from transformers, default is True"}
     )
-    torch_dtype: Optional[torch.dtype | str] = torch.bfloat16
+    torch_dtype: Optional[Union[torch.dtype , str]] = torch.bfloat16
 
 @dataclass
 class DataArguments:

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -7,13 +7,11 @@ class LoraConfig:
     lora_alpha: int = 32
     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
     bias = "none"
-    task_type: str = "CAUSAL_LM"
     lora_dropout: float = 0.05
 
 
 @dataclass
 class PromptTuningConfig:
-    task_type: str = "CAUSAL_LM"
     prompt_tuning_init: str = "TEXT"
     num_virtual_tokens: int = 8
     prompt_tuning_init_text: str = "Classify if the tweet is a complaint or not:"

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List
 
-
 @dataclass
-class lora_config:
+class LoraConfig:
     r: int = 8
     lora_alpha: int = 32
     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
@@ -13,7 +12,7 @@ class lora_config:
 
 
 @dataclass
-class prompt_tuning_config:
+class PromptTuningConfig:
     task_type: str = "CAUSAL_LM"
     prompt_tuning_init: str = "TEXT"
     num_virtual_tokens: int = 8

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -13,6 +13,7 @@ from tuning.utils.data_type_utils import get_torch_dtype
 from aim_loader import get_aimstack_callback
 from transformers.utils import logging
 from dataclasses import asdict
+from typing import Optional
 
 from peft import LoraConfig
 import os
@@ -32,7 +33,7 @@ def train(
         model_args: configs.ModelArguments,
         data_args: configs.DataArguments,
         train_args: configs.TrainingArguments,
-        tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig
+        tuning_config: Optional[peft_config.LoraConfig | peft_config.PromptTuningConfig] = None
    ):
     """Call the SFTTrainer
 
@@ -40,13 +41,11 @@ def train(
         model args: tuning.config.configs.ModelArguments
         data args: tuning.config.configs.DataArguments
         data args: tuning.config.configs.TrainingArguments
-        tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig
+        tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig | None for fine tuning
     """
     run_distributed = int(os.environ.get("WORLD_SIZE", "1")) > 1
 
     logger = logging.get_logger("sft_trainer")
-    # parser = transformers.HfArgumentParser((configs.ModelArguments, configs.DataArguments, configs.TrainingArguments))
-    # model_args, data_args, training_args, _ = parser.parse_args_into_dataclasses(return_remaining_strings=True)
 
     # make sure to unset FSDP args when running on single gpu
     if not run_distributed:

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -153,10 +153,7 @@ def train(
 def main(**kwargs):
     parser = transformers.HfArgumentParser((configs.ModelArguments, configs.DataArguments, configs.TrainingArguments))
     model_args, data_args, training_args, _ = parser.parse_args_into_dataclasses(return_remaining_strings=True)
-    print(training_args.peft_method)
     tune_config = create_tuning_config(training_args, **kwargs)
-    print(type(tune_config))
-    print(tune_config)
     train(model_args, data_args, training_args, tune_config)
 
 if __name__ == "__main__":

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -53,6 +53,8 @@ def train(
     # Validate parameters
     if (not isinstance(train_args.num_train_epochs, float)) or (train_args.num_train_epochs <= 0):
         raise ValueError("num_train_epochs has to be an integer/float >= 1")
+    if (not isinstance(train_args.gradient_accumulation_steps , int)) or (train_args.gradient_accumulation_steps <= 0):
+        raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
 
     # make sure to unset FSDP args when running on single gpu
     if not run_distributed:

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -13,7 +13,7 @@ from tuning.utils.data_type_utils import get_torch_dtype
 from aim_loader import get_aimstack_callback
 from transformers.utils import logging
 from dataclasses import asdict
-from typing import Optional
+from typing import Optional, Union
 
 from peft import LoraConfig
 import os
@@ -33,7 +33,7 @@ def train(
         model_args: configs.ModelArguments,
         data_args: configs.DataArguments,
         train_args: configs.TrainingArguments,
-        peft_config: Optional[peft_config.LoraConfig | peft_config.PromptTuningConfig] = None,
+        peft_config: Optional[Union[peft_config.LoraConfig, peft_config.PromptTuningConfig]] = None,
    ):
     """Call the SFTTrainer
 

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -29,14 +29,16 @@ def create_tuning_config(train_config, **kwargs):
         Return:
            peft_config.LoraConfig | peft_config.PromptTuningConfig
     """
-    assert train_config.peft_method in [None, "lora", "pt"], \
+    assert train_config.peft_method in [None, "lora", "pt", "None"], \
         f"peft config {train_config.peft_method} not defined in peft.py"
     if train_config.peft_method == "lora":
         tune_config = peft_config.LoraConfig()
         update_config(tune_config, **kwargs)
-    if train_config.peft_method == "pt":
+    elif train_config.peft_method == "pt":
         tune_config = peft_config.PromptTuningConfig()
         update_config(tune_config, **kwargs)
+    else:
+        tune_config=None
     return tune_config
 
 
@@ -47,7 +49,7 @@ def get_peft_config(train_config, tuning_config):
            tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig
        Return: HF PEFT config
     """
-    assert train_config.peft_method in [None, "lora", "pt"], \
+    assert train_config.peft_method in [None, "lora", "pt", "None"], \
         f"peft config {train_config.peft_method} not defined in peft.py"
 
     if train_config.peft_method == "lora":

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -27,7 +27,7 @@ def create_tuning_config(train_config, **kwargs):
            train_config: tuning.config.configs.TrainingArguments
            kawrgs: parameters to initialize library configs with
         Return:
-           peft_config.LoraConfig | peft_config.PromptTuningConfig
+           peft_config.LoraConfig | peft_config.PromptTuningConfig | None
     """
     assert train_config.peft_method in [None, "lora", "pt", "None"], \
         f"peft config {train_config.peft_method} not defined in peft.py"
@@ -38,7 +38,7 @@ def create_tuning_config(train_config, **kwargs):
         tune_config = peft_config.PromptTuningConfig()
         update_config(tune_config, **kwargs)
     else:
-        tune_config=None
+        tune_config = None # full parameter tuning
     return tune_config
 
 
@@ -46,8 +46,8 @@ def get_peft_config(train_config, tuning_config):
     """Accept the train config and parameters and return HF PEFT config for tuning
        Args:
            train_config: tuning.config.configs.TrainingArguments
-           tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig
-       Return: HF PEFT config
+           tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig | None
+       Return: HF PEFT config or None
     """
     assert train_config.peft_method in [None, "lora", "pt", "None"], \
         f"peft config {train_config.peft_method} not defined in peft.py"


### PR DESCRIPTION
As part of first refactor , I have created a function for train which will accept predefined dataclasses as arguments instead of taking all possible parameters. 
This was done for the following reasons:
1. **more readability** - now I know exactly what arguments train function accepts
2. **allows for easier parameter validation  + usability** - since users have to pass either Loraconfig dataclass or promptuning dataclass, they know upfront what parameters are relevant for each type. 
3. **modular code** - rather than having everything in a big main function, we can have train, load and run in future

The main function is reading all arguments from command line and passing relevant params to train() as an example. 

 I will move the main() to an example script going forward, and we can continue to call that main() function with command line arguments or let it serve as a reference for users who want to call train() function directly .

**Usage of the script has not changed in this PR. All code changes are structural only, and I verified that pt, lora and ft work same was as they do in main branch**

```
python tuning/sft_trainer.py  \               
--model_name_or_path $MODEL_PATH  \
--data_path $DATA_PATH  \
--output_dir $OUTPUT_PATH  \
--num_train_epochs 5  \
--per_device_train_batch_size 4  \
--per_device_eval_batch_size 4  \
--gradient_accumulation_steps 4  \
--evaluation_strategy "no"  \
--save_strategy "epoch"  \
--learning_rate 1e-5  \
--weight_decay 0.  \
--warmup_ratio 0.03  \
--lr_scheduler_type "cosine"  \
--logging_steps 1  \
--include_tokens_per_second  \
--packing False  \
--response_template "\n### Label:"  \
--dataset_text_field "output" \
--use_flash_attn False  \
--tokenizer_name_or_path $MODEL_PATH \
--torch_dtype "float32" \
--peft_method None
```