### PR TITLE
fix import of aim_loader

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -10,7 +10,7 @@ from tuning.config import configs, peft_config
 from tuning.utils.config_utils import get_hf_peft_config
 from tuning.utils.data_type_utils import get_torch_dtype
 
-from aim_loader import get_aimstack_callback
+from tuning.aim_loader import get_aimstack_callback
 from transformers.utils import logging
 from dataclasses import asdict
 from typing import Optional, Union


### PR DESCRIPTION
When I install `tuning` and try to run `sft_trainer.train()` from within another python script, I get error
```
Traceback (most recent call last):
  File "/app/launch_training.py", line 28, in <module>
    from tuning import sft_trainer
  File "/usr/local/lib/python3.11/site-packages/tuning/sft_trainer.py", line 13, in <module>
    from aim_loader import get_aimstack_callback
ModuleNotFoundError: No module named 'aim_loader'
```

This should fix this error