### PR TITLE
Fix copying over logs

### DIFF
--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -106,11 +106,12 @@ def main():
                 dirs_exist_ok=True,
             )
 
-        # copy over logs
-        shutil.copy(
-            os.path.join(training_args.output_dir, sft_trainer.TRAINING_LOGS_FILENAME),
-            original_output_dir,
+        # copy over any loss logs
+        train_logs_filepath = os.path.join(
+            training_args.output_dir, sft_trainer.TRAINING_LOGS_FILENAME
         )
+        if os.path.exists(train_logs_filepath):
+            shutil.copy(train_logs_filepath, original_output_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Fix copying over logs when `num_processes>1`

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Built new image, ran a sample job on test cluster and checked `training_logs.jsonl` was copied over

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass