### PR TITLE
OS update in dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -39,7 +39,8 @@ ARG SET_NUM_PROCESSES_TO_NUM_GPUS=True
 
 USER root
 
-RUN dnf remove -y --disableplugin=subscription-manager \
+RUN dnf update -y \
+    && dnf remove -y --disableplugin=subscription-manager \
         subscription-manager \
         # we install newer version of requests via pip
         python3.11-requests \
@@ -108,10 +109,13 @@ RUN dnf config-manager \
 
 ENV LIBRARY_PATH="$CUDA_HOME/lib64/stubs"
 
-RUN dnf install -y python3.11 git && \
-    ln -s /usr/bin/python3.11 /bin/python && \
-    python -m ensurepip --upgrade && \
-    dnf clean all
+RUN dnf install -y python3.11 git \
+    && ln -s /usr/bin/python3.11 /bin/python \
+    && python -m ensurepip --upgrade \
+    && dnf clean all
+
+# Removes the example private key to avoid high severity vulnerability warning
+RUN rm -f /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem
 
 WORKDIR /tmp
 COPY --from=wheel /tmp/*.whl /tmp/bdist_name /tmp/


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This Dockerfile change does two things:
1.  It does a `dnf update -y` so that we catch the latest fixes that might not yet be in the latest ubi build. For example in this case there are 2 known `libexpat` medium vulnerabilities that this update method closes in our image.
2. This removes a high `Private keys stored in image` issue with `Found: /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem`
### Related issue number

<!-- For example: "Closes #1234" -->
Closes issue https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/758
### How to verify the PR
(Note, you need an environment running with Kueue and KFTO)  Otherwise, it might be possible with Kind.

1. Clone the branch to your podman environment
```
git clone https://github.com/jbusche/fms-hf-tuning.git -b jb-issue-758
cd fms-hf-tunin
```
2.  Build the image:
```
docker build -t fms-hf-tuning:issue758-1 . -f build/Dockerfile
```
3.  Push it to quay.io for testing:
```
podman tag localhost/fms-hf-tuning:issue758-1 quay.io/jbusche/fms-hf-tuning:issue758-1
podman push quay.io/jbusche/fms-hf-tuning:issue758-1
```
4.  Try Ted's testing method:
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-config
data:
  config.json: |
    {
      "accelerate_launch_args": {
        "num_machines": 1,
        "num_processes": 2
      },
      "model_name_or_path": "bigscience/bloom-560m",
      "training_data_path": "/etc/config/twitter_complaints_small.json",
      "output_dir": "/tmp/out",
      "num_train_epochs": 1.0,
      "per_device_train_batch_size": 4,
      "per_device_eval_batch_size": 4,
      "gradient_accumulation_steps": 4,
      "evaluation_strategy": "no",
      "save_strategy": "epoch",
      "learning_rate": 1e-5,
      "weight_decay": 0.0,
      "lr_scheduler_type": "cosine",
      "logging_steps": 1.0,
      "packing": false,
      "include_tokens_per_second": true,
      "response_template": "\n### Label:",
      "dataset_text_field": "output",
      "use_flash_attn": false,
      "torch_dtype": "float32",
      "peft_method": "pt",
      "tokenizer_name_or_path": "bigscience/bloom"
    }
  twitter_complaints_small.json: |
    {"Tweet text":"@HMRCcustomers No this is my first job","ID":0,"Label":2,"text_label":"no complaint","output":"### Text: @HMRCcustomers No this is my first job\n\n### Label: no complaint"}
    {"Tweet text":"@KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.","ID":1,"Label":2,"text_label":"no complaint","output":"### Text: @KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.\n\n### Label: no complaint"}
    {"Tweet text":"If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService","ID":2,"Label":1,"text_label":"complaint","output":"### Text: If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService\n\n### Label: complaint"}
    {"Tweet text":"@EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.","ID":3,"Label":1,"text_label":"complaint","output":"### Text: @EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.\n\n### Label: complaint"}
    {"Tweet text":"Couples wallpaper, so cute. :) #BrothersAtHome","ID":4,"Label":2,"text_label":"no complaint","output":"### Text: Couples wallpaper, so cute. :) #BrothersAtHome\n\n### Label: no complaint"}
    {"Tweet text":"@mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG","ID":5,"Label":2,"text_label":"no complaint","output":"### Text: @mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG\n\n### Label: no complaint"}
    {"Tweet text":"@Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?","ID":6,"Label":2,"text_label":"no complaint","output":"### Text: @Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?\n\n### Label: no complaint"}
    {"Tweet text":"@nationalgridus I have no water and the bill is current and paid. Can you do something about this?","ID":7,"Label":1,"text_label":"complaint","output":"### Text: @nationalgridus I have no water and the bill is current and paid. Can you do something about this?\n\n### Label: complaint"}
    {"Tweet text":"Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora","ID":8,"Label":1,"text_label":"complaint","output":"### Text: Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora\n\n### Label: complaint"}
    {"Tweet text":"@JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd","ID":9,"Label":2,"text_label":"no complaint","output":"### Text: @JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd\n\n### Label: no complaint"}
---
apiVersion: "kubeflow.org/v1"
kind: PyTorchJob
metadata:
  name: ted-kfto-sft
  labels:
    kueue.x-k8s.io/queue-name: lq-trainer
spec:
  pytorchReplicaSpecs:
    Master:
      replicas: 1
      restartPolicy: Never # Do not restart the pod on failure. If you do set it to OnFailure, be sure to also set backoffLimit
      template:
        spec:
          containers:
            - name: pytorch
              # This is the temp location util image is officially released
              image: quay.io/jbusche/fms-hf-tuning:issue758-1
              imagePullPolicy: IfNotPresent
              command:
                - "python"
                - "/app/accelerate_launch.py"
              env:
                - name: SFT_TRAINER_CONFIG_JSON_PATH
                  value: /etc/config/config.json
              volumeMounts:
              - name: config-volume
                mountPath: /etc/config
          volumes:
          - name: config-volume
            configMap:
              name: my-config
              items:
              - key: config.json
                path: config.json
              - key: twitter_complaints_small.json
                path: twitter_complaints_small.json
EOF
```
5. Watch that it's running:
```
watch oc get pods,pytorchjobs
```
Results in:
```
Every 2.0s: oc get pods,pytorchjobs                                                                                                                  api.ted414.cp.fyre.ibm.com: Wed Apr 17 13:36:46 2024

NAME                        READY   STATUS    RESTARTS   AGE
pod/ted-kfto-sft-master-0   1/1     Running   0          5m42s

NAME                                   STATE     AGE
pytorchjob.kubeflow.org/ted-kfto-sft   Running   5m42s
```
6. And when complete it should look like this:
```
Every 2.0s: oc get pods,pytorchjobs                                                                                                                  api.ted414.cp.fyre.ibm.com: Wed Apr 17 13:37:14 2024

NAME                        READY   STATUS      RESTARTS   AGE
pod/ted-kfto-sft-master-0   0/1     Completed   0          6m10s

NAME                                   STATE       AGE
pytorchjob.kubeflow.org/ted-kfto-sft   Succeeded   6m1
```

Another way to test is to run the twistlock Jenkins job to verify that the vulnerabilities are fixed.  Here are the before and after runs:
Before:
https://wcp-ai-foundation-team-jenkins.swg-devops.com/job/security/job/twistlock-container-scan/456/
After:
https://wcp-ai-foundation-team-jenkins.swg-devops.com/job/security/job/twistlock-container-scan/455/



### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass