### PR TITLE
feat: add flash attn to inference and eval scripts

### DIFF
--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -57,6 +57,11 @@ def parse_and_validate_args():
         action="store_true",
     )
     parser.add_argument("--purge_results", action=argparse.BooleanOptionalAction)
+    parser.add_argument(
+        "--use_flash_attn",
+        help="Whether to load the model using Flash Attention 2",
+        action="store_true",
+    )
     parsed_args = parser.parse_args()
 
     print(f"Multiclass / multioutput delimiter: {parsed_args.delimiter}")
@@ -441,7 +446,7 @@ def export_experiment_info(
 
 if __name__ == "__main__":
     args = parse_and_validate_args()
-    tuned_model = TunedCausalLM.load(args.model)
+    tuned_model = TunedCausalLM.load(args.model, use_flash_attn=args.use_flash_attn)
     eval_data = datasets.load_dataset(
         "json", data_files=args.data_path, split=args.split
     )

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -183,7 +183,7 @@ class TunedCausalLM:
                         attn_implementation="flash_attention_2"
                         if use_flash_attn
                         else None,
-                        torch_dtype=torch.float16 if use_flash_attn else None,
+                        torch_dtype=torch.bfloat16 if use_flash_attn else None,
                     )
                 except OSError as e:
                     print("Failed to initialize checkpoint model!")
@@ -194,7 +194,7 @@ class TunedCausalLM:
             model = AutoModelForCausalLM.from_pretrained(
                 checkpoint_path,
                 attn_implementation="flash_attention_2" if use_flash_attn else None,
-                torch_dtype=torch.float16 if use_flash_attn else None,
+                torch_dtype=torch.bfloat16 if use_flash_attn else None,
             )
 
         device = "cuda" if torch.cuda.is_available() else None

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -142,7 +142,10 @@ class TunedCausalLM:
 
     @classmethod
     def load(
-        cls, checkpoint_path: str, base_model_name_or_path: str = None
+        cls,
+        checkpoint_path: str,
+        base_model_name_or_path: str = None,
+        use_flash_attn: bool = False,
     ) -> "TunedCausalLM":
         """Loads an instance of this model.
 
@@ -152,6 +155,8 @@ class TunedCausalLM:
                 adapter_config.json.
             base_model_name_or_path: str [Default: None]
                 Override for the base model to be used.
+            use_flash_attn: bool [Default: False]
+                Whether to load the model using flash attention.
 
         By default, the paths for the base model and tokenizer are contained within the adapter
         config of the tuned model. Note that in this context, a path may refer to a model to be
@@ -173,14 +178,24 @@ class TunedCausalLM:
         try:
             with AdapterConfigPatcher(checkpoint_path, overrides):
                 try:
-                    model = AutoPeftModelForCausalLM.from_pretrained(checkpoint_path)
+                    model = AutoPeftModelForCausalLM.from_pretrained(
+                        checkpoint_path,
+                        attn_implementation="flash_attention_2"
+                        if use_flash_attn
+                        else None,
+                        torch_dtype=torch.float16 if use_flash_attn else None,
+                    )
                 except OSError as e:
                     print("Failed to initialize checkpoint model!")
                     raise e
         except FileNotFoundError:
             print("No adapter config found! Loading as a merged model...")
             # Unable to find the adapter config; fall back to loading as a merged model
-            model = AutoModelForCausalLM.from_pretrained(checkpoint_path)
+            model = AutoModelForCausalLM.from_pretrained(
+                checkpoint_path,
+                attn_implementation="flash_attention_2" if use_flash_attn else None,
+                torch_dtype=torch.float16 if use_flash_attn else None,
+            )
 
         device = "cuda" if torch.cuda.is_available() else None
         print(f"Inferred device: {device}")
@@ -246,6 +261,11 @@ def main():
         type=int,
         default=20,
     )
+    parser.add_argument(
+        "--use_flash_attn",
+        help="Whether to load the model using Flash Attention 2",
+        action="store_true",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--text", help="Text to run inference on")
     group.add_argument(
@@ -261,6 +281,7 @@ def main():
     loaded_model = TunedCausalLM.load(
         checkpoint_path=args.model,
         base_model_name_or_path=args.base_model_name_or_path,
+        use_flash_attn=args.use_flash_attn,
     )
 
     # Run inference on the text; if multiple were provided, process them all


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Add `use_flash_attn` flag for the inference and evaluation scripts. When used, this will load the model using flash attention which can affect the inference results.

### Related issue number

related to: #103 

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Ran the scripts loading llama-7b model and a Lora tuned llama-7b model that requires merging. Saw that when using flag, the model is loaded with flash attention as noted by the log output.

inference:
```sh
# without
$ python scripts/run_inference.py --model /llama-eval-pvc/LLaMa/models/hf/7B --out_file llama_7b --max_new_tokens 50 --text "Today is a good day. What do you want to do today?" 
No adapter config found! Loading as a merged model...
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████| 2/2 [00:25<00:00, 12.86s/it]
Inferred device: cuda
100%|█████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.29s/it]
Exported results to: llama_7b

# with flash attn
$ python scripts/run_inference.py --model /llama-eval-pvc/LLaMa/models/hf/7B --out_file llama_7b_flash --max_new_tokens 50 --text "Today is a good day. What do you want to do today?" --use_flash_attn
No adapter config found! Loading as a merged model...
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with model.to('cuda').
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.35s/it]
Inferred device: cuda
100%|█████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.80s/it]
Exported results to: llama_7b_flash

# lora tuned model with flash attn
$ python scripts/run_inference.py --model /nfs-storage-pvc/llama2-7b-twitter-lora-default-checkpoint-15/ --base_model_name_or_path /llama-eval-pvc/LLaMa/models/hf/7B --out_file llama_7b_lora --max_new_tokens 50 --text "Today is a good day. What do you want to do today?" --use_flash_attn
You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.03s/it]
Inferred device: cuda
100%|█████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.02s/it]
Exported results to: llama_7b_lora
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass