### PR TITLE
Move sklearn to optional, install optionals for linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 dynamic = ["dependencies"]
 
 [project.optional-dependencies]
-dev = ["wheel", "packaging", "ninja"]
+dev = ["wheel", "packaging", "ninja", "scikit-learn>=1.0, <2.0"]
 flash-attn = ["flash-attn"]
 aim = ["aim==3.18.1"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,3 @@ trl
 peft>=0.8.0
 datasets>=2.15.0
 fire
-
-# Dependencies needed only to run scripts.
-# TODO: Figure out a better place to put these.
-scikit-learn>=1.0, <2.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ allowlist_externals = ./scripts/fmt.sh
 description = lint with pylint
 deps = pylint>=2.16.2,<=3.1.0
         pytest
+        .[dev]
         -r requirements.txt
 commands = pylint tuning scripts/*.py build/*.py tests
 allowlist_externals = pylint


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

- Moves sklearn to optional dev dependencies
- Include optional dev dependencies when linting to avoid pylint import errors on optional dependencies

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

Run linting and see that the sklearn import does not result in a linting failure.

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass