### PR TITLE
fix: Handling of FSDP Wrapping for PEFT in Training Script

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -276,7 +276,7 @@ def train(
 
     if trainer.is_fsdp_enabled and peft_config is not None:
         trainer.accelerator.state.fsdp_plugin.auto_wrap_policy = fsdp_auto_wrap_policy(
-            model
+            trainer.model
         )
     trainer.train()
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

I discovered an issue with how PEFT with FSDP is handled in the tuning script, `sft_trainer.py`.  In this [portion](https://github.com/foundation-model-stack/fms-hf-tuning/blob/8548a6df86e0a3ea00ece11a47c3aac2971a512e/tuning/sft_trainer.py#L272C1-L274C10) of the tuning script, the FSDP wrap policy is applied on a full model. This will result in an incorrect wrapping of FSDP layers that won't be applied on the adapter layers and subsequently produce wrong gradients in training.

Instead, after `SFTTrainer` creates the PEFT model in its initialization, then apply the wrap policy on the trainer's model.

I made the change in the code to correct the behaviour. Below, i demonstrate the effect of the bug and how the fix eliminates the problem.

### Tests

<!-- Please provide instruction or screenshots on how to verify the PR.-->

| The training was observed to produce nan gradients in distributed PEFT | After the fix is introduced, we do not see the nan gradients anymore |
| -------- | ------- |
| <img src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/165894159/7f63b2e4-f91e-45bd-bb1b-d3ce0e6424da" width="450"/>  | <img src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/165894159/bba1207b-371c-44aa-8d4c-9ad81e157d7a" width="450"/>    |
