### PR TITLE
fix: replace eval with a safer alternative

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 "trl",
 "peft>=0.8.0",
 "datasets>=2.15.0",
-"fire"
+"fire",
+"simpleeval",
 ]
 
 [project.optional-dependencies]

--- a/tests/data/trainercontroller/__init__.py
+++ b/tests/data/trainercontroller/__init__.py
@@ -29,6 +29,9 @@ TRAINER_CONFIG_EXPOSED_METRICS_YAML = os.path.join(_DATA_DIR, "exposed_metrics.y
 TRAINER_CONFIG_INCORRECT_SOURCE_EVENT_EXPOSED_METRICS_YAML = os.path.join(
     _DATA_DIR, "incorrect_source_event_exposed_metrics.yaml"
 )
+TRAINER_CONFIG_TEST_INVALID_TYPE_RULE_YAML = os.path.join(
+    _DATA_DIR, "loss_with_invalid_type_rule.yaml"
+)
 TRAINER_CONFIG_TEST_MALICIOUS_OS_RULE_YAML = os.path.join(
     _DATA_DIR, "loss_with_malicious_os_rule.yaml"
 )

--- a/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
+++ b/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
@@ -1,0 +1,10 @@
+controller-metrics:
+  - name: loss
+    class: Loss
+controllers:
+  - name: loss-controller-wrong-os-rule
+    triggers:
+      - on_log
+    rule: "2+2"
+    operations:
+      - hfcontrols.should_training_stop

--- a/tests/utils/test_evaluator.py
+++ b/tests/utils/test_evaluator.py
@@ -1,0 +1,166 @@
+# Copyright The IBM Tuning Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+# Standard
+from typing import Tuple
+
+# Third Party
+import numpy as np
+import pytest
+
+# Local
+from tuning.utils.evaluator import get_evaluator
+
+
+def test_mailicious_inputs_to_eval():
+    """Tests the malicious rules"""
+    rules: list[Tuple[str, bool, str]] = [
+        # Valid rules
+        ("", False, "flags['is_training'] == False"),
+        ("", False, "not flags['is_training']"),
+        ("", True, "-10 < loss"),
+        ("", True, "+1000 > loss"),
+        ("", True, "~1000 < loss"),
+        ("", True, "(10 + 10) < loss"),
+        ("", True, "(20 - 10) < loss"),
+        ("", True, "(20/10) < loss"),
+        ("", True, "(20 % 10) < loss"),
+        ("", False, "loss < 1.0"),
+        ("", False, "(loss < 1.0)"),
+        ("", False, "loss*loss < 1.0"),
+        ("", False, "loss*loss*loss < 1.0"),
+        ("", False, "(loss*loss)*loss < 1.0"),
+        ("", True, "int(''.join(['3', '4'])) < loss"),
+        ("", True, "loss < 9**9"),
+        ("", False, "loss < sqrt(xs[0]*xs[0] + xs[1]*xs[1])"),
+        ("", True, "len(xs) > 2"),
+        ("", True, "loss < abs(-100)"),
+        ("", True, "loss == flags.aaa.bbb[0].ccc"),
+        ("", True, "array3d[0][1][1] == 4"),
+        ("", True, "numpyarray[0][1][1] == 4"),
+        (
+            "",
+            True,
+            "len(xs) == 4 and xs[0] == 1 and (xs[1] == 0 or xs[2] == 0) and xs[3] == 2",
+        ),
+        # Invalid rules
+        (
+            "'aaa' is not defined for expression 'loss == aaa.bbb[0].ccc'",
+            False,
+            "loss == aaa.bbb[0].ccc",
+        ),
+        ("0", False, "loss == flags[0].ccc"),  # KeyError
+        (
+            "Attribute 'ddd' does not exist in expression 'loss == flags.ddd[0].ccc'",
+            False,
+            "loss == flags.ddd[0].ccc",
+        ),
+        (
+            "Sorry, access to __attributes  or func_ attributes is not available. (__class__)",
+            False,
+            "'x'.__class__",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            # Try to instantiate and call Quitter
+            "().__class__.__base__.__subclasses__()[141]('', '')()",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            # pylint: disable=line-too-long
+            "[x for x in ().__class__.__base__.__subclasses__() if x.__name__ == 'Quitter'][0]('', '')()",
+        ),
+        (
+            "Function 'getattr' not defined, for expression 'getattr((), '__class__')'.",
+            False,
+            "getattr((), '__class__')",
+        ),
+        (
+            "Function 'getattr' not defined, for expression 'getattr((), '_' '_class_' '_')'.",
+            False,
+            "getattr((), '_' '_class_' '_')",
+        ),
+        (
+            "Sorry, I will not evalute something that long.",
+            False,
+            '["hello"]*10000000000',
+        ),
+        (
+            "Sorry, I will not evalute something that long.",
+            False,
+            "'i want to break free'.split() * 9999999999",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            "(lambda x='i want to break free'.split(): x * 9999999999)()",
+        ),
+        (
+            "Sorry, NamedExpr is not available in this evaluator",
+            False,
+            "(x := 'i want to break free'.split()) and (x * 9999999999)",
+        ),
+        ("Sorry! I don't want to evaluate 9 ** 387420489", False, "9**9**9**9"),
+        (
+            "Function 'mymetric1' not defined, for expression 'mymetric1() > loss'.",
+            True,
+            "mymetric1() > loss",
+        ),
+        (
+            "Function 'mymetric2' not defined, for expression 'mymetric2(loss) > loss'.",
+            True,
+            "mymetric2(loss) > loss",
+        ),
+    ]
+    metrics = {
+        "loss": 42.0,
+        "flags": {"is_training": True, "aaa": {"bbb": [{"ccc": 42.0}]}},
+        "xs": [1, 0, 0, 2],
+        "array3d": [
+            [
+                [1, 2],
+                [3, 4],
+            ],
+            [
+                [5, 6],
+                [7, 8],
+            ],
+        ],
+        "numpyarray": (np.arange(8).reshape((2, 2, 2)) + 1),
+    }
+
+    evaluator = get_evaluator(metrics=metrics)
+
+    for validation_error, expected_rule_is_true, rule in rules:
+        rule_parsed = evaluator.parse(expr=rule)
+        if validation_error == "":
+            actual_rule_is_true = evaluator.eval(
+                expr=rule,
+                previously_parsed=rule_parsed,
+            )
+            assert (
+                actual_rule_is_true == expected_rule_is_true
+            ), "failed to execute the rule"
+        else:
+            with pytest.raises(Exception) as exception_handler:
+                evaluator.eval(
+                    expr=rule,
+                    previously_parsed=rule_parsed,
+                )
+            assert str(exception_handler.value) == validation_error

--- a/tuning/trainercontroller/control.py
+++ b/tuning/trainercontroller/control.py
@@ -18,6 +18,7 @@
 # Standard
 from dataclasses import dataclass
 from typing import List, Optional
+import ast
 
 # Local
 from tuning.trainercontroller.operations import Operation
@@ -36,5 +37,6 @@ class Control:
     """Stores the name of control, rule byte-code corresponding actions"""
 
     name: str
-    rule: Optional[object] = None  # stores bytecode of the compiled rule
+    rule_str: str
+    rule: Optional[ast.AST] = None  # stores the abstract syntax tree of the parsed rule
     operation_actions: Optional[List[OperationAction]] = None

--- a/tuning/utils/evaluator.py
+++ b/tuning/utils/evaluator.py
@@ -1,0 +1,20 @@
+# Standard
+from math import sqrt
+
+# Third Party
+from simpleeval import DEFAULT_FUNCTIONS, DEFAULT_NAMES, EvalWithCompoundTypes
+
+
+def get_evaluator(metrics: dict) -> EvalWithCompoundTypes:
+    """Returns an evaluator that can be used to evaluate simple Python expressions."""
+    all_names = {
+        **metrics,
+        **DEFAULT_NAMES.copy(),
+    }
+    all_funcs = {
+        "abs": abs,
+        "len": len,
+        "sqrt": sqrt,
+        **DEFAULT_FUNCTIONS.copy(),
+    }
+    return EvalWithCompoundTypes(functions=all_funcs, names=all_names)


### PR DESCRIPTION
### Description of the change

Use the AST module to evaluate the rules instead of `eval`.

1. We use the Python AST library to parse the code.
2. We use this library https://github.com/danthedeckie/simpleeval for traversing and evaluating the generated AST.
3. The output of evaluation should be a boolean value which we return indicating if the rule succeeded.

Example supported expressions: https://github.com/danthedeckie/simpleeval?tab=readme-ov-file#operators

Support for more complex types (list, dict, etc.) are also implemented:
- https://github.com/danthedeckie/simpleeval?tab=readme-ov-file#compound-types
- https://github.com/danthedeckie/simpleeval/blob/2a12b5856d6f70b78dc1ac38840c80c1be6c6c4e/simpleeval.py#L638-L642

Notes:
- PyPi https://pypi.org/project/simpleeval/ (MIT Licence)
- Array Multiplication `["hello"]*10` is allowed but limited to smaller numbers to avoid Denial of Service (DOS).
- List comprehension is allowed but limited to small number of iterations to avoid DOS.
- Exponentiation `9**9` is allowed but limited to smaller numbers to avoid DOS.
- Access to double underscore attributes like `__class__` is disallowed to avoid access to arbitrary classes like `Quitter`.
- Lambda expressions are disallowed for simplicity and to reduce the attack surface. Can be added back in if necessary.
- Access to builtin functions and globals are disallowed expect for `int`, `float`, `str`, `rand` and `randint`.
- Has support for accessing keys in dicts using the short syntax:`foo.bar` . Example dict: `{"foo": {"bar": 42}})`

### Related issue number

Fixes https://github.com/foundation-model-stack/fms-hf-tuning/issues/148

### How to verify the PR

Have added unit tests for the safe evaluator.

`make test`

### Was the PR tested

- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass