### PR TITLE
fix : the way args are passed

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -167,9 +167,9 @@ def main(**kwargs):
                                                             peft_config.PromptTuningConfig))
     parser.add_argument('--peft_method', type=str.lower, choices=['pt', 'lora', None, 'none'], default="pt")
     model_args, data_args, training_args, lora_config, prompt_tuning_config, peft_method, _ = parser.parse_args_into_dataclasses(return_remaining_strings=True)
-    if peft_method =="lora":
+    if peft_method.peft_method =="lora":
         tune_config=lora_config
-    elif peft_method =="pt":
+    elif peft_method.peft_method =="pt":
         tune_config=prompt_tuning_config
     else:
         tune_config=None


### PR DESCRIPTION
Now that I am using HF parser the arguments are returned in their own namespace so we need to access them as class objects.

Without this fix, it was always setting tuning config to None and doing Fine tuning