### PR TITLE
feat: Trainer state as a metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ venv/
 *.bkp
 *.bkp.*
 *bkp*
+
+# Auto generated file
+tuning/_version.py

--- a/examples/trainercontroller_configs/loss.yaml
+++ b/examples/trainercontroller_configs/loss.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller
     triggers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 "trl",
 "peft>=0.8.0",
 "datasets>=2.15.0",
-"fire"
+"fire",
+"jsonschema>=4.21.1"
 ]
 
 [project.optional-dependencies]

--- a/tests/data/trainercontroller/__init__.py
+++ b/tests/data/trainercontroller/__init__.py
@@ -22,6 +22,9 @@ _DATA_DIR = os.path.join(os.path.dirname(__file__))
 TRAINER_CONFIG_TEST_LOSS_ON_THRESHOLD_YAML = os.path.join(
     _DATA_DIR, "loss_on_threshold.yaml"
 )
+TRAINER_CONFIG_TEST_LOSS_ON_THRESHOLD_WITH_TRAINER_STATE_YAML = os.path.join(
+    _DATA_DIR, "loss_on_threshold_with_trainer_state.yaml"
+)
 TRAINER_CONFIG_TEST_MALICIOUS_OS_RULE_YAML = os.path.join(
     _DATA_DIR, "loss_with_malicious_os_rule.yaml"
 )

--- a/tests/data/trainercontroller/loss_custom_metric.yaml
+++ b/tests/data/trainercontroller/loss_custom_metric.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  testflag:
-    CustomMetric:
+  - name: testflag
+    class: CustomMetric
 controllers:
   - name: loss-controller-custom-metric
     triggers:

--- a/tests/data/trainercontroller/loss_custom_operation.yaml
+++ b/tests/data/trainercontroller/loss_custom_operation.yaml
@@ -1,9 +1,9 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 operations:
-  customoperation:
-    CustomOperation:
+  - name: customoperation
+    class: CustomOperation
 controllers:
   - name: loss-controller-custom-operation
     triggers:

--- a/tests/data/trainercontroller/loss_custom_operation_invalid_action.yaml
+++ b/tests/data/trainercontroller/loss_custom_operation_invalid_action.yaml
@@ -1,9 +1,9 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 operations:
-  customoperation:
-    CustomOperationInvalidAction:
+  - name: customoperation
+    class: CustomOperationInvalidAction
 controllers:
   - name: loss-controller-custom-operation-invalid-action
     triggers:

--- a/tests/data/trainercontroller/loss_invalid_metric.yaml
+++ b/tests/data/trainercontroller/loss_invalid_metric.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    MissingMetricClass:
+  - name: loss
+    class: MissingMetricClass
 controllers:
   - name: loss-controller-invalid-metric
     triggers:

--- a/tests/data/trainercontroller/loss_invalid_operation.yaml
+++ b/tests/data/trainercontroller/loss_invalid_operation.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller-invalid-operation
     triggers:

--- a/tests/data/trainercontroller/loss_invalid_operation_action.yaml
+++ b/tests/data/trainercontroller/loss_invalid_operation_action.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller-invalid-operation-action
     triggers:

--- a/tests/data/trainercontroller/loss_invalid_trigger.yaml
+++ b/tests/data/trainercontroller/loss_invalid_trigger.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller-invalid-trigger
     triggers:

--- a/tests/data/trainercontroller/loss_on_threshold.yaml
+++ b/tests/data/trainercontroller/loss_on_threshold.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller
     triggers:

--- a/tests/data/trainercontroller/loss_on_threshold_with_trainer_state.yaml
+++ b/tests/data/trainercontroller/loss_on_threshold_with_trainer_state.yaml
@@ -7,6 +7,6 @@ controllers:
   - name: loss-controller
     triggers:
       - on_log
-    rule: loss < 2.2 and state['epoch'] > 5
+    rule: loss < 2 and state["epoch"] >= 0.5
     operations:
       - hfcontrols.should_training_stop

--- a/tests/data/trainercontroller/loss_with_malicious_input_rule.yaml
+++ b/tests/data/trainercontroller/loss_with_malicious_input_rule.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller-wrong-input-rule
     triggers:

--- a/tests/data/trainercontroller/loss_with_malicious_os_rule.yaml
+++ b/tests/data/trainercontroller/loss_with_malicious_os_rule.yaml
@@ -1,6 +1,6 @@
 controller-metrics:
-  loss:
-    Loss:
+  - name: loss
+    class: Loss
 controllers:
   - name: loss-controller-wrong-os-rule
     triggers:

--- a/tests/trainercontroller/test_tuning_trainercontroller.py
+++ b/tests/trainercontroller/test_tuning_trainercontroller.py
@@ -67,7 +67,8 @@ def _setup_data() -> InputData:
                 {"loss": 2.1, "epoch": 0.25},
                 {"loss": 1.3, "epoch": 0.5},
                 {"loss": 0.9, "epoch": 0.6},
-            ]
+            ],
+            epoch=0.6,
         ),
     )
 
@@ -79,6 +80,22 @@ def test_loss_on_threshold():
     test_data = _setup_data()
     tc_callback = tc.TrainerControllerCallback(
         td.TRAINER_CONFIG_TEST_LOSS_ON_THRESHOLD_YAML
+    )
+    control = TrainerControl(should_training_stop=False)
+    # Trigger on_init_end to perform registration of handlers to events
+    tc_callback.on_init_end(args=test_data.args, state=test_data.state, control=control)
+    # Trigger rule and test the condition
+    tc_callback.on_log(args=test_data.args, state=test_data.state, control=control)
+    assert control.should_training_stop == True
+
+
+def test_loss_on_threshold_with_trainer_state():
+    """Tests the loss threshold with trainer state example in
+    `examples/trainer-controller-configs/loss_on_threshold_with_trainer_state.yaml`
+    """
+    test_data = _setup_data()
+    tc_callback = tc.TrainerControllerCallback(
+        td.TRAINER_CONFIG_TEST_LOSS_ON_THRESHOLD_WITH_TRAINER_STATE_YAML
     )
     control = TrainerControl(should_training_stop=False)
     # Trigger on_init_end to perform registration of handlers to events

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -54,6 +54,7 @@ CONTROLLERS_KEY = "controllers"
 ARGS_KEY = "arguments"
 
 CONTROLLER_NAME_KEY = "name"
+CONTROLLER_CLASS_KEY = "class"
 CONTROLLER_RULE_KEY = "rule"
 CONTROLLER_TRIGGERS_KEY = "triggers"
 CONTROLLER_OPERATIONS_KEY = OPERATIONS_KEY
@@ -70,12 +71,12 @@ properties:
         type: array
         items:
             type: object
-            required: ["name", "class"]
+            required: ["{CONTROLLER_NAME_KEY}", "{CONTROLLER_CLASS_KEY}"]
             additionalProperties: false
             properties:
-                name:
+                "{CONTROLLER_NAME_KEY}":
                     type: string
-                class:
+                "{CONTROLLER_CLASS_KEY}":
                     type: string
                 "{ARGS_KEY}":
                     type: object
@@ -83,12 +84,12 @@ properties:
         type: array
         items:
             type: object
-            required: ["name", "class"]
+            required: ["{CONTROLLER_NAME_KEY}", "{CONTROLLER_CLASS_KEY}"]
             additionalProperties: false
             properties:
-                name:
+                "{CONTROLLER_NAME_KEY}":
                     type: string
-                class:
+                "{CONTROLLER_CLASS_KEY}":
                     type: string
                 "{ARGS_KEY}":
                     type: object
@@ -96,18 +97,18 @@ properties:
         type: array
         items:
             type: object
-            required: ["name", "rule", "triggers", "operations"]
+            required: ["{CONTROLLER_NAME_KEY}", "{CONTROLLER_RULE_KEY}", "{CONTROLLER_TRIGGERS_KEY}", "{CONTROLLER_OPERATIONS_KEY}"]
             additionalProperties: false
             properties:
-                {CONTROLLER_NAME_KEY}:
+                "{CONTROLLER_NAME_KEY}":
                     type: string
-                {CONTROLLER_RULE_KEY}:
+                "{CONTROLLER_RULE_KEY}":
                     type: string
-                {CONTROLLER_TRIGGERS_KEY}:
+                "{CONTROLLER_TRIGGERS_KEY}":
                     type: array
                     items:
                         type: string
-                {CONTROLLER_OPERATIONS_KEY}:
+                "{CONTROLLER_OPERATIONS_KEY}":
                     type: array
                     items:
                         type: string
@@ -178,10 +179,10 @@ class TrainerControllerCallback(TrainerCallback):
                 CONTROLLER_METRICS_KEY
             ]
             for metric_obj in default_controller_metrics:
-                metric_name: str = metric_obj["name"]
+                metric_name: str = metric_obj[CONTROLLER_NAME_KEY]
                 found = False
                 for self_controller_metric in self_controller_metrics:
-                    if self_controller_metric["name"] == metric_name:
+                    if self_controller_metric[CONTROLLER_NAME_KEY] == metric_name:
                         found = True
                         break
                 if not found:
@@ -205,10 +206,10 @@ class TrainerControllerCallback(TrainerCallback):
                 OPERATIONS_KEY
             ]
             for op_obj in default_controller_operations:
-                op_name: str = op_obj["name"]
+                op_name: str = op_obj[CONTROLLER_NAME_KEY]
                 found = False
                 for self_controller_operation in self_controller_operations:
-                    if self_controller_operation["name"] == op_name:
+                    if self_controller_operation[CONTROLLER_NAME_KEY] == op_name:
                         found = True
                         break
                 if not found:
@@ -359,9 +360,9 @@ class TrainerControllerCallback(TrainerCallback):
 
         # Metric handler validation and registration is performed here.
         for metric_config in self.trainer_controller_config[CONTROLLER_METRICS_KEY]:
-            metric_name = metric_config["name"]
+            metric_name = metric_config[CONTROLLER_NAME_KEY]
             # Get the metric class name from the config section.
-            metric_handler_name = metric_config["class"]
+            metric_handler_name = metric_config[CONTROLLER_CLASS_KEY]
             # Get the handler class using the metric class name.
             if metric_handler_name not in self.metric_handlers:
                 raise KeyError(f"Undefined metric handler {metric_handler_name}")
@@ -391,9 +392,9 @@ class TrainerControllerCallback(TrainerCallback):
         ):
             # Operation handler validation and registration is performed here.
             for operation_config in self.trainer_controller_config[OPERATIONS_KEY]:
-                operation_name = operation_config["name"]
+                operation_name = operation_config[CONTROLLER_NAME_KEY]
                 # Get the operation class name from the config section.
-                operation_handler_name = operation_config["class"]
+                operation_handler_name = operation_config[CONTROLLER_CLASS_KEY]
                 # Get the handler class arguments using the operation class name.
                 operation_args = (
                     operation_config[ARGS_KEY] if ARGS_KEY in operation_config else {}

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -23,6 +23,7 @@ import os
 import re
 
 # Third Party
+from jsonschema import Draft202012Validator, ValidationError
 from transformers import (
     TrainerCallback,
     TrainerControl,
@@ -50,11 +51,73 @@ logger = logging.get_logger(__name__)
 CONTROLLER_METRICS_KEY = "controller-metrics"
 OPERATIONS_KEY = "operations"
 CONTROLLERS_KEY = "controllers"
+ARGS_KEY = "arguments"
 
 CONTROLLER_NAME_KEY = "name"
-CONTROLLER_TRIGGERS_KEY = "triggers"
 CONTROLLER_RULE_KEY = "rule"
-CONTROLLER_OPERATIONS_KEY = "operations"
+CONTROLLER_TRIGGERS_KEY = "triggers"
+CONTROLLER_OPERATIONS_KEY = OPERATIONS_KEY
+
+CONTROLLER_METRICS_SCHEMA_YAML = f"""
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://example.com/product.schema.json"
+title: "Metrics and Operations"
+description: "Controller metrics and operations."
+type: object
+additionalProperties: false
+properties:
+    "{CONTROLLER_METRICS_KEY}":
+        type: array
+        items:
+            type: object
+            required: ["name", "class"]
+            additionalProperties: false
+            properties:
+                name:
+                    type: string
+                class:
+                    type: string
+                "{ARGS_KEY}":
+                    type: object
+    "{OPERATIONS_KEY}":
+        type: array
+        items:
+            type: object
+            required: ["name", "class"]
+            additionalProperties: false
+            properties:
+                name:
+                    type: string
+                class:
+                    type: string
+                "{ARGS_KEY}":
+                    type: object
+    "{CONTROLLERS_KEY}":
+        type: array
+        items:
+            type: object
+            required: ["name", "rule", "triggers", "operations"]
+            additionalProperties: false
+            properties:
+                {CONTROLLER_NAME_KEY}:
+                    type: string
+                {CONTROLLER_RULE_KEY}:
+                    type: string
+                {CONTROLLER_TRIGGERS_KEY}:
+                    type: array
+                    items:
+                        type: string
+                {CONTROLLER_OPERATIONS_KEY}:
+                    type: array
+                    items:
+                        type: string
+"""
+CONTROLLER_METRICS_SCHEMA = yaml.safe_load(CONTROLLER_METRICS_SCHEMA_YAML)
+assert isinstance(CONTROLLER_METRICS_SCHEMA, dict)
+Draft202012Validator.check_schema(schema=CONTROLLER_METRICS_SCHEMA)
+CONTROLLER_METRICS_SCHEMA_VALIDATOR = Draft202012Validator(
+    schema=CONTROLLER_METRICS_SCHEMA
+)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -74,7 +137,8 @@ class TrainerControllerCallback(TrainerCallback):
         if isinstance(trainer_controller_config, str):
             if os.path.exists(trainer_controller_config):
                 with open(trainer_controller_config, "r", encoding="utf-8") as f:
-                    self.trainer_controller_config = yaml.safe_load(f)
+                    self.trainer_controller_config: dict = yaml.safe_load(f)
+                assert isinstance(self.trainer_controller_config, dict)
             else:
                 raise FileNotFoundError(
                     f"Trainer controller configuration \
@@ -82,6 +146,17 @@ class TrainerControllerCallback(TrainerCallback):
                 )
         else:
             self.trainer_controller_config = trainer_controller_config
+
+        if CONTROLLER_METRICS_KEY not in self.trainer_controller_config:
+            self.trainer_controller_config[CONTROLLER_METRICS_KEY] = []
+
+        if OPERATIONS_KEY not in self.trainer_controller_config:
+            self.trainer_controller_config[OPERATIONS_KEY] = []
+
+        try:
+            CONTROLLER_METRICS_SCHEMA_VALIDATOR.validate(self.trainer_controller_config)
+        except ValidationError as e:
+            raise ValueError("Trainer controller configuration is invalid.") from e
 
         # Initialize the list of metrics from default `metrics.yaml` in the \
         # controllermetric package. In addition, any metrics mentioned in \
@@ -96,14 +171,21 @@ class TrainerControllerCallback(TrainerCallback):
             and CONTROLLER_METRICS_KEY in default_metrics_config
             and len(default_metrics_config[CONTROLLER_METRICS_KEY]) > 0
         ):
-            for metric_name in default_metrics_config[CONTROLLER_METRICS_KEY].keys():
-                if (
-                    metric_name
-                    not in self.trainer_controller_config[CONTROLLER_METRICS_KEY]
-                ):
-                    self.trainer_controller_config[CONTROLLER_METRICS_KEY][
-                        metric_name
-                    ] = default_metrics_config[CONTROLLER_METRICS_KEY][metric_name]
+            self_controller_metrics = self.trainer_controller_config[
+                CONTROLLER_METRICS_KEY
+            ]
+            default_controller_metrics: list[dict] = default_metrics_config[
+                CONTROLLER_METRICS_KEY
+            ]
+            for metric_obj in default_controller_metrics:
+                metric_name: str = metric_obj["name"]
+                found = False
+                for self_controller_metric in self_controller_metrics:
+                    if self_controller_metric["name"] == metric_name:
+                        found = True
+                        break
+                if not found:
+                    self_controller_metrics.append(metric_obj)
 
         # Initialize the list of operations from default `operations.yaml` \
         # in the operations package. In addition, any operations mentioned \
@@ -118,13 +200,19 @@ class TrainerControllerCallback(TrainerCallback):
             and OPERATIONS_KEY in default_operations_config
             and len(default_operations_config[OPERATIONS_KEY]) > 0
         ):
