### PR TITLE
fix: bug with AIM server availability check

### DIFF
--- a/tuning/aim_loader.py
+++ b/tuning/aim_loader.py
@@ -38,6 +38,6 @@ def get_aimstack_callback():
     if aim_db:
         aim_callback = AimCallback(repo=aim_db, experiment=aim_experiment)
     else:
-        aim_callback = AimCallback(experiment=aim_experiment)
+        aim_callback = None
 
     return aim_callback

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -244,7 +244,9 @@ def train(
 
     callbacks = [FileLoggingCallback(logger)]
     if is_aim_available():
-        callbacks.append(get_aimstack_callback())
+        aimstack_callback = get_aimstack_callback()
+        if aimstack_callback is not None:
+            callbacks.append(aimstack_callback)
 
     if (trainer_controller_args is not None) and (
         trainer_controller_args.trainer_controller_config_file is not None


### PR DESCRIPTION
### Description of the change

Fixes the bug in https://github.com/foundation-model-stack/fms-hf-tuning/issues/131

### Related issue number

https://github.com/foundation-model-stack/fms-hf-tuning/issues/131

### How to verify the PR

Run an end-to-end test using https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/tuning/sft_trainer.py in a `venv` or `conda` environment which has the AIM package installed. Even without an AIM server running the training should succeed.

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass