### PR TITLE
Add sample unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install -r setup_requirements.txt
+      - name: Run unit tests
+        run: tox -e py

--- a/tests/utils/test_data_type_utils.py
+++ b/tests/utils/test_data_type_utils.py
@@ -29,5 +29,6 @@ def test_str_to_torch_dtype_exit():
 
 def test_get_torch_dtype():
     for t in dtype_dict.keys():
+        # When passed a string, it gets converted to torch.dtype
         assert data_type_utils.get_torch_dtype(t) == dtype_dict.get(t)
         assert data_type_utils.get_torch_dtype(dtype_dict.get(t)) == dtype_dict.get(t)

--- a/tests/utils/test_data_type_utils.py
+++ b/tests/utils/test_data_type_utils.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+# Third Party
+import pytest
+import torch
+
+# Local
+from tuning.utils import data_type_utils
+
+dtype_dict = {
+    "bool": torch.bool,
+    "double": torch.double,
+    "float32": torch.float32,
+    "int64": torch.int64,
+    "long": torch.long,
+}
+
+
+def test_str_to_torch_dtype():
+    for t in dtype_dict.keys():
+        assert data_type_utils.str_to_torch_dtype(t) == dtype_dict.get(t)
+
+
+def test_str_to_torch_dtype_exit():
+    with pytest.raises(SystemExit):
+        data_type_utils.str_to_torch_dtype("foo")
+
+
+def test_get_torch_dtype():
+    for t in dtype_dict.keys():
+        assert data_type_utils.get_torch_dtype(t) == dtype_dict.get(t)
+        assert data_type_utils.get_torch_dtype(dtype_dict.get(t)) == dtype_dict.get(t)

--- a/tests/utils/test_data_type_utils.py
+++ b/tests/utils/test_data_type_utils.py
@@ -31,4 +31,5 @@ def test_get_torch_dtype():
     for t in dtype_dict.keys():
         # When passed a string, it gets converted to torch.dtype
         assert data_type_utils.get_torch_dtype(t) == dtype_dict.get(t)
+        # When passed a torch.dtype, we get the same torch.dtype returned
         assert data_type_utils.get_torch_dtype(dtype_dict.get(t)) == dtype_dict.get(t)

--- a/tests/utils/test_data_type_utils.py
+++ b/tests/utils/test_data_type_utils.py
@@ -23,7 +23,7 @@ def test_str_to_torch_dtype():
 
 
 def test_str_to_torch_dtype_exit():
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         data_type_utils.str_to_torch_dtype("foo")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = lint, fmt
+envlist = py, lint, fmt
+
+[testenv]
+description = run unit tests
+deps =
+    pytest>=7
+    -r requirements.txt
+commands =
+    pytest {posargs:tests}
 
 [testenv:fmt]
 description = format with pre-commit

--- a/tuning/utils/data_type_utils.py
+++ b/tuning/utils/data_type_utils.py
@@ -22,7 +22,7 @@ def str_to_torch_dtype(dtype_str: str) -> torch.dtype:
     dt = getattr(torch, dtype_str, None)
     if not isinstance(dt, torch.dtype):
         logger.error(" ValueError: Unrecognized data type of a torch.Tensor")
-        exit(-1)
+        raise ValueError("Unrecognized data type of a torch.Tensor")
     return dt
 
 


### PR DESCRIPTION
Changes:
1. Adds unit tests for utilts/data_type_utils module
2. Enables unit test framework in the workflow for every PR

Closes #5

Verify in a virtual env:
```bash
git clone https://github.com/tedhtchang/fms-hf-tuning -b add_sample_unit_test
cd fms-hf-tuning
pip install -r setup_requirement.txt
tox run -e py
```
Should see something like:
```
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.11.7, pytest-8.0.2, pluggy-1.4.0
cachedir: .tox/py/.pytest_cache
rootdir: /Users/tedchang/pub_git/fms-hf-tuning
collected 3 items

tests/test_data_type_utils.py ...                                                                                                                                                                                                                                        [100%]

============================================================================================================================== 3 passed in 0.97s ===============================================================================================================================
```