### PR TITLE
fix: Allow makefile to run test independent of fmt/lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+# Run all
+.PHONY: all
+all: fmt lint test
+
 # Run unit tests
 .PHONY: test
-test: fmt lint
+test:
 	tox -e py
 
 # Format python code
@@ -9,6 +13,6 @@ fmt:
 	tox -e fmt
 
 # Run pylint to check code
-..PHONY: lint
+.PHONY: lint
 lint:
 	tox -e lint


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Allow to run test at development time independent of fmt or lint saving time.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

Yes. `make all`, `make test` and `make` work as expected.

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass