### PR TITLE
Add Contributing file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+#####################################################
+#
+# List of approvers for fms-hf-tuning repository
+#
+#####################################################
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+*  @anhuong @Ssukriti

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+👍🎉 First off, thank you for taking the time to contribute! 🎉👍
+
+The following is a set of guidelines for contributing. These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## What Should I Know Before I Get Started?
+
+### Code of Conduct
+
+This project adheres to the [Contributor Covenant](./code-of-conduct.md). By participating, you are expected to uphold this code.
+
+Please report unacceptable behavior to one of the [Code Owners](./CODEOWNERS).
+
+### How Do I Start Contributing?
+
+The below workflow is designed to help you begin your first contribution journey. It will guide you through creating and picking up issues, working through them, having your work reviewed, and then merging.
+
+Help on open source projects is always welcome and there is always something that can be improved. For example, documentation (like the text you are reading now) can always use improvement, code can always be clarified, variables or functions can always be renamed or commented on, and there is always a need for more test coverage. If you see something that you think should be fixed, take ownership! Here is how you get started:
+
+## How Can I Contribute?
+
+When contributing, it's useful to start by looking at [issues](https://github.com/foundation-model-stack/fms-hf-tuning/issues). After picking up an issue, writing code, or updating a document, make a pull request and your work will be reviewed and merged. If you're adding a new feature or find a bug, it's best to [write an issue](https://github.com/foundation-model-stack/fms-hf-tuning/issues/new) first to discuss it with maintainers.
+
+To contribute to this repo, you'll use the Fork and Pull model common in many open source repositories. For details on this process, check out [The GitHub Workflow
+Guide](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md)
+from Kubernetes.
+
+When your contribution is ready, you can create a pull request. Pull requests are often referred to as "PR". In general, we follow the standard [GitHub pull request](https://help.github.com/en/articles/about-pull-requests) process. Follow the template to provide details about your pull request to the maintainers.
+
+Before sending pull requests, make sure your changes pass formatting, linting and unit tests.
+
+#### Code Review
+
+Once you've [created a pull request](#how-can-i-contribute), maintainers will review your code and may make suggestions to fix before merging. It will be easier for your pull request to receive reviews if you consider the criteria the reviewers follow while working. Remember to:
+
+- Run tests locally and ensure they pass
+- Follow the project coding conventions
+- Write detailed commit messages
+- Break large changes into a logical series of smaller patches, which are easy to understand individually and combine to solve a broader issue
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report. Following these guidelines helps maintainers and the community understand your report ✏️, reproduce the behavior 💻, and find related reports 🔎.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Currently bugs are tracked as [GitHub New Issue](https://github.com/foundation-model-stack/fms-hf-tuning/issues/new). Create an issue and provide:
+
+- Describe the bug
+- Platform
+- Provide details about the environment you are using 
+- Sample Code to help reproduce the bug
+- Expected behavior
+- Observed behavior
+- Additional context
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion, including completely new features, tools, and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion ✏️ and find related suggestions 🔎
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub new issue](https://github.com/foundation-model-stack/fms-hf-tuning/issues/new). Create an issue and provide:
+
+- Is your feature request related to a problem? Please describe
+- Describe the solution you'd like
+- Describe alternatives you've considered
+- Additional context
+
+#### How Do I Submit A (Good) Improvement Item?
+
+Improvements to existing functionality are tracked as [GitHub new issue](https://github.com/foundation-model-stack/fms-hf-tuning/issues/new). Create an issue and provide:
+
+- Description
+- Discussion
+
+## Development
+
+### Set up your dev environment
+
+The following tools are required:
+
+- [git](https://git-scm.com)
+- [python](https://www.python.org) (v3.8+)
+- [pip](https://pypi.org/project/pip/) (v23.0+)
+
+Installation:
+``` 
+pip install -r requirements.txt
+pip install -U datasets
+pip install -e .
+```
+
+### Unit tests
+
+Work in process, to be completed soon. 
+
+## Your First Code Contribution
+
+Unsure where to begin contributing? You can start by looking through these issues:
+
+- Issues with the [`good first issue` label](https://github.com/foundation-model-stack/fms-hf-tuning/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) - these should only require a few lines of code and are good targets if you're just starting contributing.
+- Issues with the [`help wanted` label](https://github.com/foundation-model-stack/fms-hf-tuning/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) - these range from simple to more complex, but are generally things we want but can't get to in a short time frame.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,76 @@
+# Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+-   Trolling, insulting/derogatory comments, and personal or political attacks
+-   Public or private harassment
+-   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the [project team](./CODEOWNERS). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
This is first draft of issue https://github.com/foundation-model-stack/fms-hf-tuning/issues/55

I'm using the caikit [CONTRIBUTING.md ](https://github.com/caikit/caikit/blob/main/CONTRIBUTING.md) document as a template, but changing items to properly fit the FMS instead of caikit convention.

Some things that might need tweaks:
- The new CODEOWNERS file might need different or additional people added 
- Right now there are no template(s) on new issues, but that's something that could be added later.
- Development setup and unit testing will likely change soon due to issues https://github.com/foundation-model-stack/fms-hf-tuning/issues/5 and https://github.com/foundation-model-stack/fms-hf-tuning/issues/56