### PR TITLE
Raise if fsdp plugin is unset

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -167,6 +167,11 @@ def train(
     )
 
     if run_distributed and peft_config is not None:
+        if not hasattr(trainer.accelerator.state, "fsdp_plugin"):
+            raise AttributeError(
+                "Accelerator state has no attr fsdp_plugin! Hint: did you set ACCELERATE_USE_FSDP?"
+            )
+        
         trainer.accelerator.state.fsdp_plugin.auto_wrap_policy = fsdp_auto_wrap_policy(model)
     trainer.train()
 


### PR DESCRIPTION
When we try to run multigpu training, we explicitly set:
```
trainer.accelerator.state.fsdp_plugin.auto_wrap_policy = fsdp_auto_wrap_policy(model)
```
before launching the trainer. However, the Accelerator state doesn't always define the `fsdp_plugin` attribute, so this can crash in a cryptic way if we launch with Torchrun for multigpu with the wrong settings.

The `fsdp_plugin` of the Accelerator state for multigpu configurations is set [here](https://github.com/huggingface/accelerate/blob/main/src/accelerate/state.py#L816) in the Accelerate source. If you don't set `ACCELERATE_USE_FSDP`, it won't be defined.

This PR explicitly checks to see if the accelerator state has an `fsdp_plugin` before trying to update the auto wrap policy; if it doesn't, it raises an attribute error with a hint that you probably need to set `ACCELERATE_USE_FSDP` to run with a multigpu configuration.