### PR TITLE
feat: support str in target_modules for LoraConfig

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tokenizers>=0.13.3
 tqdm
 trl
 ninja
-peft
+peft>=0.8.0
 datasets>=2.15.0
 flash-attn
 fire

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -1,11 +1,17 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Union, Optional
 
 @dataclass
 class LoraConfig:
     r: int = 8
     lora_alpha: int = 32
-    target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"])
+    target_modules: Optional[Union[List[str], str]] = field(default_factory=lambda: ["q_proj", "v_proj"], metadata={
+        "help": "The names of the modules to apply LORA to. When using a string, LORA uses regex matching. When using "
+            "a list of strings, LORA selects modules which either completely match or end with one of the strings. "
+            "If the value is the string 'all-linear', then LORA selects all linear and Conv1D modules except for "
+            "the output layer. If the value is none, then LORA chooses modules depending on the model architecture. "
+            "In that case, in that case LORA raises an exception prompting the user to manually select the modules."
+    })
     bias = "none"
     lora_dropout: float = 0.05
 

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
-from typing import List, Union, Optional
+from typing import List
 
 @dataclass
 class LoraConfig:
     r: int = 8
     lora_alpha: int = 32
-    target_modules: Optional[Union[List[str], str]] = field(default_factory=lambda: ["q_proj", "v_proj"], metadata={
+    target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"], metadata={
         "help": "The names of the modules to apply LORA to. When using a string, LORA uses regex matching. When using "
             "a list of strings, LORA selects modules which either completely match or end with one of the strings. "
             "If the value is the string 'all-linear', then LORA selects all linear and Conv1D modules except for "

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -6,11 +6,9 @@ class LoraConfig:
     r: int = 8
     lora_alpha: int = 32
     target_modules: List[str] = field(default_factory=lambda: ["q_proj", "v_proj"], metadata={
-        "help": "The names of the modules to apply LORA to. When using a string, LORA uses regex matching. When using "
-            "a list of strings, LORA selects modules which either completely match or end with one of the strings. "
-            "If the value is the string 'all-linear', then LORA selects all linear and Conv1D modules except for "
-            "the output layer. If the value is none, then LORA chooses modules depending on the model architecture. "
-            "In that case, in that case LORA raises an exception prompting the user to manually select the modules."
+        "help": "The names of the modules to apply LORA to. LORA selects modules which either completely match or "
+        "end with one of the strings. If the value is [\"all-linear\"], then LORA selects all linear and Conv1D "
+        "modules except for the output layer."
     })
     bias = "none"
     lora_dropout: float = 0.05

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -189,7 +189,9 @@ def main(**kwargs):
                                                             peft_config.PromptTuningConfig))
     parser.add_argument('--peft_method', type=str.lower, choices=['pt', 'lora', None, 'none'], default="pt")
     model_args, data_args, training_args, lora_config, prompt_tuning_config, peft_method, _ = parser.parse_args_into_dataclasses(return_remaining_strings=True)
-    if peft_method.peft_method =="lora":
+    if peft_method.peft_method == "lora":
+        if lora_config.target_modules == ["all-linear"]:
+            lora_config.target_modules = "all-linear"
         tune_config=lora_config
     elif peft_method.peft_method =="pt":
         tune_config=prompt_tuning_config

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -190,8 +190,6 @@ def main(**kwargs):
     parser.add_argument('--peft_method', type=str.lower, choices=['pt', 'lora', None, 'none'], default="pt")
     model_args, data_args, training_args, lora_config, prompt_tuning_config, peft_method, _ = parser.parse_args_into_dataclasses(return_remaining_strings=True)
     if peft_method.peft_method == "lora":
-        if lora_config.target_modules == ["all-linear"]:
-            lora_config.target_modules = "all-linear"
         tune_config=lora_config
     elif peft_method.peft_method =="pt":
         tune_config=prompt_tuning_config

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -51,7 +51,10 @@ def get_hf_peft_config(task_type, tuning_config):
        Return: HF PEFT config or None
     """
     if isinstance(tuning_config, peft_config.LoraConfig):
-        hf_peft_config = LoraConfig(task_type=task_type, **asdict(tuning_config))
+        lora_config = asdict(tuning_config)
+        if lora_config["target_modules"] == ["all-linear"]:
+            lora_config["target_modules"] = "all-linear"
+        hf_peft_config = LoraConfig(task_type=task_type, **lora_config)
     elif isinstance(tuning_config, peft_config.PromptTuningConfig):
         hf_peft_config = PromptTuningConfig(task_type=task_type, **asdict(tuning_config))
     else:


### PR DESCRIPTION
Resolves #37


- [x] Update definition of LoraConfig.target_modules to match that of the target_modules in [lora](https://github.com/huggingface/peft/blob/c1a83fd692cfbd5297d252e4eae4fdc4c59efa8c/src/peft/tuners/lora/config.py#L51-L58)
- [x] support --target_modules=all-linear
- [x] updated requirements.txt with depenncy to peft>0.8.0 (this version introduces support for --target_modules=all-linear)