### PR TITLE
Allow SFT_TRAINER_CONFIG_JSON_ENV_VAR to be encoded json string

### DIFF
--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -42,7 +42,7 @@ def txt_to_obj(txt):
     try:
         # If the bytes represent JSON string
         return json.loads(message_bytes)
-    except:
+    except UnicodeDecodeError:
         # Otherwise the bytes are a pickled python dictionary
         return pickle.loads(message_bytes)
 
@@ -96,11 +96,7 @@ def main():
         peft_method_parsed = contents.get("peft_method")
         logging.debug("Input params parsed: %s", contents)
     elif json_env_var:
-        try:
-            job_config_dict = txt_to_obj(json_env_var)
-        except Exception as e:
-            logging.error(e)
-            raise ValueError("Unable to parse value of SFT_TRAINER_CONFIG_JSON_ENV_VAR")
+        job_config_dict = txt_to_obj(json_env_var)
         logging.debug("Input params parsed: %s", job_config_dict)
 
         (

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -40,8 +40,8 @@ def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
     message_bytes = base64.b64decode(base64_bytes)
     try:
-         # If the bytes represent JSON string
-         return json.loads(message_bytes)
+        # If the bytes represent JSON string
+        return json.loads(message_bytes)
     except:
         # Otherwise the bytes are a pickled python dictionary
         return pickle.loads(message_bytes)

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -39,8 +39,12 @@ import transformers
 def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
     message_bytes = base64.b64decode(base64_bytes)
-    obj = pickle.loads(message_bytes)
-    return obj
+    try:
+         # If the bytes represent JSON string
+         return json.loads(message_bytes)
+    except:
+        # Otherwise the bytes are a pickled python dictionary
+        return pickle.loads(message_bytes)
 
 
 def get_highest_checkpoint(dir_path):
@@ -92,7 +96,11 @@ def main():
         peft_method_parsed = contents.get("peft_method")
         logging.debug("Input params parsed: %s", contents)
     elif json_env_var:
-        job_config_dict = txt_to_obj(json_env_var)
+        try:
+            job_config_dict = txt_to_obj(json_env_var)
+        except Exception as e:
+            logging.error(e)
+            raise ValueError("Unable to parse value of SFT_TRAINER_CONFIG_JSON_ENV_VAR")
         logging.debug("Input params parsed: %s", job_config_dict)
 
         (


### PR DESCRIPTION
Allow SFT_TRAINER_CONFIG_JSON_ENV_VAR to be encoded json string, not just pickled python

<!-- Thank you for the contribution! -->

### Description of the change

Users of SFT Trainer may be using other programming languages than python to programmatically deploy the job, therefore SFT_TRAINER_CONFIG_JSON_ENV_VAR should not just accept a pickled python object, but also accept just a plain encoded json string.