### PR TITLE
fix full param tuning

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -155,7 +155,7 @@ def train(
         peft_config=peft_config,
     )
 
-    if run_distributed:
+    if run_distributed and peft_config is not None:
         trainer.accelerator.state.fsdp_plugin.auto_wrap_policy = fsdp_auto_wrap_policy(model)
     trainer.train()
 


### PR DESCRIPTION
when peft config is None, we are doing full parameter tuning, in which case the "peft fsdp wrapping" won't be a good wrapping.  And this causes some side issues like nested wrapping, which further caused some weird behaviors and errors.