### PR TITLE
feat: combine train and eval loss into one file

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -293,14 +293,17 @@ def test_run_causallm_ft_and_inference():
 
 def _validate_training(tempdir, check_eval=False):
     assert any(x.startswith("checkpoint-") for x in os.listdir(tempdir))
-    train_loss_file_path = "{}/train_loss.jsonl".format(tempdir)
-    assert os.path.exists(train_loss_file_path) == True
-    assert os.path.getsize(train_loss_file_path) > 0
+    train_logs_file_path = "{}/training_logs.jsonl".format(tempdir)
+    train_log_contents = ""
+    with open(train_logs_file_path) as f:
+        train_log_contents = f.read()
+
+    assert os.path.exists(train_logs_file_path) == True
+    assert os.path.getsize(train_logs_file_path) > 0
+    assert "training_loss" in train_log_contents
 
     if check_eval:
-        eval_loss_file_path = os.path.join(tempdir, "eval_loss.jsonl")
-        assert os.path.exists(eval_loss_file_path)
-        assert os.path.getsize(eval_loss_file_path) > 0
+        assert "validation_loss" in train_log_contents
 
 
 def _get_checkpoint_path(dir_path):

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -63,13 +63,11 @@ class FileLoggingCallback(TrainerCallback):
         if not state.is_world_process_zero:
             return
 
-        # separate evaluation loss with train loss
-        log_file_path = os.path.join(args.output_dir, "train_loss.jsonl")
-        eval_log_file_path = os.path.join(args.output_dir, "eval_loss.jsonl")
+        log_file_path = os.path.join(args.output_dir, "training_logs.jsonl")
         if logs is not None and "loss" in logs and "epoch" in logs:
-            self._track_loss("loss", log_file_path, logs, state)
+            self._track_loss("train_loss", log_file_path, logs, state)
         elif logs is not None and "eval_loss" in logs and "epoch" in logs:
-            self._track_loss("eval_loss", eval_log_file_path, logs, state)
+            self._track_loss("eval_loss", log_file_path, logs, state)
 
     def _track_loss(self, loss_key, log_file, logs, state):
         try:

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -56,7 +56,7 @@ class FileLoggingCallback(TrainerCallback):
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         """Checks if this log contains keys of interest, e.g., loss, and if so, creates
-        train_loss.jsonl in the model output dir (if it doesn't already exist),
+        training_logs.jsonl in the model output dir (if it doesn't already exist),
         appends the subdict of the log & dumps the file.
         """
         # All processes get the logs from this node; only update from process 0.
@@ -65,16 +65,16 @@ class FileLoggingCallback(TrainerCallback):
 
         log_file_path = os.path.join(args.output_dir, "training_logs.jsonl")
         if logs is not None and "loss" in logs and "epoch" in logs:
-            self._track_loss("train_loss", log_file_path, logs, state)
+            self._track_loss("loss", "training_loss", log_file_path, logs, state)
         elif logs is not None and "eval_loss" in logs and "epoch" in logs:
-            self._track_loss("eval_loss", log_file_path, logs, state)
+            self._track_loss("eval_loss", "validation_loss", log_file_path, logs, state)
 
-    def _track_loss(self, loss_key, log_file, logs, state):
+    def _track_loss(self, loss_key, log_name, log_file, logs, state):
         try:
             # Take the subdict of the last log line; if any log_keys aren't part of this log
             # object, assume this line is something else, e.g., train completion, and skip.
             log_obj = {
-                "name": loss_key,
+                "name": log_name,
                 "data": {
                     "epoch": round(logs["epoch"], 2),
                     "step": state.global_step,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Combine train and eval logs into single training logs file.

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

From unit tests, output file looks like:
`training_logs.jsonl`
```json
{"data": {"epoch": 1.0, "step": 1, "timestamp": "2024-04-04T23:22:00.986341", "value": 8.0445}, "name": "training_loss"}
{"data": {"epoch": 1.0, "step": 1, "timestamp": "2024-04-04T23:22:01.377816", "value": 10.59613037109375}, "name": "validation_loss"}
{"data": {"epoch": 2.0, "step": 3, "timestamp": "2024-04-04T23:22:01.985366", "value": 4.015}, "name": "training_loss"}
{"data": {"epoch": 2.0, "step": 3, "timestamp": "2024-04-04T23:22:02.157271", "value": 10.596086502075195}, "name": "validation_loss"}
{"data": {"epoch": 3.0, "step": 5, "timestamp": "2024-04-04T23:22:02.798441", "value": 3.9365}, "name": "training_loss"}
{"data": {"epoch": 3.0, "step": 5, "timestamp": "2024-04-04T23:22:02.986173", "value": 10.596071243286133}, "name": "validation_loss"}
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass