### PR TITLE
Merge models

### DIFF
--- a/tuning/utils/merge_model_utils.py
+++ b/tuning/utils/merge_model_utils.py
@@ -83,21 +83,3 @@ def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
     if "base_model_name_or_path" not in adapter_dict:
         raise KeyError("Base model adapter config exists, but has no base_model_name_or_path!")
     return adapter_dict["base_model_name_or_path"]
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Creates a merged lora model"
-    )
-    parser.add_argument("--checkpoint_model", help="Path to the checkpoint [tuned lora model]", required=True)
-    parser.add_argument("--export_path", help="Path to write the merged model to", required=True)
-    parser.add_argument("--base_model", help="Base model to be used [default=None; infers from adapter config]", default=None)
-    parser.add_argument("--save_tokenizer", default=False, action="store_true", help="Whether or not we should export the tokenizer to the export_path")
-    args = parser.parse_args()
-
-    create_merged_model(
-        checkpoint_models=[args.checkpoint_model, args.checkpoint_model],
-        export_path=args.export_path,
-        base_model=args.base_model,
-        save_tokenizer=args.save_tokenizer,
-    )

--- a/tuning/utils/merge_model_utils.py
+++ b/tuning/utils/merge_model_utils.py
@@ -1,16 +1,20 @@
+# Standard
+from typing import Union
 import argparse
 import json
 import os
-from typing import Union
-from tqdm import tqdm
+
+# Third Party
 from peft import PeftModel
+from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
+
 
 def create_merged_model(
     checkpoint_models: Union[str, list[str]],
-    export_path: str=None,
-    base_model: str=None,
-    save_tokenizer: bool=True
+    export_path: str = None,
+    base_model: str = None,
+    save_tokenizer: bool = True,
 ):
     """Given a base model & checkpoint model(s) which were tuned with lora, load into memory
     & create a merged model. If an export path is specified, write it to disk. If multiple
@@ -69,7 +73,7 @@ def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
     Args:
         checkpoint_model: str
             Checkpoint model containing the adapter config, which specifies the base model.
-    
+
     Returns:
         str
             base_model_name_or_path specified in the adapter config of the tuned peft model.
@@ -81,5 +85,7 @@ def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
     with open(adapter_config, "r") as cfg:
         adapter_dict = json.load(cfg)
     if "base_model_name_or_path" not in adapter_dict:
-        raise KeyError("Base model adapter config exists, but has no base_model_name_or_path!")
+        raise KeyError(
+            "Base model adapter config exists, but has no base_model_name_or_path!"
+        )
     return adapter_dict["base_model_name_or_path"]

--- a/tuning/utils/merge_model_utils.py
+++ b/tuning/utils/merge_model_utils.py
@@ -1,0 +1,53 @@
+import json
+import os
+from peft import PeftModel
+from transformers import AutoModelForCausalLM
+
+def create_merged_model(checkpoint_model: str, export_path: str=None, base_model: str=None):
+    """Given a base model & a checkpoint model containing adapters, which were tuned with lora,
+    load both into memory & create a merged model. If an export path is specified, write it
+    to disk.
+
+    Args:
+        checkpoint_model: str
+            Lora checkpoint containing adapters.
+        export_path: str
+            Path to export the merged model to.
+        base_model: str
+            Base model to be leveraged. If no base model is specified, the base model is pulled
+            from the checkpoint model's adapter config.
+
+    Returns:
+        transformers model
+            Merged model created from the checkpoint / base model.
+    """
+    if base_model is None:
+        base_model = fetch_base_model_from_checkpoint(checkpoint_model)
+    model = AutoModelForCausalLM.from_pretrained(base_model)
+    model_combined = PeftModel.from_pretrained(model, checkpoint_model)
+    model_combined = model_combined.merge_and_unload()
+    if export_path is not None:
+        model_combined.save_pretrained(export_path)
+    return model_combined
+
+def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
+    """Inspects the checkpoint model, locates the adapter config, and grabs the
+    base_model_name_or_path.
+
+    Args:
+        checkpoint_model: str
+            Checkpoint model containing the adapter config, which specifies the base model.
+    
+    Returns:
+        str
+            base_model_name_or_path specified in the adapter config of the tuned peft model.
+    """
+    adapter_config = os.path.join(checkpoint_model, "adapter_config.json")
+    if not os.path.isfile(adapter_config):
+        raise FileNotFoundError("Unable to locate adapter config to infer base model!")
+
+    with open(adapter_config, "r") as cfg:
+        adapter_dict = json.load(cfg)
+    if "base_model_name_or_path" not in adapter_dict:
+        raise KeyError("Base model adapter config exists, but has no base_model_name_or_path!")
+    return adapter_dict["base_model_name_or_path"]

--- a/tuning/utils/merge_model_utils.py
+++ b/tuning/utils/merge_model_utils.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 from peft import PeftModel
@@ -30,6 +31,7 @@ def create_merged_model(checkpoint_model: str, export_path: str=None, base_model
         model_combined.save_pretrained(export_path)
     return model_combined
 
+
 def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
     """Inspects the checkpoint model, locates the adapter config, and grabs the
     base_model_name_or_path.
@@ -51,3 +53,19 @@ def fetch_base_model_from_checkpoint(checkpoint_model: str) -> str:
     if "base_model_name_or_path" not in adapter_dict:
         raise KeyError("Base model adapter config exists, but has no base_model_name_or_path!")
     return adapter_dict["base_model_name_or_path"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Creates a merged lora model"
+    )
+    parser.add_argument("--checkpoint_model", help="Path to the checkpoint [tuned lora model]", required=True)
+    parser.add_argument("--export_path", help="Path to write the merged model to", required=True)
+    parser.add_argument("--base_model", help="Base model to be used [default=None; infers from adapter config]", default=None)
+    args = parser.parse_args()
+
+    create_merged_model(
+        checkpoint_model=args.checkpoint_model,
+        export_path=args.export_path,
+        base_model=args.base_model,
+    )


### PR DESCRIPTION
This PR adds a post-processing utility for merging one or more lora models back into a base model. If multiple lora models are provided, they are combined with equal weights (references supporting that this is what this PR is actually doing are provided in the docstring). An optional flag can be set to also export the tokenizer.


Example usage showing calling the merge util func and reloading + running an inference call with a tiny llama model - I've tried the same to with a llama 7b model to make sure it doesn't explode successfully:


```python
from tuning.utils.merge_model_utils import create_merged_model

save_tokenizer = True
base_model = "TinyLlama/TinyLlama-1.1B-step-50K-105b"
# checkpoints from tuning the tinyllama model
checkpoint_models = ["out/checkpoint-9", "out/checkpoint-13"]
merged_model_id = "my_merged_model"

# Creating the merged model...
create_merged_model(
    checkpoint_models=checkpoint_models,
    export_path=merged_model_id,
    base_model=base_model,
    save_tokenizer=save_tokenizer
)


# Reloading the tokenizer + merged model
import transformers
tokenizer = transformers.AutoTokenizer.from_pretrained(merged_model_id)
model = transformers.AutoModelForCausalLM.from_pretrained(merged_model_id).to("cuda")
## Make sure we can run some text through without exploding
tok_res = tokenizer("This is a text", return_tensors="pt")
gen_result = model.generate(tok_res.input_ids.to("cuda"))
decoded_toks = tokenizer.batch_decode(gen_result, skip_special_tokens=False)[0]
print(f"Model text: {decoded_toks}")
```