### PR TITLE
Add file logger callback & export train loss json file

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -1,5 +1,6 @@
 # Standard
 from typing import Optional, Union
+import json
 import os
 
 # Third Party
@@ -17,8 +18,9 @@ from transformers.utils import logging
 from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
 import datasets
 import fire
-import torch
 import transformers
+from transformers import TrainerCallback
+from transformers.utils import logging
 
 # Local
 from tuning.aim_loader import get_aimstack_callback
@@ -37,6 +39,40 @@ class PeftSavingCallback(TrainerCallback):
 
         if "pytorch_model.bin" in os.listdir(checkpoint_path):
             os.remove(os.path.join(checkpoint_path, "pytorch_model.bin"))
+
+
+class FileLoggingCallback(TrainerCallback):
+    """Exports metrics, e.g., training loss to a file in the checkpoint directory."""
+    # Keys to be exported from the log dict
+    log_keys = ["loss", "epoch"]
+
+    def __init__(self, logger):
+        self.logger = logger
+        self.existing_logs = []
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        """Checks if this log contains keys of interest, e.g., los, and if so, creates
+        train_loss.json in the model output dir (if it doesn't already exist),
+        appends the subdict of the log & dumps the file.
+        """
+
+        log_file_path = os.path.join(args.output_dir, "train_loss.json")
+        if logs is not None:
+            try:
+                # Take the subdict of the last log line; if any log_keys aren't part of this log
+                # object, asssume this line is something else, e.g., train completion, and skip.
+                log_obj = {k: logs[k] for k in FileLoggingCallback.log_keys}
+            except KeyError:
+                return
+
+            # Redump the json file in the checkpoint directory with the updated log line
+            self.existing_logs.append(log_obj)
+            with open(log_file_path, "w") as log_file:
+                json.dump(self.existing_logs, log_file, sort_keys=True, indent=4)
+        else:
+            # In general, this shouldn't happen, but the file logger should never crash
+            # the training; if we have nothing to log, just warn to the console.
+            self.logger.warning("File logging callback invoked, but logs are None")
 
 
 def train(
@@ -175,7 +211,9 @@ def train(
         logger.info(f"Validation dataset length is {len(formatted_validation_dataset)}")
 
     aim_callback = get_aimstack_callback()
-    callbacks = [aim_callback, PeftSavingCallback()]
+    file_logger_callback = FileLoggingCallback(logger)
+    peft_saving_callback = PeftSavingCallback()
+    callbacks=[aim_callback, peft_saving_callback, file_logger_callback]
 
     if train_args.packing:
         logger.info("Packing is set to True")

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -55,7 +55,9 @@ class FileLoggingCallback(TrainerCallback):
         train_loss.json in the model output dir (if it doesn't already exist),
         appends the subdict of the log & dumps the file.
         """
-
+        # All processes get the logs from this node; only update from process 0.
+        if not state.is_world_process_zero:
+            return
         log_file_path = os.path.join(args.output_dir, "train_loss.json")
         if logs is not None:
             try:

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -20,8 +20,6 @@ from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
 import datasets
 import fire
 import transformers
-from transformers import TrainerCallback
-from transformers.utils import logging
 
 # Local
 from tuning.aim_loader import get_aimstack_callback
@@ -44,6 +42,7 @@ class PeftSavingCallback(TrainerCallback):
 
 class FileLoggingCallback(TrainerCallback):
     """Exports metrics, e.g., training loss to a file in the checkpoint directory."""
+
     def __init__(self, logger):
         self.logger = logger
 
@@ -67,8 +66,8 @@ class FileLoggingCallback(TrainerCallback):
                         "epoch": round(logs["epoch"], 2),
                         "step": state.global_step,
                         "value": logs["loss"],
-                        "timestamp": datetime.isoformat(datetime.now())
-                    }
+                        "timestamp": datetime.isoformat(datetime.now()),
+                    },
                 }
             except KeyError:
                 return
@@ -216,7 +215,7 @@ def train(
     aim_callback = get_aimstack_callback()
     file_logger_callback = FileLoggingCallback(logger)
     peft_saving_callback = PeftSavingCallback()
-    callbacks=[aim_callback, peft_saving_callback, file_logger_callback]
+    callbacks = [aim_callback, peft_saving_callback, file_logger_callback]
 
     if train_args.packing:
         logger.info("Packing is set to True")


### PR DESCRIPTION
This PR adds a new callback, which is invoked on the logging event - if the most recent log contains specific keys, the subdictionary is extracted, and the `train_loss.json` is reexported.

Example using LLama 7b with the twitter complaints example (tested on single GPU with a v100).

```bash
python tuning/sft_trainer.py  --model_name_or_path $MODEL_PATH  --data_path $DATA_PATH  --output_dir $OUTPUT_PATH  --num_train_epochs 5  --per_device_train_batch_size 4  --per_device_eval_batch_size 4  --gradient_accumulation_steps 4  --evaluation_strategy "no"  --save_strategy "epoch"  --learning_rate 1e-5  --weight_decay 0.  --warmup_ratio 0.03  --lr_scheduler_type "cosine"  --logging_steps 1  --include_tokens_per_second  --packing False  --response_template "\n### Label:"  --peft_method pt --tokenizer_name_or_path $MODEL_PATH --dataset_text_field "output" --torch_dtype "float32" --use_flash_attn False
```

Produces a `train_loss.json` file in the output directory:
```bash
$ ls out
checkpoint-13  checkpoint-15  checkpoint-3  checkpoint-6  checkpoint-9  train_loss.jsonl
```


Here is an example of the json file that gets created.
```json
{"data": {"epoch": 0.31, "step": 1, "timestamp": "2024-02-13T12:29:27.387128", "value": 10.6876}, "name": "loss"}
{"data": {"epoch": 0.62, "step": 2, "timestamp": "2024-02-13T12:29:28.078879", "value": 10.8365}, "name": "loss"}
{"data": {"epoch": 0.92, "step": 3, "timestamp": "2024-02-13T12:29:28.749249", "value": 10.767}, "name": "loss"}
{"data": {"epoch": 1.23, "step": 4, "timestamp": "2024-02-13T12:29:31.796401", "value": 10.8091}, "name": "loss"}
{"data": {"epoch": 1.54, "step": 5, "timestamp": "2024-02-13T12:29:32.436218", "value": 10.7143}, "name": "loss"}
{"data": {"epoch": 1.85, "step": 6, "timestamp": "2024-02-13T12:29:33.187178", "value": 10.7687}, "name": "loss"}
{"data": {"epoch": 2.15, "step": 7, "timestamp": "2024-02-13T12:29:36.343676", "value": 10.7223}, "name": "loss"}
{"data": {"epoch": 2.46, "step": 8, "timestamp": "2024-02-13T12:29:37.021809", "value": 10.7292}, "name": "loss"}
{"data": {"epoch": 2.77, "step": 9, "timestamp": "2024-02-13T12:29:37.708132", "value": 10.8619}, "name": "loss"}
{"data": {"epoch": 3.08, "step": 10, "timestamp": "2024-02-13T12:29:42.506561", "value": 10.6114}, "name": "loss"}
{"data": {"epoch": 3.38, "step": 11, "timestamp": "2024-02-13T12:29:43.154734", "value": 10.6282}, "name": "loss"}
{"data": {"epoch": 3.69, "step": 12, "timestamp": "2024-02-13T12:29:43.838959", "value": 10.7648}, "name": "loss"}
{"data": {"epoch": 4.0, "step": 13, "timestamp": "2024-02-13T12:29:44.538090", "value": 10.8187}, "name": "loss"}
{"data": {"epoch": 4.31, "step": 14, "timestamp": "2024-02-13T12:29:48.925495", "value": 10.6256}, "name": "loss"}
{"data": {"epoch": 4.62, "step": 15, "timestamp": "2024-02-13T12:29:49.682787", "value": 10.7308}, "name": "loss"}
```

Note that logs are only exported from the main process to avoid writing from mulitple processes for multigpu tunings.