-            for operation_name in default_operations_config[OPERATIONS_KEY].keys():
-                if OPERATIONS_KEY not in self.trainer_controller_config:
-                    self.trainer_controller_config[OPERATIONS_KEY] = {}
-                if operation_name not in self.trainer_controller_config[OPERATIONS_KEY]:
-                    self.trainer_controller_config[OPERATIONS_KEY][
-                        operation_name
-                    ] = default_operations_config[OPERATIONS_KEY][operation_name]
+            self_controller_operations = self.trainer_controller_config[OPERATIONS_KEY]
+            default_controller_operations: list[dict] = default_operations_config[
+                OPERATIONS_KEY
+            ]
+            for op_obj in default_controller_operations:
+                op_name: str = op_obj["name"]
+                found = False
+                for self_controller_operation in self_controller_operations:
+                    if self_controller_operation["name"] == op_name:
+                        found = True
+                        break
+                if not found:
+                    self_controller_operations.append(op_obj)
 
         # Load list of valid events for the trainercontroller callback
         # These events are assumed to start with "on_" prefix (on_epoch_end(), on_step_end() etc)
@@ -137,17 +225,17 @@ class TrainerControllerCallback(TrainerCallback):
         logger.debug("List of valid events %s", repr(self.valid_events))
 
         # Handlers to trigger on each metric
-        self.metric_handlers = {}
-        self.metrics_on_event = {}
+        self.metric_handlers: dict[str, type[MetricHandler]] = {}
+        self.metrics_on_event: dict[str, list[MetricHandler]] = {}
         self.register_metric_handlers(default_metric_handlers)
 
         # Supported operations
-        self.operation_handlers = {}
+        self.operation_handlers: dict[str, type[Operation]] = {}
         self.operation_actions = {}
         self.register_operation_handlers(default_operation_handlers)
 
         # controls
-        self.control_actions_on_event = {}
+        self.control_actions_on_event: dict[str, list[Control]] = {}
 
         # List of fields produced by the metrics
         self.metrics = {}
@@ -263,31 +351,33 @@ class TrainerControllerCallback(TrainerCallback):
         kwargs["control"] = control
 
         # Check if there any metrics listed in the configuration
-        if CONTROLLER_METRICS_KEY not in self.trainer_controller_config:
+        if (
+            CONTROLLER_METRICS_KEY not in self.trainer_controller_config
+            or len(self.trainer_controller_config[CONTROLLER_METRICS_KEY]) == 0
+        ):
             logger.warning("Trainer controller config has no metrics.")
 
         # Metric handler validation and registration is performed here.
-        for metric_name, metric_config in self.trainer_controller_config[
-            CONTROLLER_METRICS_KEY
-        ].items():
+        for metric_config in self.trainer_controller_config[CONTROLLER_METRICS_KEY]:
+            metric_name = metric_config["name"]
             # Get the metric class name from the config section.
-            metric_handler_name = next(iter(metric_config.keys()))
+            metric_handler_name = metric_config["class"]
             # Get the handler class using the metric class name.
             if metric_handler_name not in self.metric_handlers:
                 raise KeyError(f"Undefined metric handler {metric_handler_name}")
-            metric_handler = self.metric_handlers[metric_handler_name]
+            metric_handler_class = self.metric_handlers[metric_handler_name]
             # Get the metric handler class arguments specified in the config.
-            metric_args = metric_config[metric_handler_name]
-            if metric_args is None:
-                metric_args = {}
+            metric_args = metric_config[ARGS_KEY] if ARGS_KEY in metric_config else {}
             # Metric handler instance is created here.
-            obj = metric_handler(name=metric_name, **metric_args, **kwargs)
+            metric_handler = metric_handler_class(
+                name=metric_name, **metric_args, **kwargs
+            )
             # Add metric instances to the events.
-            for event_name in obj.get_events():
+            for event_name in metric_handler.get_events():
                 if event_name in self.valid_events:
                     if event_name not in self.metrics_on_event:
                         self.metrics_on_event[event_name] = []
-                    self.metrics_on_event[event_name].append(obj)
+                    self.metrics_on_event[event_name].append(metric_handler)
                 else:
                     raise KeyError(
                         "Event name (%s) is not valid in metric %s"
@@ -295,54 +385,68 @@ class TrainerControllerCallback(TrainerCallback):
                     )
 
         # Check if there any operations listed in the configuration
-        if OPERATIONS_KEY in self.trainer_controller_config:
+        if (
+            OPERATIONS_KEY in self.trainer_controller_config
+            and len(self.trainer_controller_config[OPERATIONS_KEY]) > 0
+        ):
             # Operation handler validation and registration is performed here.
-            for operation_name, operation_config in self.trainer_controller_config[
-                OPERATIONS_KEY
-            ].items():
+            for operation_config in self.trainer_controller_config[OPERATIONS_KEY]:
+                operation_name = operation_config["name"]
                 # Get the operation class name from the config section.
-                operation_handler_name = next(iter(operation_config.keys()))
+                operation_handler_name = operation_config["class"]
                 # Get the handler class arguments using the operation class name.
-                operation_args = operation_config[operation_handler_name]
-                if operation_args is None:
-                    operation_args = {}
+                operation_args = (
+                    operation_config[ARGS_KEY] if ARGS_KEY in operation_config else {}
+                )
                 # Operation handler instance is created here.
-                operation = self.operation_handlers[operation_handler_name](
-                    **operation_args, **kwargs
+                operation_handler_class = self.operation_handlers[
+                    operation_handler_name
+                ]
+                operation_handler = operation_handler_class(
+                    name=operation_name, **operation_args, **kwargs
                 )
                 # Add operation action instances.
-                for action_name in operation.get_actions():
-                    self.operation_actions[
-                        operation_name + "." + action_name
-                    ] = OperationAction(instance=operation, action=action_name)
+                for action_name in operation_handler.get_actions():
+                    op_key = operation_name + "." + action_name
+                    if op_key in self.operation_actions:
+                        logger.warning(
+                            "Trying to add the operation '%s' when it already exists, ignoring...",
+                            op_key,
+                        )
+                        continue
+                    self.operation_actions[op_key] = OperationAction(
+                        instance=operation_handler, action=action_name
+                    )
 
         # Initialize controllers with respect to events.
         if CONTROLLERS_KEY in self.trainer_controller_config:
             for controller in self.trainer_controller_config[CONTROLLERS_KEY]:
+                controller_name: str = controller[CONTROLLER_NAME_KEY]
+                controller_ops: list[str] = controller[CONTROLLER_OPERATIONS_KEY]
+                controller_rule: str = controller[CONTROLLER_RULE_KEY]
+                if not self._validate_rule(controller_rule):
+                    raise ValueError(
+                        "Rule for control %s is invalid" % (controller_name)
+                    )
                 for event_name in controller[CONTROLLER_TRIGGERS_KEY]:
                     if event_name not in self.valid_events:
                         raise KeyError(
                             "Controller %s has an invalid event (%s)"
-                            % (controller[CONTROLLER_NAME_KEY], event_name)
+                            % (controller_name, event_name)
                         )
-                    # Generates the byte-code for the rule from trainer configuration
-                    if not self._validate_rule(controller[CONTROLLER_RULE_KEY]):
-                        raise ValueError(
-                            "Rule for control %s is invalid"
-                            % (controller[CONTROLLER_NAME_KEY])
-                        )
+                    # Generates the byte-code for the rule from the trainer configuration
                     control = Control(
-                        name=controller[CONTROLLER_NAME_KEY],
-                        rule=compile(controller[CONTROLLER_RULE_KEY], "", "eval"),
+                        name=controller_name,
+                        rule=compile(controller_rule, "", "eval"),
                         operation_actions=[],
                     )
-                    for control_operation_name in controller[CONTROLLER_OPERATIONS_KEY]:
+                    for control_operation_name in controller_ops:
                         if control_operation_name not in self.operation_actions:
                             raise KeyError(
                                 "Invalid operation %s for control %s"
                                 % (
                                     control_operation_name,
-                                    controller[CONTROLLER_NAME_KEY],
+                                    controller_name,
                                 )
                             )
                         control.operation_actions.append(

--- a/tuning/trainercontroller/controllermetrics/__init__.py
+++ b/tuning/trainercontroller/controllermetrics/__init__.py
@@ -20,9 +20,12 @@ from typing import Type
 
 # Local
 from .loss import Loss
+from .stateoftrainer import StateOfTrainer
 
 # List of metric handlers
 handlers = []
+
+INVALID_VALUE = float("nan")
 
 
 def register(cl: Type):
@@ -35,4 +38,5 @@ def register(cl: Type):
 
 
 # Register the default metric handlers in this package here
+register(StateOfTrainer)
 register(Loss)

--- a/tuning/trainercontroller/controllermetrics/stateoftrainer.py
+++ b/tuning/trainercontroller/controllermetrics/stateoftrainer.py
@@ -1,0 +1,74 @@
+# Copyright The IBM Tuning Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+# Standard
+from typing import Any
+import dataclasses
+
+# Third Party
+from transformers import TrainerState
+
+# Local
+from tuning.trainercontroller.controllermetrics.metricshandler import MetricHandler
+
+
+class StateOfTrainer(MetricHandler):
+    """Implements the controller metric which exposes the trainer state"""
+
+    def __init__(self, **kwargs):
+        """Initializes the metric handler, by registering the event \
+            list and arguments with base handler.
+
+        Args:
+            kwargs: List of arguments (key, value)-pairs
+        """
+        super().__init__(
+            events=[
+                "on_init_end",
+                "on_step_end",
+                "on_epoch_begin",
+                "on_epoch_end",
+                "on_prediction_step",
+                "on_predict",
+                "on_log",
+                "on_train_end",
+                "on_train_begin",
+                "on_evaluate",
+            ],
+            **kwargs
+        )
+
+    def validate(self) -> bool:
+        """Validate the training arguments (e.g logging_steps) are \
+            compatible with the computation of this metric.
+
+        Returns:
+            bool
+        """
+        return True
+
+    def compute(self, state: TrainerState = None, **kwargs) -> Any:
+        """Exposes the trainer state.
+
+        Args:
+            state: TrainerState object
+            kwargs: Remaining event arguments
+
+        Returns:
+            dict. Trainer state as a dictionary
+        """
+        return dataclasses.asdict(state)

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -41,6 +41,6 @@ class Operation(metaclass=abc.ABCMeta):
             raise ValueError(f"Invalid operation {action}")
         self.valid_actions[action](**kwargs)
 
-    def get_actions(self):
+    def get_actions(self) -> list[str]:
         """Gets the list of all valid actions."""
         return self.valid_actions.keys()

--- a/tuning/trainercontroller/operations/operations.yaml
+++ b/tuning/trainercontroller/operations/operations.yaml
@@ -1,3 +1,3 @@
 operations:
-  hfcontrols:
-    HFControls:
+  - name: hfcontrols
+    class: HFControls

--- a/tuning/utils/import_utils.py
+++ b/tuning/utils/import_utils.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Standard
+import os
+
 # Third Party
 from transformers.utils.import_utils import _is_package_available
 
@@ -19,4 +22,4 @@ _is_aim_available = _is_package_available("aim")
 
 
 def is_aim_available():
-    return _is_aim_available
+    return _is_aim_available and (os.environ.get("AIMSTACK_DB") is not None)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

This PR exposes the trainer state at every trainer loop event as a metric, which could be used as part of the trainer controller rules.

<!-- Please summarize the changes -->

### Related issue number

Closes #134 

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->
Apart from the test cases, the feature could be validated by running the trainer scripts using the example configuration:
```
python ./tuning/sft_trainer.py
...
--trainer_controller_config_file examples/trainercontroller_configs/loss.yaml
...
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [X] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass