### PR TITLE
feat: update launch training with accelerate for multi-gpu

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -116,6 +116,9 @@ COPY launch_training.py /app
 RUN chmod +x /app/launch_training.py
 COPY accelerate_launch.py /app
 RUN chmod +x /app/accelerate_launch.py
+COPY accelerate_fsdp_defaults.yaml /app
+
+ENV FSDP_DEFAULTS_FILE_PATH="/app/accelerate_fsdp_defaults.yaml"
 
 # Need a better way to address this hack
 RUN touch /.aim_profile && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -114,6 +114,8 @@ COPY LICENSE /licenses/
 
 COPY launch_training.py /app
 RUN chmod +x /app/launch_training.py
+COPY accelerate_launch.py /app
+RUN chmod +x /app/accelerate_launch.py
 
 # Need a better way to address this hack
 RUN touch /.aim_profile && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -125,8 +125,8 @@ RUN touch /.aim_profile && \
 
 # create tuning user and give ownership to dirs
 RUN useradd -u $USER_UID tuning -m -g 0 --system && \
-    chown -R $USER:0 /app && \
-    chmod -R g+rwX /app
+    chown -R $USER:0 /app /tmp/fms-hf-tuning && \
+    chmod -R g+rwX /app /tmp/fms-hf-tuning
 
 WORKDIR /app
 USER ${USER}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -109,7 +109,7 @@ RUN mkdir -p /licenses
 COPY LICENSE /licenses/
 
 # Copy scripts and default configs
-COPY launch_training.py accelerate_launch.py accelerate_fsdp_defaults.yaml /app/
+COPY build/launch_training.py build/accelerate_launch.py fixtures/accelerate_fsdp_defaults.yaml /app/
 RUN chmod +x /app/launch_training.py /app/accelerate_launch.py
 
 ENV FSDP_DEFAULTS_FILE_PATH="/app/accelerate_fsdp_defaults.yaml"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -112,11 +112,9 @@ RUN git clone https://github.com/foundation-model-stack/fms-hf-tuning.git && \
 RUN mkdir -p /licenses
 COPY LICENSE /licenses/
 
-COPY launch_training.py /app
-RUN chmod +x /app/launch_training.py
-COPY accelerate_launch.py /app
-RUN chmod +x /app/accelerate_launch.py
-COPY accelerate_fsdp_defaults.yaml /app
+# Copy scripts and default configs
+COPY launch_training.py accelerate_launch.py accelerate_fsdp_defaults.yaml /app/
+RUN chmod +x /app/launch_training.py /app/accelerate_launch.py
 
 ENV FSDP_DEFAULTS_FILE_PATH="/app/accelerate_fsdp_defaults.yaml"
 
@@ -128,8 +126,8 @@ RUN touch /.aim_profile && \
 
 # create tuning user and give ownership to dirs
 RUN useradd -u $USER_UID tuning -m -g 0 --system && \
-    chown -R $USER:0 /app /tmp/fms-hf-tuning && \
-    chmod -R g+rwX /app /tmp/fms-hf-tuning
+    chown -R $USER:0 /app /tmp && \
+    chmod -R g+rwX /app /tmp
 
 WORKDIR /app
 USER ${USER}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -132,4 +132,4 @@ RUN useradd -u $USER_UID tuning -m -g 0 --system && \
 WORKDIR /app
 USER ${USER}
 
-CMD [ "tail", "-f", "/dev/null" ]
+CMD [ "python", "/app/accelerate_launch.py" ]

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,164 @@
+# Building fms-hf-tuning as an Image
+
+The Dockerfile provides a way of running fms-hf-tuning SFT Trainer. It installs the dependencies needed and adds two additional scripts that helps to parse arguments to pass to SFT Trainer. The `accelerate_launch.py` script is run by default when running the image to trigger SFT trainer for single or multi GPU by parsing arguments and running `accelerate launch launch_training.py`. 
+
+## Configuration
+
+The scripts accept a JSON formatted config which are set by environment variables. `SFT_TRAINER_CONFIG_JSON_PATH` can be set to the mounted path of the JSON config. Alternatively, `SFT_TRAINER_CONFIG_JSON_ENV_VAR` can be set to the encoded JSON config using the below function:
+
+```py
+import base64
+
+ def encode_json(my_json_string):
+    base64_bytes = base64.b64encode(my_json_string.encode("ascii"))
+    txt = base64_bytes.decode("ascii")
+    return txt
+```
+
+The keys for the JSON config are all of the flags available to use with [SFT Trainer](https://huggingface.co/docs/trl/sft_trainer#trl.SFTTrainer).
+
+For configuring `accelerate launch`, use key `multiGPU` and pass the set of flags accepted by [accelerate launch](https://huggingface.co/docs/accelerate/package_reference/cli#accelerate-launch).
+
+For example, the below config is used for running with two GPUs and FSDP for PEFT tuning:
+
+Note that `num_processes` which is the total number of processes to be launched in parallel,should match the number of GPUs to run on.
+
+```json
+{
+    "multiGPU": {
+        "num_machines": 1,
+        "main_process_port": 1234,
+        "num_processes": 2,
+        "use_fsdp": true,
+        "fsdp_backward_prefetch_policy": "TRANSFORMER_BASED_WRAP",
+        "fsdp_sharding_strategy": 1,
+        "fsdp_state_dict_type": "FULL_STATE_DICT",
+        "fsdp_cpu_ram_efficient_loading": true,
+        "fsdp_sync_module_states": true
+    },
+    "model_name_or_path": "/llama/7B",
+    "training_data_path": "/data/twitter_complaints.json",
+    "output_dir": "/output/llama-7b-pt-multigpu",
+    "num_train_epochs": 5.0,
+    "per_device_train_batch_size": 4,
+    "per_device_eval_batch_size": 4,
+    "gradient_accumulation_steps": 4,
+    "save_strategy": "epoch",
+    "learning_rate": 0.03,
+    "weight_decay": 0.0,
+    "lr_scheduler_type": "cosine",
+    "logging_steps": 1.0,
+    "packing": false,
+    "include_tokens_per_second": true,
+    "response_template": "\n### Label:",
+    "dataset_text_field": "output",
+    "use_flash_attn": false,
+    "torch_dtype": "bfloat16",
+    "tokenizer_name_or_path": "/llama/7B"
+}
+```
+
+When `multiGPU` is set, the [FSDP config](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/fixtures/accelerate_fsdp_defaults.yaml) is used by default. Any of these values can be overwritten by passing in flags via the JSON config or by passing in your own config file using key `config_file`.
+
+If `multiGPU` is set and `num_processes` is not explicitly set, the number of processes/GPUs will be determined by the number of GPUs available via `torch.cuda.device_count()`.
+
+If `multiGPU` is not set, the script will assume single-GPU and run with `num_processes=1`. The number of GPUs used can also be set by setting environment variable `CUDA_VISIBLE_DEVICES`.
+
+
+## Building the Image
+
+With docker, build the image with:
+
+```sh
+docker build . -t sft-trainer:mytag
+```
+
+## Running the Image
+
+Run sft-trainer-image with the JSON env var and mounts set up.
+
+```sh
+docker run -v config.json:/app/config.json -v $MODEL_PATH:/model -v $TRAINING_DATA_PATH:/data/twitter_complaints.json --env SFT_TRAINER_CONFIG_JSON_PATH=/app/config.json sft-trainer:mytag
+```
+
+This will run `accelerate_launch.py` with the JSON config passed.
+
+An example Kubernetes Pod for deploying sft-trainer which requires creating PVCs with the model and input dataset and any mounts needed for the outputted tuned model:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+name: sft-trainer-config
+data:
+config.json: |
+    {
+      "multiGPU": {
+            "num_machines": 1,
+            "main_process_port": 1234,
+            "num_processes": 2,
+            "use_fsdp": true,
+            "fsdp_backward_prefetch_policy": "TRANSFORMER_BASED_WRAP",
+            "fsdp_sharding_strategy": 1,
+            "fsdp_state_dict_type": "FULL_STATE_DICT",
+            "fsdp_cpu_ram_efficient_loading": true,
+            "fsdp_sync_module_states": true
+        },
+        "model_name_or_path": "/data/input/llama/7B",
+        "training_data_path": "/data/input/twitter_complaints.json",
+        "output_dir": "/data/output/llama-7b-pt-multigpu",
+        "num_train_epochs": 5.0,
+        "per_device_train_batch_size": 4,
+        "per_device_eval_batch_size": 4,
+        "gradient_accumulation_steps": 4,
+        "save_strategy": "epoch",
+        "learning_rate": 0.03,
+        "weight_decay": 0.0,
+        "lr_scheduler_type": "cosine",
+        "logging_steps": 1.0,
+        "packing": false,
+        "include_tokens_per_second": true,
+        "response_template": "\n### Label:",
+        "dataset_text_field": "output",
+        "use_flash_attn": false,
+        "torch_dtype": "bfloat16",
+        "tokenizer_name_or_path": "/data/input/llama/7B"
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+name: sft-trainer-test
+spec:
+containers:
+    env:
+        - name: SFT_TRAINER_CONFIG_JSON_PATH
+        value: /config/config.json
+    image: sft-trainer:mytag
+    imagePullPolicy: IfNotPresent
+    name: tuning-test
+    resources:
+        limits:
+        nvidia.com/gpu: "1"
+        requests:
+        nvidia.com/gpu: "1"
+    volumeMounts:
+        - mountPath: /data/input
+        name: input-data
+        - mountPath: /data/output
+        name: output-data
+        - mountPath: /config
+        name: sft-trainer-config
+restartPolicy: Never
+terminationGracePeriodSeconds: 30
+volumes:
+    - name: input-data
+    persistentVolumeClaim:
+        claimName: input-pvc
+    - name: output-data
+    persistentVolumeClaim:
+        claimName: output-pvc
+    - name: sft-trainer-config
+    configMap:
+        name: sft-trainer-config
+```

--- a/build/README.md
+++ b/build/README.md
@@ -39,7 +39,6 @@ For example, the below config is used for running with two GPUs and FSDP for fin
         "fsdp_cpu_ram_efficient_loading": true,
         "fsdp_sync_module_states": true
     },
-    "multi_gpu": true,
     "model_name_or_path": "/llama/13B",
     "training_data_path": "/data/twitter_complaints.json",
     "output_dir": "/output/llama-7b-pt-multigpu",
@@ -62,13 +61,9 @@ For example, the below config is used for running with two GPUs and FSDP for fin
 }
 ```
 
-When `multi_gpu` is set to true, the [FSDP config](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/fixtures/accelerate_fsdp_defaults.yaml) is used by default. Any of these values can be overwritten by passing in flags via the JSON config or by passing in your own config file using key `config_file`.
+Users should always set `num_processes` to be explicit about the number of processes to run tuning on. When `num_processes` is greater than 1, the [FSDP config](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/fixtures/accelerate_fsdp_defaults.yaml) is used by default. Any of these values can be overwritten by passing in flags via `accelerate_launch_args` in the JSON config or by passing in your own config file using key `config_file`.
 
-If `multi_gpu` is set and `num_processes` is not explicitly set, the number of processes/GPUs will be determined by the number of GPUs available via `torch.cuda.device_count()`.
-
-If `multi_gpu` is not set, the script will assume single-GPU and run with `num_processes=1`. This can be overwritten by setting `num_processes` or a `config_file` which contains `num_processes`.
-
-Note that `num_processes` which is the total number of processes to be launched in parallel, should match the number of GPUs to run on. The number of GPUs used can also be set by setting environment variable `CUDA_VISIBLE_DEVICES`.
+Note that `num_processes` which is the total number of processes to be launched in parallel, should match the number of GPUs to run on. The number of GPUs used can also be set by setting environment variable `CUDA_VISIBLE_DEVICES`. If ``num_processes=1`, the script will assume single-GPU.
 
 
 ## Building the Image

--- a/build/README.md
+++ b/build/README.md
@@ -67,10 +67,10 @@ If `multiGPU` is not set, the script will assume single-GPU and run with `num_pr
 
 ## Building the Image
 
-With docker, build the image with:
+With docker, build the image at the top level with:
 
 ```sh
-docker build . -t sft-trainer:mytag
+docker build . -t sft-trainer:mytag -f build/Dockerfile
 ```
 
 ## Running the Image

--- a/build/README.md
+++ b/build/README.md
@@ -66,7 +66,7 @@ When `multi_gpu` is set to true, the [FSDP config](https://github.com/foundation
 
 If `multi_gpu` is set and `num_processes` is not explicitly set, the number of processes/GPUs will be determined by the number of GPUs available via `torch.cuda.device_count()`.
 
-If `multi_gpu` is not set, the script will assume single-GPU and run with `num_processes=1`.
+If `multi_gpu` is not set, the script will assume single-GPU and run with `num_processes=1`. This can be overwritten by setting `num_processes` or a `config_file` which contains `num_processes`.
 
 Note that `num_processes` which is the total number of processes to be launched in parallel, should match the number of GPUs to run on. The number of GPUs used can also be set by setting environment variable `CUDA_VISIBLE_DEVICES`.
 
@@ -146,9 +146,9 @@ containers:
     name: tuning-test
     resources:
         limits:
-        nvidia.com/gpu: "1"
+            nvidia.com/gpu: "2"
         requests:
-        nvidia.com/gpu: "1"
+            nvidia.com/gpu: "2"
     volumeMounts:
         - mountPath: /data/input
         name: input-data

--- a/build/README.md
+++ b/build/README.md
@@ -61,7 +61,7 @@ For example, the below config is used for running with two GPUs and FSDP for fin
 }
 ```
 
-Users should always set `num_processes` to be explicit about the number of processes to run tuning on. When `num_processes` is greater than 1, the [FSDP config](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/fixtures/accelerate_fsdp_defaults.yaml) is used by default. Any of these values can be overwritten by passing in flags via `accelerate_launch_args` in the JSON config or by passing in your own config file using key `config_file`.
+Users should always set `num_processes` to be explicit about the number of processes to run tuning on. When `num_processes` is greater than 1, the [FSDP config](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/fixtures/accelerate_fsdp_defaults.yaml) is used by default. You can also set your own default values by specifying your own config file using key `config_file`. Any of these values in configs can be overwritten by passing in flags via `accelerate_launch_args` in the JSON config.
 
 Note that `num_processes` which is the total number of processes to be launched in parallel, should match the number of GPUs to run on. The number of GPUs used can also be set by setting environment variable `CUDA_VISIBLE_DEVICES`. If ``num_processes=1`, the script will assume single-GPU.
 
@@ -105,7 +105,6 @@ config.json: |
             "fsdp_cpu_ram_efficient_loading": true,
             "fsdp_sync_module_states": true
         },
-        "multi_gpu": true,
         "model_name_or_path": "/llama/13B",
         "training_data_path": "/data/twitter_complaints.json",
         "output_dir": "/output/llama-7b-pt-multigpu",

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -1,9 +1,31 @@
-from accelerate.commands.launch import launch_command_parser, launch_command
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script wraps launch_training to run with accelerate for multi and single GPU cases.
+Read multiGPU configuration via environment variable `SFT_TRAINER_CONFIG_JSON_PATH`
+for the path to the JSON config file with parameters or `SFT_TRAINER_CONFIG_JSON_ENV_VAR`
+for the encoded config string to parse.
+"""
+
+# Standard
 import json
 import os
 import base64
 import pickle
+import logging
 
+# Third Party
+from accelerate.commands.launch import launch_command_parser, launch_command
 
 def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
@@ -16,6 +38,9 @@ def txt_to_obj(txt):
         return pickle.loads(message_bytes)
 
 def main():
+    LOGLEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
+    logging.basicConfig(level=LOGLEVEL)
+
     json_configs = {}
     json_path = os.getenv("SFT_TRAINER_CONFIG_JSON_PATH")
     json_env_var = os.getenv("SFT_TRAINER_CONFIG_JSON_ENV_VAR")
@@ -28,21 +53,24 @@ def main():
         json_configs = txt_to_obj(json_env_var)
 
     # parse multiGPU args
-    print("json_configs[multiGPU]", json_configs["multiGPU"])
-
-    multigpu_args = []
+    multi_gpu_args = []
     if json_configs.get("multiGPU"):
+        logging.info("Using multi-GPU configs: %s", json_configs.get("multiGPU"))
         for key, val in json_configs["multiGPU"].items():
-            multigpu_args.append(f"--{key}")
-            multigpu_args.append(str(val))
+            multi_gpu_args.append(f"--{key}")
+            multi_gpu_args.append(str(val))
     
+        # add FSDP config
+        fsdp_filepath = os.getenv("FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml")
+        multi_gpu_args.append("--config_file")
+        multi_gpu_args.append(fsdp_filepath)
+
     # add training_script
-    multigpu_args.append("/app/launch_training.py")
+    multi_gpu_args.append("/app/launch_training.py")
     
-    print("multigpu_args", multigpu_args)
+    logging.debug("multi_gpu_args: %s", multi_gpu_args)
     parser = launch_command_parser()
-    args = parser.parse_args(args=multigpu_args)
-    print(args)
+    args = parser.parse_args(args=multi_gpu_args)
     launch_command(args)
 
 if __name__ == "__main__":

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -36,8 +36,8 @@ def main():
             multigpu_args.append(f"--{key}")
             multigpu_args.append(str(val))
     
-    # TODO: add training_script // rest of args -- no args 
-    multigpu_args.append("--training_script /app/launch_training.py")    
+    # add training_script
+    multigpu_args.append("/app/launch_training.py")
     
     print("multigpu_args", multigpu_args)
     parser = launch_command_parser()

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -1,0 +1,49 @@
+from accelerate.commands.launch import launch_command_parser, launch_command
+import json
+import os
+import base64
+import pickle
+
+
+def txt_to_obj(txt):
+    base64_bytes = txt.encode("ascii")
+    message_bytes = base64.b64decode(base64_bytes)
+    try:
+        # If the bytes represent JSON string
+        return json.loads(message_bytes)
+    except UnicodeDecodeError:
+        # Otherwise the bytes are a pickled python dictionary
+        return pickle.loads(message_bytes)
+
+def main():
+    json_configs = {}
+    json_path = os.getenv("SFT_TRAINER_CONFIG_JSON_PATH")
+    json_env_var = os.getenv("SFT_TRAINER_CONFIG_JSON_ENV_VAR")
+
+    if json_path:
+        with open(json_path, "r", encoding="utf-8") as f:
+            json_configs = json.load(f)
+
+    elif json_env_var:
+        json_configs = txt_to_obj(json_env_var)
+
+    # parse multiGPU args
+    print("json_configs[multiGPU]", json_configs["multiGPU"])
+
+    multigpu_args = []
+    if json_configs.get("multiGPU"):
+        for key, val in json_configs["multiGPU"].items():
+            multigpu_args.append(f"--{key}")
+            multigpu_args.append(str(val))
+    
+    # TODO: add training_script // rest of args -- no args 
+    multigpu_args.append("--training_script /app/launch_training.py")    
+    
+    print("multigpu_args", multigpu_args)
+    parser = launch_command_parser()
+    args = parser.parse_args(args=multigpu_args)
+    print(args)
+    launch_command(args)
+
+if __name__ == "__main__":
+    main()

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -81,6 +81,8 @@ def main():
 
     num_processes = accelerate_config.get("num_processes")
     if num_processes:
+        # if multi GPU setting and accelerate config_file not passed by user,
+        # use the default config for default set of parameters
         if num_processes > 1 and not accelerate_config.get("config_file"):
             # Add default FSDP config
             fsdp_filepath = os.getenv(

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -28,6 +28,7 @@ import logging
 from accelerate.commands.launch import launch_command_parser, launch_command
 import torch
 
+
 def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
     message_bytes = base64.b64decode(base64_bytes)
@@ -37,6 +38,7 @@ def txt_to_obj(txt):
     except UnicodeDecodeError:
         # Otherwise the bytes are a pickled python dictionary
         return pickle.loads(message_bytes)
+
 
 def main():
     LOGLEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
@@ -60,10 +62,12 @@ def main():
         for key, val in json_configs["multiGPU"].items():
             multi_gpu_args.append(f"--{key}")
             multi_gpu_args.append(str(val))
-    
+
         # add FSDP config
         if not json_configs.get("multiGPU").get("config_file"):
-            fsdp_filepath = os.getenv("FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml")
+            fsdp_filepath = os.getenv(
+                "FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml"
+            )
             if os.path.exists(fsdp_filepath):
                 logging.info(f"Setting accelerate config file to: {fsdp_filepath}")
                 multi_gpu_args.append("--config_file")
@@ -79,11 +83,12 @@ def main():
 
     # add training_script
     multi_gpu_args.append("/app/launch_training.py")
-    
+
     logging.debug("multi_gpu_args: %s", multi_gpu_args)
     parser = launch_command_parser()
     args = parser.parse_args(args=multi_gpu_args)
     launch_command(args)
+
 
 if __name__ == "__main__":
     main()

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -75,33 +75,34 @@ def main():
                 accelerate_launch_args.append(f"--{key}")
                 accelerate_launch_args.append(str(val))
 
-        if json_configs.get("multi_gpu"):
-            # add FSDP config
-            if not accelerate_config.get("config_file"):
-                fsdp_filepath = os.getenv(
-                    "FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml"
-                )
-                if os.path.exists(fsdp_filepath):
-                    logging.info("Setting accelerate config file to: %s", fsdp_filepath)
-                    accelerate_launch_args.append("--config_file")
-                    accelerate_launch_args.append(fsdp_filepath)
+    if json_configs.get("multi_gpu"):
+        # add FSDP config
+        if not accelerate_config.get("config_file"):
+            fsdp_filepath = os.getenv(
+                "FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml"
+            )
+            if os.path.exists(fsdp_filepath):
+                logging.info("Setting accelerate config file to: %s", fsdp_filepath)
+                accelerate_launch_args.append("--config_file")
+                accelerate_launch_args.append(fsdp_filepath)
 
-                # add num_processes to overwrite config file set one
-                if not accelerate_config.get("num_processes"):
-                    num_gpus = torch.cuda.device_count()
-                    if num_gpus > 1:
-                        logging.info("Setting accelerate num processes to %s", num_gpus)
-                        accelerate_launch_args.append("--num_processes")
-                        accelerate_launch_args.append(str(num_gpus))
-        else:
-            accelerate_launch_args.append("--num_processes")
-            accelerate_launch_args.append("1")
+            # add num_processes to overwrite config file set one
+            if not accelerate_config.get("num_processes"):
+                num_gpus = torch.cuda.device_count()
+                if num_gpus > 1:
+                    logging.info("Setting accelerate num processes to %s", num_gpus)
+                    accelerate_launch_args.append("--num_processes")
+                    accelerate_launch_args.append(str(num_gpus))
+    else:
+        accelerate_launch_args.append("--num_processes")
+        accelerate_launch_args.append("1")
 
     # add training_script
     accelerate_launch_args.append("/app/launch_training.py")
 
     logging.debug("accelerate_launch_args: %s", accelerate_launch_args)
     args = parser.parse_args(args=accelerate_launch_args)
+    logging.debug("accelerate launch parsed args: %s", args)
     launch_command(args)
 
 

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -57,7 +57,7 @@ def main():
 
     # parse multiGPU args
     multi_gpu_args = []
-    if json_configs.get("multiGPU"):
+    if json_configs.get("multiGPU") is not None:
         logging.info("Using multi-GPU configs: %s", json_configs.get("multiGPU"))
         for key, val in json_configs["multiGPU"].items():
             multi_gpu_args.append(f"--{key}")
@@ -69,7 +69,7 @@ def main():
                 "FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml"
             )
             if os.path.exists(fsdp_filepath):
-                logging.info(f"Setting accelerate config file to: {fsdp_filepath}")
+                logging.info("Setting accelerate config file to: %s", fsdp_filepath)
                 multi_gpu_args.append("--config_file")
                 multi_gpu_args.append(fsdp_filepath)
 
@@ -77,7 +77,7 @@ def main():
         if not json_configs.get("multiGPU").get("num_processes"):
             num_gpus = torch.cuda.device_count()
             if num_gpus > 1:
-                logging.info(f"Setting accelerate num processes to {num_gpus}")
+                logging.info("Setting accelerate num processes to %s", num_gpus)
                 multi_gpu_args.append("--num_processes")
                 multi_gpu_args.append(str(num_gpus))
 

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -76,9 +76,9 @@ def main():
                 if actions_type_map.get(key) == "_StoreAction":
                     accelerate_launch_args.append(str(val))
 
-    if json_configs.get("multi_gpu"):
-        # add FSDP config
-        if not accelerate_config.get("config_file"):
+    if not accelerate_config.get("config_file"):
+        if json_configs.get("multi_gpu"):
+            # add FSDP config
             fsdp_filepath = os.getenv(
                 "FSDP_DEFAULTS_FILE_PATH", "/app/accelerate_fsdp_defaults.yaml"
             )
@@ -94,9 +94,9 @@ def main():
                     logging.info("Setting accelerate num processes to %s", num_gpus)
                     accelerate_launch_args.append("--num_processes")
                     accelerate_launch_args.append(str(num_gpus))
-    else:
-        accelerate_launch_args.append("--num_processes")
-        accelerate_launch_args.append("1")
+        else:
+            accelerate_launch_args.append("--num_processes")
+            accelerate_launch_args.append("1")
 
     # add training_script
     accelerate_launch_args.append("/app/launch_training.py")

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -80,6 +80,9 @@ def main():
                 logging.info("Setting accelerate num processes to %s", num_gpus)
                 multi_gpu_args.append("--num_processes")
                 multi_gpu_args.append(str(num_gpus))
+    else:
+        multi_gpu_args.append("--num_processes")
+        multi_gpu_args.append("1")
 
     # add training_script
     multi_gpu_args.append("/app/launch_training.py")

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -66,7 +66,8 @@ def main():
     LOGLEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
     logging.basicConfig(level=LOGLEVEL)
 
-    logging.info("Attempting to launch training script")
+    logging.info("Initializing launch training script")
+
     parser = transformers.HfArgumentParser(
         dataclass_types=(
             configs.ModelArguments,
@@ -122,7 +123,7 @@ def main():
     elif peft_method_parsed == "pt":
         tune_config = prompt_tuning_config
 
-    logging.debug(
+    logging.info(
         "Parameters used to launch training: \
     model_args %s, data_args %s, training_args %s, tune_config %s",
         model_args,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

- Adds additional script that parses params for `accelerate launch` which calls original launch_training to support multi (and single) GPU tuning
- Dockerfile changes:
   - Add new script and default FSDP config to image
   - Give tuning user ownership of /tmp dir - helps with running fms-hf-tuning code
   - Update default command to run accelerate launch script
- Update logging messages launch_training

### Related issue number

closes: #88 

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Tested script running fine tuning on multi-GPU cluster for large models that required loading on multi-GPUs to run. Ran with the default FSDP config provided.

Testing with FSDP, 3 GPUs, FT with granite-13b-instruct-v2' model:

```sh
# ran script in pod connected to 3 GPUs with debug logging set
$ python /app/accelerate_launch.py 

# Input params parsed
INFO:root:Using multi-GPU configs: {'num_machines': 1, 'num_processes': 3, 'main_process_port': 1234, 'config_file': '/tmp/fms-hf-tuning/fixtures/accelerate_fsdp_defaults.yaml'}
DEBUG:root:multi_gpu_args: ['--num_machines', '1', '--num_processes', '3', '--main_process_port', '1234', '--config_file', '/tmp/fms-hf-tuning/fixtures/accelerate_fsdp_defaults.yaml', '/app/launch_training.py']
/usr/local/lib/python3.11/site-packages/accelerate/utils/launch.py:232: FutureWarning: `fsdp_backward_prefetch_policy` is deprecated and will be removed in version 0.27.0 of 🤗 Accelerate. Use `fsdp_backward_prefetch` instead
  warnings.warn(
INFO:root:Using nproc_per_node=3.

# note that below you see launch_training script triggered 3 times
INFO:root:Attempting to launch training script
INFO:root:Attempting to launch training script
INFO:root:Attempting to launch training script

# note that below is also printed 3 times for each process running launch_training script
DEBUG:root:Input params parsed: {'multiGPU': {'num_machines': 1, 'num_processes': 3, 'main_process_port': 1234, 'config_file': '/tmp/fms-hf-tuning/fixtures/accelerate_fsdp_defaults.yaml'}, 'model_name_or_path': '/granite-pvc/granite-13b-instruct-v2', 'training_data_path': 'twitter_complaints.json', 'output_dir': 'granite-13b-instruct-v2-ft-multigpu', 'num_train_epochs': 5.0, 'per_device_train_batch_size': 4, 'per_device_eval_batch_size': 4, 'gradient_accumulation_steps': 4, 'evaluation_strategy': 'no', 'save_strategy': 'epoch', 'learning_rate': 0.03, 'weight_decay': 0.0, 'lr_scheduler_type': 'cosine', 'logging_steps': 1.0, 'packing': False, 'include_tokens_per_second': True, 'response_template': '\n### Label:', 'dataset_text_field': 'output', 'use_flash_attn': False, 'torch_dtype': 'bfloat16', 'tokenizer_name_or_path': '/granite-pvc/granite-13b-instruct-v2'}

# includes lots of logs on cuda fsdp resource usage
[rank0]:[2024-03-22 21:21:45,850] torch.distributed.fsdp._debug_utils: [WARNING] FSDP _optim_state_dict() profiling:  defaultdict(<class 'float'>, {'preprocessing': 0.04680833197198808, 'preprocessing_with_comm': 0.003385562915354967, <Type.ALLGATHER_OBJ: 'all_gather_object'>: 0.11370941274799407, <Type.ALLGATHER: 'all_gather'>: 0.40186795219779015, <Type.D2H: 'D2H'>: 22.668807602720335, <Type.RESHARDING: 'resharding'>: 23.291323721176013, 'state_converting': 23.29437973885797, <Type.ALL: 'all'>: 23.34716020594351})

....
# successful tuning
INFO:root:Copying last checkpoint checkpoint-5 into output dir /platform-testing-cos/anhuong/granite-13b-instruct-v2-ft-multigpu
{'train_runtime': 502.18, 'train_samples_per_second': 0.498, 'train_steps_per_second': 0.01, 'train_tokens_per_second': 10.833, 'train_loss': 109.41771049499512, 'epoch': 4.0}
INFO:root:Copying last checkpoint checkpoint-5 into output dir /platform-testing-cos/anhuong/granite-13b-instruct-v2-ft-multigpu
100%|███████████████████████████████████████████████████████████████████████████████| 5/5 [08:21<00:00, 70.52s/it]DEBUG:aim.sdk.run:Closing resource <aim.ext.resource.tracker.ResourceTracker object at 0x7fd54ce67710>

$ ls granite-13b-instruct-v2-ft-multigpu
config.json			  model-00005-of-00006.safetensors  rng_state_1.pth	     train_loss.jsonl
generation_config.json		  model-00006-of-00006.safetensors  rng_state_2.pth	     trainer_state.json
model-00001-of-00006.safetensors  model.safetensors.index.json	    scheduler.pt	     training_args.bin
model-00002-of-00006.safetensors  optimizer.bin			    special_tokens_map.json
model-00003-of-00006.safetensors  pytorch_model_fsdp.bin	    tokenizer.json
model-00004-of-00006.safetensors  rng_state_0.pth		    tokenizer_config.json
```

multi-gpu shown in nvidia-smi output:
```sh
# note 3 processes running launch_training script
$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
tuning         1  0.0  0.0   5320  2520 ?        Ss   20:51   0:00 /usr/bin/coreutils --coreutils-prog-shebang=sle
tuning        19  0.0  0.0   4920  4092 pts/0    Ss   20:52   0:00 bash
tuning       378  1.7  0.0 5948140 459388 pts/0  Sl+  21:11   0:03 python /app/accelerate_launch.py
tuning       444 51.0  2.0 127945092 27616120 ?  Rsl  21:11   1:44 /bin/python -u /app/launch_training.py
tuning       445 41.8  0.1 104744860 1518380 ?   Rsl  21:11   1:25 /bin/python -u /app/launch_training.py
tuning       446 41.7  0.1 101277092 1509280 ?   Rsl  21:11   1:25 /bin/python -u /app/launch_training.py
tuning       491  0.0  0.0   4840  4020 pts/1    Ss   21:12   0:00 bash
tuning       585  0.0  0.0   7536  3480 pts/1    R+   21:15   0:00 ps aux

# initial loading of the model
Fri Mar 22 21:15:15 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.104.05             Driver Version: 535.104.05   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A100-SXM4-80GB          On  | 00000000:0A:04.0 Off |                    0 |
| N/A   30C    P0              84W / 400W |  75997MiB / 81920MiB |     22%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA A100-SXM4-80GB          On  | 00000000:0C:05.0 Off |                    0 |
| N/A   32C    P0             105W / 400W |  75717MiB / 81920MiB |    100%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA A100-SXM4-80GB          On  | 00000000:0C:06.0 Off |                    0 |
| N/A   30C    P0             113W / 400W |  75809MiB / 81920MiB |     99%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+

# running fine tuning
Fri Mar 22 21:22:03 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.104.05             Driver Version: 535.104.05   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A100-SXM4-80GB          On  | 00000000:0A:04.0 Off |                    0 |
| N/A   29C    P0              71W / 400W |  75999MiB / 81920MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA A100-SXM4-80GB          On  | 00000000:0C:05.0 Off |                    0 |
| N/A   32C    P0              90W / 400W |  75717MiB / 81920MiB |    100%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA A100-SXM4-80GB          On  | 00000000:0C:06.0 Off |                    0 |
| N/A   29C    P0              95W / 400W |  75809MiB / 81920MiB |    100%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass