### PR TITLE
add tuning/config/configs unit tests

### DIFF
--- a/tests/configs/test_configs.py
+++ b/tests/configs/test_configs.py
@@ -1,0 +1,77 @@
+# Copyright The IBM Tuning Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Third Party
+import torch
+
+# Local
+import tuning.config.configs as tuning_config
+
+NEW_MODEL_NAME = "Maykeye/TinyLLama-v0"
+
+
+def test_model_argument_configs_default():
+    data_arguments = tuning_config.DataArguments
+    model_arguments = tuning_config.ModelArguments
+    training_arguments = tuning_config.TrainingArguments
+    # test model arguments default
+    assert (
+        model_arguments.model_name_or_path == tuning_config.DEFAULT_MODEL_NAME_OR_PATH
+    )
+    assert model_arguments.use_flash_attn == True
+    assert isinstance(model_arguments.torch_dtype, torch.dtype)
+
+    # test data arguments default
+    assert data_arguments.data_path == None
+    assert data_arguments.response_template == None
+    assert data_arguments.dataset_text_field == None
+    assert data_arguments.validation_data_path == None
+
+    # test training arguments default
+    assert training_arguments.cache_dir == None
+    assert training_arguments.model_max_length == tuning_config.DEFAULT_CONTEXT_LENGTH
+    assert training_arguments.packing == False
+
+
+def test_model_argument_configs_init():
+    # new data arguments
+    data_arguments = tuning_config.DataArguments(
+        data_path="/foo/bar",
+        response_template="\n### Label:",
+        dataset_text_field="output",
+        validation_data_path="/foo/bar",
+    )
+    assert data_arguments.data_path == "/foo/bar"
+    assert data_arguments.response_template == "\n### Label:"
+    assert data_arguments.validation_data_path == "/foo/bar"
+
+    # new model arguments
+    model_arguments = tuning_config.ModelArguments(
+        model_name_or_path=NEW_MODEL_NAME, use_flash_attn=False, torch_dtype=torch.int32
+    )
+    assert model_arguments.model_name_or_path == NEW_MODEL_NAME
+    assert model_arguments.use_flash_attn == False
+    assert model_arguments.torch_dtype == torch.int32
+
+    # new training arguments
+    training_arguments = tuning_config.TrainingArguments(
+        cache_dir="/tmp/cache",
+        model_max_length=1024,
+        packing=True,
+        output_dir="/tmp/output",
+    )
+    assert training_arguments.cache_dir == "/tmp/cache"
+    assert training_arguments.model_max_length == 1024
+    assert training_arguments.packing == True
+    assert training_arguments.output_dir == "/tmp/output"

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -22,6 +22,7 @@ import transformers
 
 DEFAULT_CONTEXT_LENGTH = 4096
 DEFAULT_OPTIMIZER = "adamw_torch"
+DEFAULT_MODEL_NAME_OR_PATH = "facebook/opt-125m"
 
 IGNORE_INDEX = -100
 DEFAULT_PAD_TOKEN = "<PAD>"
@@ -32,7 +33,7 @@ DEFAULT_UNK_TOKEN = "<unk>"
 
 @dataclass
 class ModelArguments:
-    model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
+    model_name_or_path: Optional[str] = field(default=DEFAULT_MODEL_NAME_OR_PATH)
     use_flash_attn: bool = field(
         default=True,
         metadata={"help": "Use Flash attention v2 from transformers, default is True"},


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Adds unit tests for tuning.config.configs modules

### Related issue number

Closes #72 

### How to verify the PR

```shell
git clone https://github.com/tedhtchang/fms-hf-tuning.git -b add-configs-unit-tests
cd ms-hf-tuning
pytest tests/configs/test_configs.py
```
### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass