### PR TITLE
feat: add validation dataset to train

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -26,6 +26,7 @@ class DataArguments:
     data_path: str = field(default=None, metadata={"help": "Path to the training data in JSONL format."})
     response_template: str = field(default=None, metadata={"help": "Response template, separator to train on completions only"})
     dataset_text_field: str = field(default=None, metadata={"help": "Training dataset text field"})
+    validation_data_path: str = field(default=None, metadata={"help": "Path to the validation data in JSONL format."})
 
 
 @dataclass

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -137,6 +137,7 @@ def train(
     formatted_train_dataset = json_dataset['train'].map(lambda example : {f"{data_args.dataset_text_field}" : example[f"{data_args.dataset_text_field}"] + tokenizer.eos_token})
     logger.info(f"Dataset length is {len(formatted_train_dataset)}")
 
+    formatted_validation_dataset = None
     if data_args.validation_data_path:
         formatted_validation_dataset = json_dataset['validation'].map(lambda example : {f"{data_args.dataset_text_field}" : example[f"{data_args.dataset_text_field}"] + tokenizer.eos_token})
         logger.info(f"Validation dataset length is {len(formatted_validation_dataset)}")
@@ -165,6 +166,7 @@ def train(
         model=model,
         tokenizer=tokenizer,
         train_dataset=formatted_train_dataset,
+        eval_dataset=formatted_validation_dataset,
         packing=packing,
         data_collator=data_collator,
         dataset_text_field=data_args.dataset_text_field,


### PR DESCRIPTION
Tested using twitter complaints dataset for both train and validation and both were able to be parsed and passed through to training. Output shows loss (train) and eval_loss as seen below. Note that in order to run with validation dataset, must pass flag `--evaluation_strategy` with either `steps` or `epoch`. By default this flag is set to `no`. If `evaluation_strategy` is set and no validation dataset is passed, will fail with error `ValueError: Trainer: evaluation requires an eval_dataset.`. In addition, should be consistent between flags `evaluation_strategy`, `save_strategy`, and `logging_strategy`, although it will still run if they are not.

Example of running:
```
  warnings.warn(
Detected kernel version 4.18.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
You're using a BloomTokenizerFast tokenizer. Please note that with a fast tokenizer, using the `__call__` method is faster than using a method to encode the text followed by a call to the `pad` method to get a padded encoding.
  0%|                                                                                   | 0/5 [00:00<?, ?it/s]`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...
/usr/local/lib64/python3.11/site-packages/torch/utils/checkpoint.py:429: UserWarning: torch.utils.checkpoint: please pass in use_reentrant=True or use_reentrant=False explicitly. The default value of use_reentrant will be updated to be False in the future. To maintain current behavior, pass use_reentrant=True. It is recommended that you use use_reentrant=False. Refer to docs for more details on the differences between the two variants.
  warnings.warn(
/usr/local/lib64/python3.11/site-packages/torch/nn/parallel/_functions.py:68: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.
  warnings.warn('Was asked to gather along dimension 0, but all '
{'loss': 12.2306, 'learning_rate': 1e-05, 'epoch': 0.57}                                                      
{'eval_loss': 6.988900661468506, 'eval_runtime': 0.0819, 'eval_samples_per_second': 610.35, 'eval_steps_per_second': 85.449, 'epoch': 0.57}                                                                                 
 20%|███████████████                                                            | 1/5 [00:03<00:11,  2.86s/itCheckpoint destination directory /tmp/tuning-test/checkpoint-1 already exists and is non-empty.Saving will proceed but saved results may be invalid.
/usr/local/lib64/python3.11/site-packages/torch/utils/checkpoint.py:429: UserWarning: torch.utils.checkpoint: please pass in use_reentrant=True or use_reentrant=False explicitly. The default value of use_reentrant will be updated to be False in the future. To maintain current behavior, pass use_reentrant=True. It is recommended that you use use_reentrant=False. Refer to docs for more details on the differences between the two variants.
  warnings.warn(
/usr/local/lib64/python3.11/site-packages/torch/nn/parallel/_functions.py:68: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.
  warnings.warn('Was asked to gather along dimension 0, but all '
{'loss': 6.1153, 'learning_rate': 5e-06, 'epoch': 1.71}                                                       
{'eval_loss': 6.988900184631348, 'eval_runtime': 0.0848, 'eval_samples_per_second': 589.536, 'eval_steps_per_second': 82.535, 'epoch': 1.71}                                                                                
 60%|█████████████████████████████████████████████                              | 3/5 [00:03<00:01,  1.32it/sCheckpoint destination directory /tmp/tuning-test/checkpoint-3 already exists and is non-empty.Saving will proceed but saved results may be invalid.
/usr/local/lib64/python3.11/site-packages/torch/utils/checkpoint.py:429: UserWarning: torch.utils.checkpoint: please pass in use_reentrant=True or use_reentrant=False explicitly. The default value of use_reentrant will be updated to be False in the future. To maintain current behavior, pass use_reentrant=True. It is recommended that you use use_reentrant=False. Refer to docs for more details on the differences between the two variants.
  warnings.warn(
/usr/local/lib64/python3.11/site-packages/torch/nn/parallel/_functions.py:68: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.
  warnings.warn('Was asked to gather along dimension 0, but all '
{'loss': 5.2417, 'learning_rate': 0.0, 'epoch': 2.86}                                                         
{'eval_loss': 6.988900184631348, 'eval_runtime': 0.0818, 'eval_samples_per_second': 610.96, 'eval_steps_per_second': 85.534, 'epoch': 2.86}                                                                                 
100%|███████████████████████████████████████████████████████████████████████████| 5/5 [00:03<00:00,  2.58it/sCheckpoint destination directory /tmp/tuning-test/checkpoint-5 already exists and is non-empty.Saving will proceed but saved results may be invalid.
{'train_runtime': 3.663, 'train_samples_per_second': 68.249, 'train_steps_per_second': 1.365, 'train_tokens_per_second': 6562.866, 'train_loss': 6.988934707641602, 'epoch': 2.86}
100%|███████████████████████████████████████████████████████████████████████████| 5/5 [00:03<00:00,  1.38it/s]

```

closes: #6 