### PR TITLE
Fix eos token suffix removal

### DIFF
--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -49,7 +49,7 @@ def parse_and_validate_args():
     )
     parser.add_argument(
         "--eos_token",
-        help="EOS token emitted by the model; passing will rstrip() the token if present",
+        help="EOS token emitted by the model; will recursively remove the token if present",
     )
     parser.add_argument("--purge_results", action=argparse.BooleanOptionalAction)
 
@@ -138,7 +138,7 @@ def get_prediction_results(
         delimiter: Optional[str]
             Delimiter to be used for splitting apart multioutput instances.
         eos_token: Optional[str]
-            EOS token emitted by the model, which will be rstripped from predictions.
+            EOS token emitted by the model, which will be recursively removed from predictions.
     Returns:
         tuple[list]
             Tuple containing:
@@ -191,7 +191,8 @@ def postprocess_output(
             List of one or more labels.
     """
     if eos_token is not None:
-        output_text = output_text.rstrip(eos_token)
+        while output_text.removesuffix(eos_token) != output_text:
+            output_text = output_text.removesuffix(eos_token)
     if delimiter is not None:
         return [text_substr.strip() for text_substr in output_text.split(delimiter)]
     return [output_text.strip()]


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Fixes a bug introduced by https://github.com/foundation-model-stack/fms-hf-tuning/pull/121 - this should be repeatedly removing the suffix and not (character level) rstripping, nice catch @anhuong 

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass