### PR TITLE
fix: not passing PEFT argument should default to full parameter finetuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ pip install -e ".[flash-attn]"
 ```
 [FlashAttention](https://github.com/Dao-AILab/flash-attention) requires the [CUDA Toolit](https://developer.nvidia.com/cuda-toolkit) to be pre-installed.
 
+If you wish to use [aim](https://github.com/aimhubio/aim), then you need to install it:
+```
+pip install -e ".[aim]"
+```
+
 ## Data format
 The data format expectation is a single column text. The trainer is configured to expect a response template as a string. For example, if one wants to prepare the `alpaca` format data to feed into this trainer, it is quite easy and can be done with the following code.
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -103,6 +103,7 @@ RUN git clone https://github.com/foundation-model-stack/fms-hf-tuning.git && \
     cd fms-hf-tuning && \
     python -m pip install ".[dev]" && \
     python -m pip install ".[flash-attn]" && \
+    python -m pip install ".[aim]" && \
     python -m pip install -U datasets
 
 RUN mkdir -p /licenses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["dependencies"]
 [project.optional-dependencies]
 dev = ["wheel", "packaging", "ninja"]
 flash-attn = ["flash-attn"]
+aim = ["aim==3.18.1"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 accelerate>=0.20.3
 transformers
 torch
-aim==3.18.1
 sentencepiece
 tokenizers>=0.13.3
 tqdm

--- a/tuning/aim_loader.py
+++ b/tuning/aim_loader.py
@@ -15,8 +15,12 @@
 # Standard
 import os
 
-# Third Party
-from aim.hugging_face import AimCallback
+# Local
+from tuning.utils.import_utils import is_aim_available
+
+if is_aim_available():
+    # Third Party
+    from aim.hugging_face import AimCallback  # pylint: disable=import-error
 
 
 def get_aimstack_callback():

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -279,7 +279,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
         "--peft_method",
         type=str.lower,
         choices=["pt", "lora", None, "none"],
-        default="pt",
+        default="none",
     )
     (
         model_args,

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -37,11 +37,15 @@ import fire
 import transformers
 
 # Local
-from tuning.aim_loader import get_aimstack_callback
 from tuning.config import configs, peft_config
 from tuning.data import tokenizer_data_utils
 from tuning.utils.config_utils import get_hf_peft_config
 from tuning.utils.data_type_utils import get_torch_dtype
+from tuning.utils.import_utils import is_aim_available
+
+if is_aim_available():
+    # Local
+    from tuning.aim_loader import get_aimstack_callback
 
 
 class FileLoggingCallback(TrainerCallback):
@@ -215,9 +219,9 @@ def train(
             "Validation dataset length is %s", len(formatted_validation_dataset)
         )
 
-    aim_callback = get_aimstack_callback()
-    file_logger_callback = FileLoggingCallback(logger)
-    callbacks = [aim_callback, file_logger_callback]
+    callbacks = [FileLoggingCallback(logger)]
+    if is_aim_available():
+        callbacks.append(get_aimstack_callback())
 
     if train_args.packing:
         logger.info("Packing is set to True")

--- a/tuning/utils/import_utils.py
+++ b/tuning/utils/import_utils.py
@@ -1,0 +1,22 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Third Party
+from transformers.utils.import_utils import _is_package_available
+
+_is_aim_available = _is_package_available("aim")
+
+
+def is_aim_available():
+    return _is_aim_available


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Currently, not setting `--peft_method` defaults to prompt tuning. However, intuitively, not passing --peft_method should mean not to use any parameter efficient method like LoRA and prompt tuning. Therefore, its good to fallback to full parameter tuning rather prompt tuning. PR adds this.


### Related issue number

Closes #48 

### Was the PR tested

Yes ✅

```
fmstuning ❯ python sft_trainer.py --output_dir ./output
# no peft method is given so it defaults to none (full parameter tuning)
Namespace(peft_method='none')
```