### PR TITLE
add refactored build utils into docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -111,6 +111,7 @@ COPY LICENSE /licenses/
 
 # Copy scripts and default configs
 COPY build/launch_training.py build/accelerate_launch.py fixtures/accelerate_fsdp_defaults.yaml /app/
+COPY build/utils.py /app/build/
 RUN chmod +x /app/launch_training.py /app/accelerate_launch.py
 
 ENV FSDP_DEFAULTS_FILE_PATH="/app/accelerate_fsdp_defaults.yaml"


### PR DESCRIPTION
Need to be able to import utils from `build.utils` from the launch_training script. Hit error
```
Traceback (most recent call last):
  File "/app/launch_training.py", line 35, in <module>
    from build.utils import process_launch_training_args
ModuleNotFoundError: No module named 'build'
Traceback (most recent call last):
  File "/app/launch_training.py", line 35, in <module>
    from build.utils import process_launch_training_args
ModuleNotFoundError: No module named 'build'
```

Tested this in a new image and it imports successfully.