### PR TITLE
fix: set model max length to either passed in or tokenizer value

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -93,8 +93,10 @@ def train(
             "pad_token": "<pad>",
         })
     
-    model_max_length = tokenizer.model_max_length
+    model_max_length = min(train_args.model_max_length, tokenizer.model_max_length)
     logger.info(f"Model max length {model_max_length}")
+    if train_args.model_max_length > tokenizer.model_max_length:
+        logger.warning(f"model_max_length {model_max_length} exceeds tokenizer.model_max_length {tokenizer.model_max_length}, using tokenizer.model_max_length {tokenizer.model_max_length}")
     
     # TODO: we need to change this, perhaps follow what open instruct does?
     special_tokens_dict = dict()


### PR DESCRIPTION
Should use the user provided model max length if it valid and below the model's max length. Will also print log message if the user provided one exceeds the model one and both values which is helpful for debugging. Note that `train_args.model_max_length` is set by default to 4096 if the user does not provide a value.