### PR TITLE
Enable daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
With this PR, [Dependabot](https://dependabot.com/) can automatically scan the dependencies daily and create a PR if there is a newer version of the upstream package is available.