### PR TITLE
fix typo in build gha

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r tox
+          python -m pip install tox
       - name: Build and test with tox
         run: tox -e ${{ matrix.python-version.tox }}
       - name: Build and check wheel package


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

fixes a small typo in .github/workflows/build-and-publish.yaml that stops the tox install from working.

### Related issue number

Closes https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/774

### How to verify the PR

I did the following

1.  I pushed this PR to my local fork's main branch so that I could publish a new release to PyPI and test
2. Then from there I created a new release and it succeeded with this new change: https://github.com/jbusche/fms-hf-tuning/actions/runs/8824603436/job/24227364778
3. I then used this new release to try to build a local image:  
```
docker build --build-arg WHEEL_VERSION=0.0.1rc7 --progress=plain -t fms-hf-tuning:0.0.1rc7 . -f build/Dockerfile
```
4. Then I pushed it to my local openshift repo:
```
podman login -u kubeadmin -p $(oc whoami -t) $(oc registry info) --tls-verify=false
podman tag localhost/fms-hf-tuning:0.0.1rc7 $(oc registry info)/opendatahub/fms-hf-tuning:0.0.1rc7
podman push  --tls-verify=false $(oc registry info)/opendatahub/fms-hf-tuning:0.0.1rc7
```
Then I ran Ted's test to see that it worked... it looked good:
```
Every 2.0s: oc get pods,pytorchjobs                                                           api.ted414.cp.fyre.ibm.com: Wed Apr 24 17:39:46 2024

NAME                        READY   STATUS      RESTARTS   AGE
pod/ted-kfto-sft-master-0   0/1     Completed   0          3m34s

NAME                                   STATE       AGE
pytorchjob.kubeflow.org/ted-kfto-sft   Succeeded   3m34s
```

### Was the PR tested
Yes, see above

- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass