### PR TITLE
Let Huggingface Properly Initialize Arguments, and Fix FSDP-LORA Checkpoint-Saves and Resumption

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -72,6 +72,3 @@ class TrainingArguments(transformers.TrainingArguments):
         default=False,
         metadata={"help": "Packing to be enabled in SFT Trainer, default is False"},
     )
-
-    def __post_init__(self):
-        super().__post_init__()

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -72,3 +72,6 @@ class TrainingArguments(transformers.TrainingArguments):
         default=False,
         metadata={"help": "Packing to be enabled in SFT Trainer, default is False"},
     )
+
+    def __post_init__(self):
+        super().__post_init__()

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -122,21 +122,6 @@ def train(
 
     logger = logging.get_logger("sft_trainer")
 
-    # Validate parameters
-    if (not isinstance(train_args.num_train_epochs, float)) or (
-        train_args.num_train_epochs <= 0
-    ):
-        raise ValueError("num_train_epochs has to be an integer/float >= 1")
-    if (not isinstance(train_args.gradient_accumulation_steps, int)) or (
-        train_args.gradient_accumulation_steps <= 0
-    ):
-        raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
-
-    # make sure to unset FSDP args when running on single gpu
-    if not run_distributed:
-        train_args.fsdp = ""
-        train_args.fsdp_config = {"xla": False}
-
     task_type = "CAUSAL_LM"
     model = AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
@@ -146,8 +131,6 @@ def train(
     )
 
     peft_config = get_hf_peft_config(task_type, peft_config)
-
-    model.gradient_checkpointing_enable()
 
     # TODO: Move these to a config as well
     tokenizer = AutoTokenizer.from_pretrained(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -110,6 +110,16 @@ def train(
 
     logger = logging.get_logger("sft_trainer")
 
+    # Validate parameters
+    if (not isinstance(train_args.num_train_epochs, float)) or (
+        train_args.num_train_epochs <= 0
+    ):
+        raise ValueError("num_train_epochs has to be an integer/float >= 1")
+    if (not isinstance(train_args.gradient_accumulation_steps, int)) or (
+        train_args.gradient_accumulation_steps <= 0
+    ):
+        raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
+
     task_type = "CAUSAL_LM"
     model = AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,


### PR DESCRIPTION
@raghukiran1224 @Ssukriti @anhuong Im suggesting two fixes here

1. We observe failures with newer version of transformers because of a newly added `xla_fsdp_v2` flag here. The current strategy is to manually patch missing flags because `transformers.TrainingArguments.__post_init__` is not called. But this means one has to constantly update the manual patches if there are changes to HF code, which is not ideal.  Huggingface trainer will properly initialize everything based on  `TrainingArguments` (including [gradient checkpointing](https://github.com/huggingface/transformers/blob/2cc8cf6ce7ae0416561acbb639df4bbc5f409b6f/src/transformers/trainer.py#L1749-L1755). 
2. The `PeftSavingCallback` is not the ideal patch now that https://github.com/huggingface/transformers/pull/28297 has been merged, where now FSDP will properly save and resume adapter checkpoints. This will supercede the `PeftSavingCallback` strategy, as `PeftSavingCallback` will not even properly handle resumptions and different state dict saving strategies, but the already merged fix will. the `PEFTCallback` is removed in `trl` [here](https://github.com/huggingface/trl/pull/1110)
