### PR TITLE
Add eval script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ peft>=0.8.0
 datasets>=2.15.0
 fire
 
+# Dependencies needed only to run scripts.
+# TODO: Figure out a better place to put these.
+scikit-learn>=1.0, <2.0

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -4,15 +4,15 @@ Metrics used: Accuracy / Micro & Macro F1.
 """
 # Standard
 from shutil import rmtree
+from typing import Any, Optional
 import argparse
 import json
 import os
-from typing import Optional, Any
 
 # Third Party
 from run_inference import TunedCausalLM
 from sklearn import preprocessing
-from sklearn.metrics import accuracy_score, f1_score, recall_score, precision_score
+from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
 from tqdm import tqdm
 import datasets
 import numpy as np
@@ -233,7 +233,9 @@ def map_predictions_and_references_to_encoded_vectors(
     return pred_vectors, reference_vectors, label_map
 
 
-def get_encoded_vector(ohe: preprocessing.OneHotEncoder, texts: list[str], unk_label: str) -> np.typing.NDArray:
+def get_encoded_vector(
+    ohe: preprocessing.OneHotEncoder, texts: list[str], unk_label: str
+) -> np.typing.NDArray:
     """Get the encoded vector representing one or more generated texts by one hot encoding each
     individual text and collapsing the result.
 
@@ -270,7 +272,9 @@ def get_encoded_vector(ohe: preprocessing.OneHotEncoder, texts: list[str], unk_l
     return vec_stack.sum(axis=0)
 
 
-def extract_unique_labels(preds: list[list[str]], refs: list[list[str]], unk_label: str) -> list[list[str]]:
+def extract_unique_labels(
+    preds: list[list[str]], refs: list[list[str]], unk_label: str
+) -> list[list[str]]:
     """Grab all of the unique labels and return them as a list of single feature lists.
     Args:
         preds: list[list[str]]
@@ -312,7 +316,9 @@ def extract_unique_labels(preds: list[list[str]], refs: list[list[str]], unk_lab
     return ref_label_list
 
 
-def compute_metrics_dict_multi(enc_preds: list[np.typing.NDArray], enc_refs: list[np.typing.NDArray]) -> dict[str, Any]:
+def compute_metrics_dict_multi(
+    enc_preds: list[np.typing.NDArray], enc_refs: list[np.typing.NDArray]
+) -> dict[str, Any]:
     """Calculate the metrics based on the encoded prediction and reference vector lists.
     Current metrics: precision, recall f1, accuracy
 
@@ -329,10 +335,18 @@ def compute_metrics_dict_multi(enc_preds: list[np.typing.NDArray], enc_refs: lis
     micro_f1 = f1_score(enc_refs, enc_preds, average="micro")
     macro_f1 = f1_score(enc_refs, enc_preds, average="macro")
     # For recall - the UNK class containing only false positives does NOT affect score.
-    micro_recall = recall_score(enc_refs, enc_preds, average="micro", zero_division=np.nan)
-    macro_recall = recall_score(enc_refs, enc_preds, average="macro", zero_division=np.nan)
-    micro_prec = precision_score(enc_refs, enc_preds, average="micro", zero_division=np.nan)
-    macro_prec = precision_score(enc_refs, enc_preds, average="macro", zero_division=np.nan)
+    micro_recall = recall_score(
+        enc_refs, enc_preds, average="micro", zero_division=np.nan
+    )
+    macro_recall = recall_score(
+        enc_refs, enc_preds, average="macro", zero_division=np.nan
+    )
+    micro_prec = precision_score(
+        enc_refs, enc_preds, average="micro", zero_division=np.nan
+    )
+    macro_prec = precision_score(
+        enc_refs, enc_preds, average="macro", zero_division=np.nan
+    )
     # NOTE: For the multiclass / multilabel scenario, sklearn accuracy does NOT assign partial
     # credit, i.e., instances are only considered correct if they match the ground truth
     # encoded vectors exactly.

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -3,13 +3,13 @@
 Metrics used: Accuracy / Micro & Macro F1.
 """
 import os
+import numpy as np
 from sklearn import preprocessing
 from sklearn.metrics import f1_score, accuracy_score
 import argparse
 import json
 from tqdm import tqdm
 import datasets
-import evaluate
 from run_inference import TunedCausalLM
 from shutil import rmtree
 
@@ -141,109 +141,73 @@ def postprocess_output(output_text, delimiter):
     if delimiter is not None:
         return [text_substr.strip() for text_substr in output_text.split(delimiter)]
     return [output_text.strip()]
-### Metric computation/display & utils for mapping labels to numerics for hf evaluate
-def map_predictions_and_references_to_numerics(predictions: list, references: list) -> tuple:
-    """Maps string predictions and references to numerics for use in accuracy and
-    f1 computations. This process is generally ambiguous and can be done a number of
-    ways, but the strategy we use is as follows:
 
-    - Prior to consideration, all predictions and references are stripped of whitespace
-    - Map all unique reference values to integers
-    - Apply mapping of ref -> int to predictions; anything else is mapped to an unknown label val
-      where the unknown label is treated as its own class
 
-    Important caveats:
-    - this strategy is case sensitive
-    - this cannot be used for multioutput classification problems as is, since the entire
-      predicted text is treated as a single label
-    - be careful about the value of the max number of tokens for generation, since this
-      essentially boils down to a string match problem
+### Metric computation/display & utils for mapping labels to numerics for sklearn
+def map_predictions_and_references_to_encoded_vectors(predictions: list, references: list):
+    ohe = preprocessing.OneHotEncoder()
+    # Extract the unique (potentially delimited labels) to fit the one hot encoder. We need to do
+    # this directly in case it's a multiclass/multilabel scenario, because the 2D arr consumed
+    # by the OHE expected consistent axis shapes, i.e., columns are treated as different features,
+    # and cannot have a variable number of values.
+    unk_label = "<UNKNOWN>"
+    unique_labels = extract_unique_labels(predictions, references, unk_label)
+    ohe.fit(unique_labels)
 
-    Args:
-        predictions: list
-            List of strings to be converted to class indices predicted by model.
-        references[list]
-            List of strings to be converted to class indices for ground truth.
+    # Now get the encoded vectors for our references and our predictions by one hot encoding
+    # theunique sublabels and collapsing them into one vector along the row dimension.
+    reference_vectors = [get_encoded_vector(ohe, refs, unk_label) for refs in references]
+    pred_vectors = [get_encoded_vector(ohe, preds, unk_label) for preds in predictions]
 
-    Returns:
-        tuple
-            Tuple containing:
-                int_predictions [list of ints] class indices for predicted samples
-                ref_predictions [list of ints] class indices for ground truth samples
-                label_map [dict] dict mapping indices to strings
-    """
-    le = preprocessing.LabelEncoder()
-    le.fit(predictions)
-    # Label encoder maps from class indices from [0, n-1], so we use n as our throwaway class
-    unk_label = le.classes_.shape[0]
-    int_predictions = [get_encoded_label(le, pred, unk_label) for pred in predictions]
-    int_references = [get_encoded_label(le, references, unk_label) for pred in predictions]
-    # Generate the class mapping + the unk label
+    # For debugging purposes - map the indices in our none hot encoded entries.
+    # NOTE: the categories_ attr is a 2D array of features, and we only care about [0]
+    # since the uniquely extracted labels are only single dim features when fitting
+    # the transform itself.
     label_map = {
-        idx: label for idx, label in enumerate(le.inverse_transform(list(range(unk_label))))
+        idx: label for idx, label in enumerate(ohe.categories_[0])
     }
-    label_map[unk_label] = "<UNKNOWN LABEL>"
-    return int_predictions, int_references, label_map
+    return pred_vectors, reference_vectors, label_map
 
-def get_encoded_label(le: preprocessing.LabelEncoder, gen_text: str, unk_label: int) -> int:
-    """Gets the encoded label of a text string.
-    Args:
-        le: preprocessing.LabelEncode
-            Label Encoder object which maps text strings into class indices.
-        gen_text: str
-            Text that was generated as a label by the model.
-        unk_label: int
-            Label to be used for unknown / garbage generation, i.e., things unknown to the
-            label encoder.
+def get_encoded_vector(ohe, texts, unk_label) -> int:
+    # Since our encoded vector is built on collapsing one hot encoded vectors,
+    # we need to explicitly handle the empty case since it is not one hot encodable.
+    # raise ValueError(np.zeros(len(ohe.categories_[0])).dtype )
+    if not texts:
+        return np.zeros(len(ohe.categories_[0]))
+    # Clean the generated text list; anything that is in the list that is not known to the
+    # one hot encoder gets replaced by the unk_label. It is okay if we have multiple unk_labels
+    # in the vector, since all of these just map to one positive entry in the encoded vector.
+    cleaned_texts = list(set([text if text in ohe.categories_[0] else unk_label for text in texts]))
+    # Encode the cleaned text as a 2D feature array of one hot encoded vectors
+    vec_stack = ohe.transform([[text] for text in cleaned_texts]).toarray()
 
-    Returns:
-        int
-            The integer label index corresponding to the generated text.
-    """
-    try:
-        return le.transform(gen_text)[0]
-    except ValueError:
-        # Model generated text that is not a valid label, i.e., is not in the label encoder
-        return unk_label
+    # Then collapse the one hot encoded vectors along the column dimension to get
+    # get the encoded binary vector for the multilabel / multiclass prediction.
+    return vec_stack.sum(axis=0)
 
+def extract_unique_labels(predictions, references, unk_label):
+    """Grab all of the unique labels and return them as a list of single feature lists."""
+    unique_ref_labels = set()
+    for ref in references:
+        for sub_label in ref:
+            # This is pretty unlikely to happen (class named "<UNKNOWN>"), but for now, raise
+            # if we see it happen, since that will currently mess up the results a little bit.
+            if sub_label == unk_label:
+                raise ValueError(f"Unk label {unk_label} is being used as a ground truth label!")                
+            unique_ref_labels.add(sub_label)
 
-def compute_metrics_dict(int_preds: list, int_references: list) -> dict:
-    """Calculate the metrics on the (int) lists of preds against ground truth.
-    
-    Args:
-        int_preds: list
-            list of class indices for texts generated by the model.
-        int_references: list
-            list of class indices for ground truth labels.
-
-    Returns:
-        dict
-            Dictionary containing F1 / accuracy metrics.
-    """
-    f1_metric = evaluate.load("f1")
-    accuracy_metric = evaluate.load("accuracy")
-    # Compute the micro & macro f1 scores
-    micro_f1 = f1_metric.compute(predictions=int_preds, references=int_references, average="micro")
-    macro_f1 = f1_metric.compute(predictions=int_preds, references=int_references, average="macro")
-    # Compute the accuracy
-    accuracy = accuracy_metric.compute(predictions=int_preds, references=int_references)
-    return {
-        "f1": {
-            "micro": micro_f1,
-            "macro": macro_f1,
-        },
-        "accuracy": accuracy
-    }
-
-
-#### Replaces legacy logic
-def map_predictions_and_references_to_one_hot_encoded_vectors(predictions: list, references: list):
-    # Currently it's a stub that we can use to validate our metric correctness
-    references = [[1,1,0], [1,0,1], [0,0,1], [0,0,0]]
-    predictions = [[0,1,1], [1,0,0], [0,0,1], [1,0,1]]
-    label_map = {0: "bird", 2: "cat", 3: "dog"}
-    # In this scenario, dog basically represents <UNK>
-    return references, predictions, label_map
+    ref_label_list = [[label] for label in unique_ref_labels]
+    # HACK - traverse the predictions and see if any unk predictions were made; if so, make a
+    # garbage <UNKNOWN> class, which we will mark as false positives here.
+    for pred in predictions:
+        for sub_pred in pred:
+            # One of our delimited predictions is unknown!
+            if sub_pred not in unique_ref_labels:
+                # Add the unk label once we know that it isn't a field in our eval data
+                print("Adding <unk> label to handle garbage label generation")
+                ref_label_list.append([unk_label])
+                return ref_label_list
+    return ref_label_list
 
 def compute_metrics_dict_multi(enc_preds, enc_refs):
     micro_f1 = f1_score(enc_refs, enc_preds, average="micro")
@@ -293,7 +257,7 @@ if __name__ == "__main__":
     model = TunedCausalLM.load(args.model)
     data = datasets.load_dataset("json", data_files=args.data_path, split=args.split)
     predictions, references, model_pred_file_info = get_prediction_results(model, data, args.max_new_tokens, args.delimiter)
-    int_preds, int_references, label_map = map_predictions_and_references_to_one_hot_encoded_vectors(predictions, references)
+    int_preds, int_references, label_map = map_predictions_and_references_to_encoded_vectors(predictions, references)
     metrics_dict = compute_metrics_dict_multi(int_preds, int_references)
     experiment_metadata = {
         "model": args.model,
@@ -301,17 +265,3 @@ if __name__ == "__main__":
         "data_path": args.data_path,
     }
     export_experiment_info(metrics_dict, label_map, model_pred_file_info, experiment_metadata, args.output_dir)
-
-
-
-"""
-python3 run_evaluation.py --model TinyLlama/TinyLlama-1.1B-step-50K-105b  --data_path stanford_alpaca/alpaca_data.json  --max_new_tokens 10
-
-{
-    'input': '',
-    'instruction': 'Give three tips for staying healthy.',
-    'output': '1.Eat a balanced diet and make sure to include plenty of fruits and vegetables. \n2. Exercise regularly to keep your body active and strong. \n3. Get enough sleep and maintain a consistent sleep schedule.'
-}
-
-note: we need scikit learn and evaluate for this script [since f1 is also written on top of sklearn]
-"""

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -2,16 +2,20 @@
 
 Metrics used: Accuracy / Micro & Macro F1.
 """
-import os
-import numpy as np
-from sklearn import preprocessing
-from sklearn.metrics import f1_score, accuracy_score
+# Standard
+from shutil import rmtree
 import argparse
 import json
+import os
+
+# Third Party
+from run_inference import TunedCausalLM
+from sklearn import preprocessing
+from sklearn.metrics import accuracy_score, f1_score
 from tqdm import tqdm
 import datasets
-from run_inference import TunedCausalLM
-from shutil import rmtree
+import numpy as np
+
 
 def parse_and_validate_args():
     """Parse the arguments and ensure everything is valid."""
@@ -28,17 +32,21 @@ def parse_and_validate_args():
         "--split", help="Split to be used for the data", default="train"
     )
     parser.add_argument(
-        "--max_new_tokens", help="Max new tokens to use in generation", type=int,
+        "--max_new_tokens",
+        help="Max new tokens to use in generation",
+        type=int,
     )
     parser.add_argument(
-        "--output_dir", help="Directory path to export results to", default="eval_results"
+        "--output_dir",
+        help="Directory path to export results to",
+        default="eval_results",
     )
     parser.add_argument(
         "--delimiter",
         help="Delimiter to be used for multilabel multiclass evaluation",
         default=None,
     )
-    parser.add_argument('--purge_results', action=argparse.BooleanOptionalAction)
+    parser.add_argument("--purge_results", action=argparse.BooleanOptionalAction)
 
     parsed_args = parser.parse_args()
 
@@ -46,7 +54,9 @@ def parse_and_validate_args():
     # If we have a collision on the outdir, only remove the existing file if we explicitly say to
     if os.path.exists(parsed_args.output_dir):
         if parsed_args.purge_results:
-            print(f"Existing output file/directory: [{parsed_args.output_dir}] will be deleted...")
+            print(
+                f"Existing output file/directory: [{parsed_args.output_dir}] will be deleted..."
+            )
             rmtree(parsed_args.output_dir)
         else:
             raise FileExistsError(
@@ -58,6 +68,7 @@ def parse_and_validate_args():
 ### Alpaca dataset formatting utilities
 PROMPT_DICT = {
     "prompt_input": (
+        # pylint: disable=line-too-long
         "Below is an instruction that describes a task, paired with an input that provides further context. "
         "Write a response that appropriately completes the request.\n\n"
         "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
@@ -68,6 +79,7 @@ PROMPT_DICT = {
         "### Instruction:\n{instruction}\n\n### Response:"
     ),
 }
+
 
 def get_formatted_example(example: dict) -> dict:
     """Given a single example, format it based on whether or not we have an input provided.
@@ -83,17 +95,30 @@ def get_formatted_example(example: dict) -> dict:
                 "input" - the formatted text to run the prediction on.
                 "output" - the target text we aim to generate.
     """
-    prompt_input, prompt_no_input = PROMPT_DICT["prompt_input"], PROMPT_DICT["prompt_no_input"]
-    formatted_input = prompt_input.format_map(example) if example.get("input", "") != "" else prompt_no_input.format_map(example)
+    prompt_input, prompt_no_input = (
+        PROMPT_DICT["prompt_input"],
+        PROMPT_DICT["prompt_no_input"],
+    )
+    formatted_input = (
+        prompt_input.format_map(example)
+        if example.get("input", "") != ""
+        else prompt_no_input.format_map(example)
+    )
     return {
         # Text to run the prediction on
         "input": formatted_input,
         # Text to be generated (does not include the input str)
-        "output": example["output"]
+        "output": example["output"],
     }
 
+
 ### Model evaluation
-def get_prediction_results(model: TunedCausalLM, data: datasets.arrow_dataset.Dataset, max_new_tokens: int, delimiter: str) -> tuple:
+def get_prediction_results(
+    model: TunedCausalLM,
+    data: datasets.arrow_dataset.Dataset,
+    max_new_tokens: int,
+    delimiter: str,
+) -> tuple:
     """Runs the model over the alpaca formatted data to get the predictions / references to be used
     when computing the metrics of interest.
 
@@ -110,11 +135,11 @@ def get_prediction_results(model: TunedCausalLM, data: datasets.arrow_dataset.Da
             Tuple containing:
                 predictions [list of strings]
                 references [list of strings]
-                model_pred_file_info [list of dicts containing formatted data to be dumped later]          
+                model_pred_info [list of dicts containing formatted data to be dumped later]
     """
-    predictions = []
-    references = []
-    model_pred_file_info = []
+    preds = []
+    refs = []
+    model_pred_info = []
     for datum in tqdm(data):
         # Format the alpaca example
         formatted_datum = get_formatted_example(datum)
@@ -127,46 +152,56 @@ def get_prediction_results(model: TunedCausalLM, data: datasets.arrow_dataset.Da
         # Save the raw output / predicted texts
         processed_pred = postprocess_output(prediction, delimiter)
         processed_ref = postprocess_output(formatted_datum["output"], delimiter)
-        predictions.append(processed_pred)
-        references.append(processed_ref)
-        model_pred_file_info.append({
-            "formatted input": formatted_datum["input"],
-            "predicted target": processed_pred,
-            "ref target": processed_ref,
-        })
-    return predictions, references, model_pred_file_info
+        preds.append(processed_pred)
+        refs.append(processed_ref)
+        model_pred_info.append(
+            {
+                "formatted input": formatted_datum["input"],
+                "predicted target": processed_pred,
+                "ref target": processed_ref,
+            }
+        )
+    return preds, refs, model_pred_info
+
 
 def postprocess_output(output_text, delimiter):
-    """NOTE: We are returning a list here, since that is what the one hot encoder module expects. """
+    """NOTE: We are returning a list here, since that is what the one hot encoder module expects."""
     if delimiter is not None:
         return [text_substr.strip() for text_substr in output_text.split(delimiter)]
     return [output_text.strip()]
 
 
 ### Metric computation/display & utils for mapping labels to numerics for sklearn
-def map_predictions_and_references_to_encoded_vectors(predictions: list, references: list):
+def map_predictions_and_references_to_encoded_vectors(
+    predictions_lists: list, references_lists: list
+):
     ohe = preprocessing.OneHotEncoder()
     # Extract the unique (potentially delimited labels) to fit the one hot encoder. We need to do
     # this directly in case it's a multiclass/multilabel scenario, because the 2D arr consumed
     # by the OHE expected consistent axis shapes, i.e., columns are treated as different features,
     # and cannot have a variable number of values.
     unk_label = "<UNKNOWN>"
-    unique_labels = extract_unique_labels(predictions, references, unk_label)
+    unique_labels = extract_unique_labels(
+        predictions_lists, references_lists, unk_label
+    )
     ohe.fit(unique_labels)
 
     # Now get the encoded vectors for our references and our predictions by one hot encoding
     # theunique sublabels and collapsing them into one vector along the row dimension.
-    reference_vectors = [get_encoded_vector(ohe, refs, unk_label) for refs in references]
-    pred_vectors = [get_encoded_vector(ohe, preds, unk_label) for preds in predictions]
+    reference_vectors = [
+        get_encoded_vector(ohe, refs, unk_label) for refs in references_lists
+    ]
+    pred_vectors = [
+        get_encoded_vector(ohe, preds, unk_label) for preds in predictions_lists
+    ]
 
     # For debugging purposes - map the indices in our none hot encoded entries.
     # NOTE: the categories_ attr is a 2D array of features, and we only care about [0]
     # since the uniquely extracted labels are only single dim features when fitting
     # the transform itself.
-    label_map = {
-        idx: label for idx, label in enumerate(ohe.categories_[0])
-    }
+    label_map = dict(enumerate(ohe.categories_[0]))
     return pred_vectors, reference_vectors, label_map
+
 
 def get_encoded_vector(ohe, texts, unk_label) -> int:
     # Since our encoded vector is built on collapsing one hot encoded vectors,
@@ -177,7 +212,9 @@ def get_encoded_vector(ohe, texts, unk_label) -> int:
     # Clean the generated text list; anything that is in the list that is not known to the
     # one hot encoder gets replaced by the unk_label. It is okay if we have multiple unk_labels
     # in the vector, since all of these just map to one positive entry in the encoded vector.
-    cleaned_texts = list(set([text if text in ohe.categories_[0] else unk_label for text in texts]))
+    cleaned_texts = list(
+        {text if text in ohe.categories_[0] else unk_label for text in texts}
+    )
     # Encode the cleaned text as a 2D feature array of one hot encoded vectors
     vec_stack = ohe.transform([[text] for text in cleaned_texts]).toarray()
 
@@ -185,21 +222,24 @@ def get_encoded_vector(ohe, texts, unk_label) -> int:
     # get the encoded binary vector for the multilabel / multiclass prediction.
     return vec_stack.sum(axis=0)
 
-def extract_unique_labels(predictions, references, unk_label):
+
+def extract_unique_labels(preds, refs, unk_label):
     """Grab all of the unique labels and return them as a list of single feature lists."""
     unique_ref_labels = set()
-    for ref in references:
+    for ref in refs:
         for sub_label in ref:
             # This is pretty unlikely to happen (class named "<UNKNOWN>"), but for now, raise
             # if we see it happen, since that will currently mess up the results a little bit.
             if sub_label == unk_label:
-                raise ValueError(f"Unk label {unk_label} is being used as a ground truth label!")                
+                raise ValueError(
+                    f"Unk label {unk_label} is being used as a ground truth label!"
+                )
             unique_ref_labels.add(sub_label)
 
     ref_label_list = [[label] for label in unique_ref_labels]
     # HACK - traverse the predictions and see if any unk predictions were made; if so, make a
     # garbage <UNKNOWN> class, which we will mark as false positives here.
-    for pred in predictions:
+    for pred in preds:
         for sub_pred in pred:
             # One of our delimited predictions is unknown!
             if sub_pred not in unique_ref_labels:
@@ -208,6 +248,7 @@ def extract_unique_labels(predictions, references, unk_label):
                 ref_label_list.append([unk_label])
                 return ref_label_list
     return ref_label_list
+
 
 def compute_metrics_dict_multi(enc_preds, enc_refs):
     micro_f1 = f1_score(enc_refs, enc_preds, average="micro")
@@ -221,47 +262,77 @@ def compute_metrics_dict_multi(enc_preds, enc_refs):
             "micro": micro_f1,
             "macro": macro_f1,
         },
-        "accuracy": accuracy
+        "accuracy": accuracy,
     }
 
-def export_experiment_info(metrics_dict: dict, label_map: dict, model_pred_file_info: dict, experiment_metadata: dict, output_dir: str):
+
+def export_experiment_info(
+    metrics: dict,
+    label_map: dict,
+    model_pred_info: dict,
+    metadata: dict,
+    output_dir: str,
+):
     """Creates an exports all experiments info / metadata.
 
     Args:
-        metrics_dict: dict
+        metrics: dict
             Dictionary containing metrics of interest (i.e., F1 / accuracy).
         label_map: dict
             Mapping of class integers / labels.
-        model_pred_file_info: dict
+        model_pred_info: dict
             List of dicts containing formatted data to be processed.
-        experiment_metadata: dict
+        metadata: dict
             Other experiment metadata of interest, e.g., model name, max new tokens, etc.
         output_dir: str
             Directory name to be created to hold the experiment files.
     """
     os.mkdir(output_dir)
-    with open(os.path.join(output_dir, "eval_metrics.json"), "w") as metrics_fp:
-        json.dump(metrics_dict, metrics_fp, indent=4, sort_keys=True)
+    with open(
+        os.path.join(output_dir, "eval_metrics.json"), "w", encoding="utf-8"
+    ) as metrics_fp:
+        json.dump(metrics, metrics_fp, indent=4, sort_keys=True)
     # Dump the label map to a file for debugging purposes
-    with open(os.path.join(output_dir, "label_map.json"), "w") as map_fp:
+    with open(
+        os.path.join(output_dir, "label_map.json"), "w", encoding="utf-8"
+    ) as map_fp:
         json.dump(label_map, map_fp, indent=4, sort_keys=True)
     # Also, dump the predictions / references info to a file for debugging purposes
-    with open(os.path.join(output_dir, "preds_and_references.json"), "w") as preds_fp:
-        json.dump(model_pred_file_info, preds_fp, indent=4, sort_keys=True)
-    with open(os.path.join(output_dir, "experiment_metadata.json"), "w") as exp_md_fp:
-        json.dump(experiment_metadata, exp_md_fp, indent=4, sort_keys=True)
+    with open(
+        os.path.join(output_dir, "preds_and_references.json"), "w", encoding="utf-8"
+    ) as preds_fp:
+        json.dump(model_pred_info, preds_fp, indent=4, sort_keys=True)
+    with open(
+        os.path.join(output_dir, "experiment_metadata.json"), "w", encoding="utf-8"
+    ) as exp_md_fp:
+        json.dump(metadata, exp_md_fp, indent=4, sort_keys=True)
 
 
 if __name__ == "__main__":
     args = parse_and_validate_args()
-    model = TunedCausalLM.load(args.model)
-    data = datasets.load_dataset("json", data_files=args.data_path, split=args.split)
-    predictions, references, model_pred_file_info = get_prediction_results(model, data, args.max_new_tokens, args.delimiter)
-    int_preds, int_references, label_map = map_predictions_and_references_to_encoded_vectors(predictions, references)
-    metrics_dict = compute_metrics_dict_multi(int_preds, int_references)
+    tuned_model = TunedCausalLM.load(args.model)
+    eval_data = datasets.load_dataset(
+        "json", data_files=args.data_path, split=args.split
+    )
+    predictions, references, model_pred_file_info = get_prediction_results(
+        tuned_model, eval_data, args.max_new_tokens, args.delimiter
+    )
+
+    (
+        pred_vecs,
+        ref_vecs,
+        eval_label_map,
+    ) = map_predictions_and_references_to_encoded_vectors(predictions, references)
+    metrics_dict = compute_metrics_dict_multi(pred_vecs, ref_vecs)
     experiment_metadata = {
         "model": args.model,
         "max_new_tokens": args.max_new_tokens,
         "data_path": args.data_path,
     }
-    export_experiment_info(metrics_dict, label_map, model_pred_file_info, experiment_metadata, args.output_dir)
+    export_experiment_info(
+        metrics_dict,
+        eval_label_map,
+        model_pred_file_info,
+        experiment_metadata,
+        args.output_dir,
+    )

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -1,0 +1,279 @@
+"""Runs evaluation on Alpaca formatted data.
+
+Metrics used: Accuracy / Micro & Macro F1.
+"""
+import os
+from sklearn import preprocessing
+import argparse
+import json
+from tqdm import tqdm
+import datasets
+import evaluate
+from run_inference import TunedCausalLM
+from shutil import rmtree
+
+def parse_and_validate_args():
+    """Parse the arguments and ensure everything is valid."""
+    parser = argparse.ArgumentParser(
+        description="Runs evaluation on a Alpaca style dataset"
+    )
+    parser.add_argument(
+        "--model", help="Path to tuned model / merged model to be loaded", required=True
+    )
+    parser.add_argument(
+        "--data_path", help="Path to the dataset to be loaded", required=True
+    )
+    parser.add_argument(
+        "--split", help="Split to be used for the data", default="train"
+    )
+    parser.add_argument(
+        "--max_new_tokens", help="Max new tokens to use in generation", type=int,
+    )
+    parser.add_argument(
+        "--output_dir", help="Directory path to export results to", default="eval_results"
+    )
+    parser.add_argument('--purge_results', action=argparse.BooleanOptionalAction)
+
+    parsed_args = parser.parse_args()
+    # If we have a collision on the outdir, only remove the existing file if we explicitly say to
+    if os.path.exists(parsed_args.output_dir):
+        if parsed_args.purge_results:
+            print(f"Existing output file/directory: [{parsed_args.output_dir}] will be deleted...")
+            rmtree(parsed_args.output_dir)
+        else:
+            raise FileExistsError(
+                f"Output dir [{parsed_args.output_dir}] exists; use --purge_results to clobber it"
+            )
+    return parsed_args
+
+
+### Alpaca dataset formatting utilities
+PROMPT_DICT = {
+    "prompt_input": (
+        "Below is an instruction that describes a task, paired with an input that provides further context. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+    ),
+    "prompt_no_input": (
+        "Below is an instruction that describes a task. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n{instruction}\n\n### Response:"
+    ),
+}
+
+def get_formatted_example(example: dict) -> dict:
+    """Given a single example, format it based on whether or not we have an input provided.
+
+    Args:
+        example: dict
+            Dictionary containing the keys for instruction / input / output, i.e., Alpaca formatted
+            data.
+
+    Returns:
+        dict
+            Dictionary containing the following:
+                "input" - the formatted text to run the prediction on.
+                "output" - the target text we aim to generate.
+    """
+    prompt_input, prompt_no_input = PROMPT_DICT["prompt_input"], PROMPT_DICT["prompt_no_input"]
+    formatted_input = prompt_input.format_map(example) if example.get("input", "") != "" else prompt_no_input.format_map(example)
+    return {
+        # Text to run the prediction on
+        "input": formatted_input,
+        # Text to be generated (does not include the input str)
+        "output": example["output"]
+    }
+
+### Model evaluation
+def get_prediction_results(model: TunedCausalLM, data: datasets.arrow_dataset.Dataset, max_new_tokens: int) -> tuple:
+    """Runs the model over the alpaca formatted data to get the predictions / references to be used
+    when computing the metrics of interest.
+
+    Args:
+        model: TunedCausalLM
+            Model to be used for evaliuation.
+        data: datasets.arrow_dataset.Dataset
+            HF dataset to be processed for evaluation.
+        max_new_tokens: int
+            Max number of tokens to be used for generation.
+
+    Returns:
+        tuple
+            Tuple containing:
+                predictions [list of strings]
+                references [list of strings]
+                model_pred_file_info [list of dicts containing formatted data to be dumped later]          
+    """
+    predictions = []
+    references = []
+    model_pred_file_info = []
+    for datum in tqdm(data):
+        # Format the alpaca example
+        formatted_datum = get_formatted_example(datum)
+        # Run the formatted text through the model, and only save the newly generated text strings
+        prediction = model.run(
+            formatted_datum["input"],
+            max_new_tokens=max_new_tokens,
+            ret_gen_text_only=True,
+        )
+        # Save the raw output / predicted texts
+        stripped_pred = prediction.strip()
+        stripped_ref = formatted_datum["output"].strip()
+        predictions.append(stripped_pred)
+        references.append(stripped_ref)
+        model_pred_file_info.append({
+            "formatted input": formatted_datum["input"],
+            "predicted target": stripped_pred,
+            "ref target": stripped_ref,
+        })
+    return predictions, references, model_pred_file_info
+
+### Metric computation/display & utils for mapping labels to numerics for hf evaluate
+def map_predictions_and_references_to_numerics(predictions: list, references: list) -> tuple:
+    """Maps string predictions and references to numerics for use in accuracy and
+    f1 computations. This process is generally ambiguous and can be done a number of
+    ways, but the strategy we use is as follows:
+
+    - Prior to consideration, all predictions and references are stripped of whitespace
+    - Map all unique reference values to integers
+    - Apply mapping of ref -> int to predictions; anything else is mapped to an unknown label val
+      where the unknown label is treated as its own class
+
+    Important caveats:
+    - this strategy is case sensitive
+    - this cannot be used for multioutput classification problems as is, since the entire
+      predicted text is treated as a single label
+    - be careful about the value of the max number of tokens for generation, since this
+      essentially boils down to a string match problem
+
+    Args:
+        predictions: list
+            List of strings to be converted to class indices predicted by model.
+        references[list]
+            List of strings to be converted to class indices for ground truth.
+
+    Returns:
+        tuple
+            Tuple containing:
+                int_predictions [list of ints] class indices for predicted samples
+                ref_predictions [list of ints] class indices for ground truth samples
+                label_map [dict] dict mapping indices to strings
+    """
+    le = preprocessing.LabelEncoder()
+    le.fit(predictions)
+    # Label encoder maps from class indices from [0, n-1], so we use n as our throwaway class
+    unk_label = le.classes_.shape[0]
+    int_predictions = [get_encoded_label(le, pred, unk_label) for pred in predictions]
+    int_references = [get_encoded_label(le, references, unk_label) for pred in predictions]
+    # Generate the class mapping + the unk label
+    label_map = {
+        idx: label for idx, label in enumerate(le.inverse_transform(list(range(unk_label))))
+    }
+    label_map[unk_label] = "<UNKNOWN LABEL>"
+    return int_predictions, int_references, label_map
+
+def get_encoded_label(le: preprocessing.LabelEncoder, gen_text: str, unk_label: int) -> int:
+    """Gets the encoded label of a text string.
+    Args:
+        le: preprocessing.LabelEncode
+            Label Encoder object which maps text strings into class indices.
+        gen_text: str
+            Text that was generated as a label by the model.
+        unk_label: int
+            Label to be used for unknown / garbage generation, i.e., things unknown to the
+            label encoder.
+
+    Returns:
+        int
+            The integer label index corresponding to the generated text.
+    """
+    try:
+        return le.transform(gen_text)[0]
+    except ValueError:
+        # Model generated text that is not a valid label, i.e., is not in the label encoder
+        return unk_label
+
+def compute_metrics_dict(int_preds: list, int_references: list) -> dict:
+    """Calculate the metrics on the (int) lists of preds against ground truth.
+    
+    Args:
+        int_preds: list
+            list of class indices for texts generated by the model.
+        int_references: list
+            list of class indices for ground truth labels.
+
+    Returns:
+        dict
+            Dictionary containing F1 / accuracy metrics.
+    """
+    f1_metric = evaluate.load("f1")
+    accuracy_metric = evaluate.load("accuracy")
+    # Compute the micro & macro f1 scores
+    micro_f1 = f1_metric.compute(predictions=int_preds, references=int_references, average="micro")
+    macro_f1 = f1_metric.compute(predictions=int_preds, references=int_references, average="macro")
+    # Compute the accuracy
+    accuracy = accuracy_metric.compute(predictions=int_preds, references=int_references)
+    return {
+        "f1": {
+            "micro": micro_f1,
+            "macro": macro_f1,
+        },
+        "accuracy": accuracy
+    }
+
+
+def export_experiment_info(metrics_dict: dict, label_map: dict, model_pred_file_info: dict, experiment_metadata: dict, output_dir: str):
+    """Creates an exports all experiments info / metadata.
+
+    Args:
+        metrics_dict: dict
+            Dictionary containing metrics of interest (i.e., F1 / accuracy).
+        label_map: dict
+            Mapping of class integers / labels.
+        model_pred_file_info: dict
+            List of dicts containing formatted data to be processed.
+        experiment_metadata: dict
+            Other experiment metadata of interest, e.g., model name, max new tokens, etc.
+        output_dir: str
+            Directory name to be created to hold the experiment files.
+    """
+    os.mkdir(output_dir)
+    with open(os.path.join(output_dir, "eval_metrics.json"), "w") as metrics_fp:
+        json.dump(metrics_dict, metrics_fp, indent=4, sort_keys=True)
+    # Dump the label map to a file for debugging purposes
+    with open(os.path.join(output_dir, "label_map.json"), "w") as map_fp:
+        json.dump(label_map, map_fp, indent=4, sort_keys=True)
+    # Also, dump the predictions / references info to a file for debugging purposes
+    with open(os.path.join(output_dir, "preds_and_references.json"), "w") as preds_fp:
+        json.dump(model_pred_file_info, preds_fp, indent=4, sort_keys=True)
+    with open(os.path.join(output_dir, "experiment_metadata.json"), "w") as exp_md_fp:
+        json.dump(experiment_metadata, exp_md_fp, indent=4, sort_keys=True)
+
+
+if __name__ == "__main__":
+    args = parse_and_validate_args()
+    model = TunedCausalLM.load(args.model)
+    data = datasets.load_dataset("json", data_files=args.data_path, split=args.split)
+    predictions, references, model_pred_file_info = get_prediction_results(model, data, args.max_new_tokens)
+    int_preds, int_references, label_map = map_predictions_and_references_to_numerics(predictions, references)
+    metrics_dict = compute_metrics_dict(int_preds, int_references)
+    experiment_metadata = {
+        "model": args.model,
+        "max_new_tokens": args.max_new_tokens,
+        "data_path": args.data_path,
+    }
+    export_experiment_info(metrics_dict, label_map, model_pred_file_info, experiment_metadata, args.output_dir)
+
+
+
+"""
+python3 run_evaluation.py --model TinyLlama/TinyLlama-1.1B-step-50K-105b  --data_path stanford_alpaca/alpaca_data.json  --max_new_tokens 10
+
+{
+    'input': '',
+    'instruction': 'Give three tips for staying healthy.',
+    'output': '1.Eat a balanced diet and make sure to include plenty of fruits and vegetables. \n2. Exercise regularly to keep your body active and strong. \n3. Get enough sleep and maintain a consistent sleep schedule.'
+}
+
+note: we need scikit learn and evaluate for this script [since f1 is also written on top of sklearn]
+"""

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -332,8 +332,8 @@ def compute_metrics_dict_multi(
         dict[str, Any]
             Dictionary of metrics.
     """
-    micro_f1 = f1_score(enc_refs, enc_preds, average="micro")
-    macro_f1 = f1_score(enc_refs, enc_preds, average="macro")
+    micro_f1 = f1_score(enc_refs, enc_preds, average="micro", zero_division=np.nan)
+    macro_f1 = f1_score(enc_refs, enc_preds, average="macro", zero_division=np.nan)
     # For recall - the UNK class containing only false positives does NOT affect score.
     micro_recall = recall_score(
         enc_refs, enc_preds, average="micro", zero_division=np.nan

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -187,7 +187,7 @@ class TunedCausalLM:
         model.to(device)
         return cls(model, tokenizer, device)
 
-    def run(self, text: str, *, max_new_tokens: int) -> str:
+    def run(self, text: str, *, max_new_tokens: int, ret_gen_text_only: bool=False) -> str:
         """Runs inference on an instance of this model.
 
         Args:
@@ -195,6 +195,9 @@ class TunedCausalLM:
                 Text on which we want to run inference.
             max_new_tokens: int
                 Max new tokens to use for inference.
+            ret_gen_text_only: bool
+                Indicates whether or not we should return the full text (i.e., input + new tokens)
+                or just the newly generated tokens.
 
         Returns:
             str
@@ -206,8 +209,12 @@ class TunedCausalLM:
         peft_outputs = self.peft_model.generate(
             input_ids=input_ids, max_new_tokens=max_new_tokens
         )
+        if ret_gen_text_only:
+            tok_to_decode = peft_outputs[:, input_ids.shape[1]:]
+        else:
+            tok_to_decode = peft_outputs
         decoded_result = self.tokenizer.batch_decode(
-            peft_outputs, skip_special_tokens=False
+            tok_to_decode, skip_special_tokens=False
         )[0]
         return decoded_result
 

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -187,7 +187,9 @@ class TunedCausalLM:
         model.to(device)
         return cls(model, tokenizer, device)
 
-    def run(self, text: str, *, max_new_tokens: int, ret_gen_text_only: bool=False) -> str:
+    def run(
+        self, text: str, *, max_new_tokens: int, ret_gen_text_only: bool = False
+    ) -> str:
         """Runs inference on an instance of this model.
 
         Args:
@@ -210,7 +212,7 @@ class TunedCausalLM:
             input_ids=input_ids, max_new_tokens=max_new_tokens
         )
         if ret_gen_text_only:
-            tok_to_decode = peft_outputs[:, input_ids.shape[1]:]
+            tok_to_decode = peft_outputs[:, input_ids.shape[1] :]
         else:
             tok_to_decode = peft_outputs
         decoded_result = self.tokenizer.batch_decode(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

- Adds a script for model evaluation for generation based classification.

Sample usage is as follows (details can be seen with `--help` - this is is just for the sake of example and illustrates how to run something). Note that `train` is the default split for loading a local file, and the usage of `--split` matches that of a normal HF dataset. A `--delimiter` may also be passed for multi output classification.
```
python3 run_evaluation.py --model TinyLlama/TinyLlama-1.1B-step-50K-105b  --data_path stanford_alpaca/alpaca_data.json  --max_new_tokens 10  --purge_results --split train[:50] --delimiter , 
```

Running an evaluation produces a directory containing 4 files, each of which is shown with an example snippet below.

1. `eval_metrics.json` - contains the metrics themselves.
```json
{
    "accuracy": 0.02,
    "f1": {
        "macro": 0.0196078431372549,
        "micro": 0.02
    },
    "precision": {
        "macro": 0.5,
        "micro": 0.02
    },
    "recall": {
        "macro": 0.02,
        "micro": 0.02
    }
}
```

2. `experiment_metadata.json` - contains misc info about the experiment that might be useful later.
```json
{
    "data_path": "stanford_alpaca/alpaca_data.json",
    "max_new_tokens": 10,
    "model": "TinyLlama/TinyLlama-1.1B-step-50K-105b"
}
```

3. `label_map.json` - contains the mapping from integer IDs to `str` classes based on the ground truth target sequences.  This is mostly useful for understanding the metrics if they look incorrect, because it's what is actually being used in the f1/accuracy calculations. If something is generated that is not in the ground truth sequences, it's put into a single `<UNKNOWN LABEL>` garbage class.

Note that the labels of this file do not matter - this is essentially garbage from an untuned model and just for the sake of example.
```json
{
    "0": "",
    "1": "![](https://github.com/",
    "2": "![logo](https://user-images",
    "3": "### Instruction:\nGenerate",
    ...
    "44": "<UNKNOWN LABEL>"
}
```

4. `preds_and_references.json` - contains the formatted inputs provided to the model, the predicted target texts, and the ground truth target texts. This is also primarily for debugging purposes, in case things look a bit strange in the metrics.

```json
[
    {
        "formatted input": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\nGive three tips for staying healthy.\n\n### Response:",
        "predicted target": "### Instruction:\nGive",
        "ref target": "1.Eat a balanced diet and make sure to include plenty of fruits and vegetables. \n2. Exercise regularly to keep your body active and strong. \n3. Get enough sleep and maintain a consistent sleep schedule."
    },
    {
        "formatted input": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\nWhat are the three primary colors?\n\n### Response:",
        "predicted target": "### Instruction:\nWhat is",
        "ref target": "The three primary colors are red, blue, and yellow."
    },
    ...
]
```

Note that currently this adds sklearn as a dependency to the project - we probably don't want to do this since scripts are not distributed, but we should figure out the right way to structure scripts dependencies. Or maybe we should just add it to dev dependencies in `pyproject.toml`?

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR
See script in comments.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass