### PR TITLE
Add exception catching / writing to termination log

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -58,14 +58,12 @@ def main():
     except (TypeError, ValueError, EnvironmentError) as e:
         logging.error(traceback.format_exc())
         write_termination_log(
-            "Exception raised during training. This may be a problem with your input: {}".format(
-                e
-            )
+            f"Exception raised during training. This may be a problem with your input: {e}"
         )
         sys.exit(USER_ERROR_EXIT_CODE)
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
-        write_termination_log("Unhandled exception during training")
+        write_termination_log(f"Unhandled exception during training. {e}")
         sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
     ##########
@@ -85,11 +83,11 @@ def main():
         return_code = e.returncode
         if return_code not in [INTERNAL_ERROR_EXIT_CODE, USER_ERROR_EXIT_CODE]:
             return_code = INTERNAL_ERROR_EXIT_CODE
-            write_termination_log("Unhandled exception during training")
+            write_termination_log(f"Unhandled exception during training. {e}")
         sys.exit(return_code)
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
-        write_termination_log("Unhandled exception during training")
+        write_termination_log(f"Unhandled exception during training. {e}")
         sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
     return 0

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -20,6 +20,7 @@ for the encoded config string to parse.
 # Standard
 import os
 import logging
+import sys
 import traceback
 
 # Third Party
@@ -45,7 +46,7 @@ def main():
     except FileNotFoundError as e:
         logging.error(traceback.format_exc())
         write_termination_log("Unable to load file: {}".format(e))
-        exit(1)
+        sys.exit(1)
     except (TypeError, ValueError, EnvironmentError) as e:
         logging.error(traceback.format_exc())
         write_termination_log(
@@ -53,18 +54,18 @@ def main():
                 e
             )
         )
-        exit(1)
-    except Exception as e:
+        sys.exit(1)
+    except Exception as e: # pylint: disable=broad-except
         logging.error(traceback.format_exc())
         write_termination_log("Unhandled exception during training")
-        exit(200)
+        sys.exit(200)
 
     try:
         launch_command(args)
-    except Exception as e:
+    except Exception as e: # pylint: disable=broad-except
         logging.error(traceback.format_exc)
         write_termination_log("Unhandled exception during training")
-        exit(200)
+        sys.exit(200)
 
 
 if __name__ == "__main__":

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -31,6 +31,8 @@ from build.utils import (
     process_accelerate_launch_args,
     get_job_config,
     write_termination_log,
+    USER_ERROR_EXIT_CODE,
+    INTERNAL_ERROR_EXIT_CODE,
 )
 
 
@@ -46,7 +48,7 @@ def main():
     except FileNotFoundError as e:
         logging.error(traceback.format_exc())
         write_termination_log("Unable to load file: {}".format(e))
-        sys.exit(1)
+        sys.exit(USER_ERROR_EXIT_CODE)
     except (TypeError, ValueError, EnvironmentError) as e:
         logging.error(traceback.format_exc())
         write_termination_log(
@@ -54,18 +56,18 @@ def main():
                 e
             )
         )
-        sys.exit(1)
+        sys.exit(USER_ERROR_EXIT_CODE)
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
         write_termination_log("Unhandled exception during training")
-        sys.exit(200)
+        sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
     try:
         launch_command(args)
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc)
         write_termination_log("Unhandled exception during training")
-        sys.exit(200)
+        sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -55,14 +55,14 @@ def main():
             )
         )
         sys.exit(1)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
         write_termination_log("Unhandled exception during training")
         sys.exit(200)
 
     try:
         launch_command(args)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc)
         write_termination_log("Unhandled exception during training")
         sys.exit(200)

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -26,7 +26,11 @@ import traceback
 from accelerate.commands.launch import launch_command
 
 # Local
-from build.utils import process_accelerate_launch_args, get_job_config, write_termination_log
+from build.utils import (
+    process_accelerate_launch_args,
+    get_job_config,
+    write_termination_log,
+)
 
 
 def main():
@@ -44,7 +48,11 @@ def main():
         exit(1)
     except (TypeError, ValueError, EnvironmentError) as e:
         logging.error(traceback.format_exc())
-        write_termination_log("Exception raised during training. This may be a problem with your input: {}".format(e))
+        write_termination_log(
+            "Exception raised during training. This may be a problem with your input: {}".format(
+                e
+            )
+        )
         exit(1)
     except Exception as e:
         logging.error(traceback.format_exc())

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -30,7 +30,11 @@ import logging
 from tuning import sft_trainer
 from tuning.utils.merge_model_utils import create_merged_model
 from tuning.config.tracker_configs import TrackerConfigFactory
-from build.utils import process_launch_training_args, get_job_config, write_termination_log
+from build.utils import (
+    process_launch_training_args,
+    get_job_config,
+    write_termination_log,
+)
 
 
 def get_highest_checkpoint(dir_path):
@@ -67,7 +71,11 @@ def main():
         ) = process_launch_training_args(job_config)
     except Exception as e:
         logging.error(traceback.format_exc())
-        write_termination_log("Exception raised during training. This may be a problem with your input: {}".format(e))
+        write_termination_log(
+            "Exception raised during training. This may be a problem with your input: {}".format(
+                e
+            )
+        )
         exit(1)
 
     (
@@ -104,7 +112,11 @@ def main():
             exit(1)
         except (TypeError, ValueError, EnvironmentError) as e:
             logging.error(traceback.format_exc())
-            write_termination_log("Exception raised during training. This may be a problem with your input: {}".format(e))
+            write_termination_log(
+                "Exception raised during training. This may be a problem with your input: {}".format(
+                    e
+                )
+            )
             exit(1)
         except Exception as e:
             logging.error(traceback.format_exc())
@@ -155,7 +167,9 @@ def main():
                 )
             except Exception as e:
                 logging.error(traceback.format_exc())
-                write_termination_log("Exception encountered writing output model to storage")
+                write_termination_log(
+                    "Exception encountered writing output model to storage"
+                )
                 exit(200)
 
         # copy over any loss logs

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -71,6 +71,8 @@ def main():
             training_args,
             tune_config,
             merge_model,
+            file_logger_config,
+            aim_config,
         ) = process_launch_training_args(job_config)
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -35,6 +35,8 @@ from build.utils import (
     process_launch_training_args,
     get_job_config,
     write_termination_log,
+    USER_ERROR_EXIT_CODE,
+    INTERNAL_ERROR_EXIT_CODE,
 )
 
 
@@ -77,7 +79,7 @@ def main():
                 e
             )
         )
-        sys.exit(1)
+        sys.exit(USER_ERROR_EXIT_CODE)
 
     (
         model_args,
@@ -106,21 +108,21 @@ def main():
         except MemoryError:
             logging.error(traceback.format_exc())
             write_termination_log("OOM error during training")
-            sys.exit(200)
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
         except FileNotFoundError as e:
             logging.error(traceback.format_exc())
             write_termination_log("Unable to load file: {}".format(e))
-            sys.exit(1)
+            sys.exit(USER_ERROR_EXIT_CODE)
         except (TypeError, ValueError, EnvironmentError) as e:
             logging.error(traceback.format_exc())
             write_termination_log(
                 f"Exception raised during training. This may be a problem with your input: {e}"
             )
-            sys.exit(1)
+            sys.exit(USER_ERROR_EXIT_CODE)
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log("Unhandled exception during training")
-            sys.exit(200)
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
         if merge_model:
             try:
@@ -149,7 +151,7 @@ def main():
             except Exception as e:  # pylint: disable=broad-except
                 logging.error(traceback.format_exc())
                 write_termination_log("Exception encountered merging model checkpoints")
-                sys.exit(200)
+                sys.exit(INTERNAL_ERROR_EXIT_CODE)
         else:
             try:
                 # copy last checkpoint into mounted output dir
@@ -169,7 +171,7 @@ def main():
                 write_termination_log(
                     "Exception encountered writing output model to storage"
                 )
-                sys.exit(200)
+                sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
         # copy over any loss logs
         try:

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -109,7 +109,9 @@ def main():
             sys.exit(USER_ERROR_EXIT_CODE)
         except HFValidationError as e:
             logging.error(traceback.format_exc())
-            write_termination_log(f"Specified base model not found. Exception: {e}")
+            write_termination_log(
+                f"There may be a problem with loading the model. Exception: {e}"
+            )
             sys.exit(USER_ERROR_EXIT_CODE)
         except (TypeError, ValueError, EnvironmentError) as e:
             logging.error(traceback.format_exc())

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -21,6 +21,7 @@ for the encoded config string to parse.
 import os
 import tempfile
 import shutil
+import traceback
 
 # First Party
 import logging
@@ -29,7 +30,7 @@ import logging
 from tuning import sft_trainer
 from tuning.utils.merge_model_utils import create_merged_model
 from tuning.config.tracker_configs import TrackerConfigFactory
-from build.utils import process_launch_training_args, get_job_config
+from build.utils import process_launch_training_args, get_job_config, write_termination_log
 
 
 def get_highest_checkpoint(dir_path):
@@ -53,9 +54,21 @@ def main():
 
     logging.info("Initializing launch training script")
 
-    job_config = get_job_config()
+    try:
+        job_config = get_job_config()
+        logging.debug("Input params parsed: %s", job_config)
 
-    logging.debug("Input params parsed: %s", job_config)
+        (
+            model_args,
+            data_args,
+            training_args,
+            tune_config,
+            merge_model,
+        ) = process_launch_training_args(job_config)
+    except Exception as e:
+        logging.error(traceback.format_exc())
+        write_termination_log("Exception raised during training. This may be a problem with your input: {}".format(e))
+        exit(1)
 
     (
         model_args,
@@ -70,61 +83,92 @@ def main():
     original_output_dir = training_args.output_dir
     with tempfile.TemporaryDirectory() as tempdir:
         training_args.output_dir = tempdir
-        tracker_config_args = TrackerConfigFactory(
-            file_logger_config=file_logger_config, aim_config=aim_config
-        )
-        sft_trainer.train(
-            model_args=model_args,
-            data_args=data_args,
-            train_args=training_args,
-            peft_config=tune_config,
-            tracker_configs=tracker_config_args,
-        )
+        try:
+            tracker_config_args = TrackerConfigFactory(
+                file_logger_config=file_logger_config, aim_config=aim_config
+            )
+            sft_trainer.train(
+                model_args=model_args,
+                data_args=data_args,
+                train_args=training_args,
+                peft_config=tune_config,
+                tracker_configs=tracker_config_args,
+            )
+        except MemoryError as e:
+            logging.error(traceback.format_exc())
+            write_termination_log("OOM error during training")
+            exit(200)
+        except FileNotFoundError as e:
+            logging.error(traceback.format_exc())
+            write_termination_log("Unable to load file: {}".format(e))
+            exit(1)
+        except (TypeError, ValueError, EnvironmentError) as e:
+            logging.error(traceback.format_exc())
+            write_termination_log("Exception raised during training. This may be a problem with your input: {}".format(e))
+            exit(1)
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            write_termination_log("Unhandled exception during training")
+            exit(200)
 
         if merge_model:
-            export_path = os.getenv(
-                "LORA_MERGE_MODELS_EXPORT_PATH", original_output_dir
-            )
+            try:
+                export_path = os.getenv(
+                    "LORA_MERGE_MODELS_EXPORT_PATH", original_output_dir
+                )
 
-            # get the highest checkpoint dir (last checkpoint)
-            lora_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
-            full_checkpoint_dir = os.path.join(
-                training_args.output_dir, lora_checkpoint_dir
-            )
+                # get the highest checkpoint dir (last checkpoint)
+                lora_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
+                full_checkpoint_dir = os.path.join(
+                    training_args.output_dir, lora_checkpoint_dir
+                )
 
-            logging.info(
-                "Merging lora tuned checkpoint %s with base model into output path: %s",
-                lora_checkpoint_dir,
-                export_path,
-            )
+                logging.info(
+                    "Merging lora tuned checkpoint %s with base model into output path: %s",
+                    lora_checkpoint_dir,
+                    export_path,
+                )
 
-            create_merged_model(
-                checkpoint_models=full_checkpoint_dir,
-                export_path=export_path,
-                base_model=model_args.model_name_or_path,
-                save_tokenizer=True,
-            )
+                create_merged_model(
+                    checkpoint_models=full_checkpoint_dir,
+                    export_path=export_path,
+                    base_model=model_args.model_name_or_path,
+                    save_tokenizer=True,
+                )
+            except Exception as e:
+                logging.error(traceback.format_exc())
+                write_termination_log("Exception encountered merging model checkpoints")
+                exit(200)
         else:
-            # copy last checkpoint into mounted output dir
-            pt_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
-            logging.info(
-                "Copying last checkpoint %s into output dir %s",
-                pt_checkpoint_dir,
-                original_output_dir,
-            )
-            shutil.copytree(
-                os.path.join(training_args.output_dir, pt_checkpoint_dir),
-                original_output_dir,
-                dirs_exist_ok=True,
-            )
+            try:
+                # copy last checkpoint into mounted output dir
+                pt_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
+                logging.info(
+                    "Copying last checkpoint %s into output dir %s",
+                    pt_checkpoint_dir,
+                    original_output_dir,
+                )
+                shutil.copytree(
+                    os.path.join(training_args.output_dir, pt_checkpoint_dir),
+                    original_output_dir,
+                    dirs_exist_ok=True,
+                )
+            except Exception as e:
+                logging.error(traceback.format_exc())
+                write_termination_log("Exception encountered writing output model to storage")
+                exit(200)
 
         # copy over any loss logs
-        train_logs_filepath = os.path.join(
-            training_args.output_dir,
-            tracker_config_args.file_logger_config.training_logs_filename,
-        )
-        if os.path.exists(train_logs_filepath):
-            shutil.copy(train_logs_filepath, original_output_dir)
+        try:
+            train_logs_filepath = os.path.join(
+                training_args.output_dir,
+                tracker_config_args.file_logger_config.training_logs_filename,
+            )
+            if os.path.exists(train_logs_filepath):
+                shutil.copy(train_logs_filepath, original_output_dir)
+        except Exception as e:
+            logging.error(traceback.format_exc())
+            # Continue, don't fail the training because of this
 
 
 if __name__ == "__main__":

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -83,16 +83,6 @@ def main():
         )
         sys.exit(USER_ERROR_EXIT_CODE)
 
-    (
-        model_args,
-        data_args,
-        training_args,
-        tune_config,
-        merge_model,
-        file_logger_config,
-        aim_config,
-    ) = process_launch_training_args(job_config)
-
     original_output_dir = training_args.output_dir
     with tempfile.TemporaryDirectory() as tempdir:
         training_args.output_dir = tempdir

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -183,7 +183,8 @@ def main():
                 shutil.copy(train_logs_filepath, original_output_dir)
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
-            # Continue, don't fail the training because of this
+            write_termination_log("Exception encountered in capturing training logs")
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
     return 0
 

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -70,7 +70,7 @@ def main():
             tune_config,
             merge_model,
         ) = process_launch_training_args(job_config)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
         write_termination_log(
             "Exception raised during training. This may be a problem with your input: {}".format(
@@ -117,7 +117,7 @@ def main():
                 f"Exception raised during training. This may be a problem with your input: {e}"
             )
             sys.exit(1)
-        except Exception as e: # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log("Unhandled exception during training")
             sys.exit(200)
@@ -146,7 +146,7 @@ def main():
                     base_model=model_args.model_name_or_path,
                     save_tokenizer=True,
                 )
-            except Exception as e: # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 logging.error(traceback.format_exc())
                 write_termination_log("Exception encountered merging model checkpoints")
                 sys.exit(200)
@@ -164,7 +164,7 @@ def main():
                     original_output_dir,
                     dirs_exist_ok=True,
                 )
-            except Exception as e: # pylint: disable=broad-except
+            except Exception as e:  # pylint: disable=broad-except
                 logging.error(traceback.format_exc())
                 write_termination_log(
                     "Exception encountered writing output model to storage"
@@ -179,7 +179,7 @@ def main():
             )
             if os.path.exists(train_logs_filepath):
                 shutil.copy(train_logs_filepath, original_output_dir)
-        except Exception as e: # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             # Continue, don't fail the training because of this
 

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -185,6 +185,8 @@ def main():
             logging.error(traceback.format_exc())
             # Continue, don't fail the training because of this
 
+    return 0
+
 
 if __name__ == "__main__":
     main()

--- a/build/utils.py
+++ b/build/utils.py
@@ -32,7 +32,7 @@ def write_termination_log(text, log_file="/dev/termination-log"):
     try:
         with open(log_file, "a", encoding="utf-8") as handle:
             handle.write(text)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         logging.warning("Unable to write termination log due to error {}".format(e))
 
 

--- a/build/utils.py
+++ b/build/utils.py
@@ -220,8 +220,8 @@ def process_accelerate_launch_args(job_config_dict):
         )
 
     # Add training_script
-    launch_directory = os.path.abspath(os.path.dirname( __file__ ))
-    accelerate_launch_args.append(launch_directory + "/launch_training.py")
+    script = os.environ.get("LAUNCH_TRAINING_SCRIPT") or "/app/launch_training.py"
+    accelerate_launch_args.append(script)
 
     logging.debug("accelerate_launch_args: %s", accelerate_launch_args)
     args = parser.parse_args(args=accelerate_launch_args)

--- a/build/utils.py
+++ b/build/utils.py
@@ -30,10 +30,9 @@ from tuning.config import configs, peft_config, tracker_configs
 
 def write_termination_log(text, log_file="/dev/termination-log"):
     try:
-        f = open(log_file, "a")
-        f.write(text)
-        f.close()
-    except Exception as e:
+        with open(log_file, "a", encoding="utf-8") as handle:
+            handle.write(text)
+    except Exception as e: # pylint: disable=broad-except
         logging.warning("Unable to write termination log due to error {}".format(e))
 
 

--- a/build/utils.py
+++ b/build/utils.py
@@ -28,10 +28,13 @@ from accelerate.commands.launch import launch_command_parser
 from tuning.config import configs, peft_config, tracker_configs
 
 
-def write_termination_log(text, log = "/dev/termination-log"):
-    f = open(log, "a")
-    f.write(text)
-    f.close()
+def write_termination_log(text, log_file = "/dev/termination-log"):
+    try:
+        f = open(log_file, "a")
+        f.write(text)
+        f.close()
+    except Exception as e:
+        logging.warning("Unable to write termination log due to error {}".format(e))
 
 
 def txt_to_obj(txt):

--- a/build/utils.py
+++ b/build/utils.py
@@ -37,7 +37,8 @@ USER_ERROR_EXIT_CODE = 1
 INTERNAL_ERROR_EXIT_CODE = 203
 
 
-def write_termination_log(text, log_file="/dev/termination-log"):
+def write_termination_log(text):
+    log_file = os.environ.get("TERMINATION_LOG_FILE", "/dev/termination-log")
     try:
         with open(log_file, "a", encoding="utf-8") as handle:
             handle.write(text)
@@ -220,7 +221,7 @@ def process_accelerate_launch_args(job_config_dict):
         )
 
     # Add training_script
-    script = os.environ.get("LAUNCH_TRAINING_SCRIPT") or "/app/launch_training.py"
+    script = os.environ.get("LAUNCH_TRAINING_SCRIPT", "/app/launch_training.py")
     accelerate_launch_args.append(script)
 
     logging.debug("accelerate_launch_args: %s", accelerate_launch_args)

--- a/build/utils.py
+++ b/build/utils.py
@@ -28,6 +28,12 @@ from accelerate.commands.launch import launch_command_parser
 from tuning.config import configs, peft_config, tracker_configs
 
 
+def write_termination_log(text, log = "/dev/termination-log"):
+    f = open(log, "a")
+    f.write(text)
+    f.close()
+
+
 def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
     message_bytes = base64.b64decode(base64_bytes)

--- a/build/utils.py
+++ b/build/utils.py
@@ -28,7 +28,7 @@ from accelerate.commands.launch import launch_command_parser
 from tuning.config import configs, peft_config, tracker_configs
 
 
-def write_termination_log(text, log_file = "/dev/termination-log"):
+def write_termination_log(text, log_file="/dev/termination-log"):
     try:
         f = open(log_file, "a")
         f.write(text)

--- a/build/utils.py
+++ b/build/utils.py
@@ -27,6 +27,15 @@ from accelerate.commands.launch import launch_command_parser
 # Local
 from tuning.config import configs, peft_config, tracker_configs
 
+# The USER_ERROR_EXIT_CODE will be thrown when the process must exit
+# as result of a user input error. User-related errors should be
+# >= 1 and <=127 due to how some kubernetes operators interpret them.
+USER_ERROR_EXIT_CODE = 1
+# The INTERNAL_ERROR_EXIT_CODE will be thrown when training
+# abnormally terminates, and it is not clearly fault of the user.
+# System-level errors should be >= 128 and <= 254
+INTERNAL_ERROR_EXIT_CODE = 203
+
 
 def write_termination_log(text, log_file="/dev/termination-log"):
     try:

--- a/build/utils.py
+++ b/build/utils.py
@@ -220,7 +220,8 @@ def process_accelerate_launch_args(job_config_dict):
         )
 
     # Add training_script
-    accelerate_launch_args.append("/app/launch_training.py")
+    launch_directory = os.path.abspath(os.path.dirname( __file__ ))
+    accelerate_launch_args.append(launch_directory + "/launch_training.py")
 
     logging.debug("accelerate_launch_args: %s", accelerate_launch_args)
     args = parser.parse_args(args=accelerate_launch_args)

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -60,87 +60,113 @@ BASE_PEFT_KWARGS = {
 }
 
 
-def test_successful_pt():
-    """Check if we can bootstrap and peft tune causallm models"""
+def serialize_args(args_json):
+    message_bytes = pickle.dumps(args_json)
+    base64_bytes = base64.b64encode(message_bytes)
+    return base64_bytes.decode("ascii")
+
+
+def setup_env(tempdir):
     os.environ["LAUNCH_TRAINING_SCRIPT"] = SCRIPT
     os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
-    with tempfile.TemporaryDirectory() as tempdir:
-        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
-        message_bytes = pickle.dumps(TRAIN_KWARGS)
-        base64_bytes = base64.b64encode(message_bytes)
-        serialized_args = base64_bytes.decode("ascii")
+    os.environ["TERMINATION_LOG_FILE"] = tempdir + "/termination-log"
 
+
+def cleanup_env():
+    os.environ.pop("LAUNCH_TRAINING_SCRIPT", None)
+    os.environ.pop("PYTHONPATH", None)
+    os.environ.pop("TERMINATION_LOG_FILE", None)
+
+
+def test_successful_pt():
+    """Check if we can bootstrap and peft tune causallm models"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
+        serialized_args = serialize_args(TRAIN_KWARGS)
         os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
 
         assert main() == 0
+        assert os.path.exists(tempdir + "/termination-log") is False
 
 
 def test_bad_script_path():
-    """Check if we can bootstrap and peft tune causallm models"""
-    os.environ["LAUNCH_TRAINING_SCRIPT"] = "invalid"
-    os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
+    """Check for appropriate error for an invalid training script location"""
     with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
         TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
-        message_bytes = pickle.dumps(TRAIN_KWARGS)
-        base64_bytes = base64.b64encode(message_bytes)
-        serialized_args = base64_bytes.decode("ascii")
-
+        serialized_args = serialize_args(TRAIN_KWARGS)
         os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        os.environ["LAUNCH_TRAINING_SCRIPT"] = "/not/here"
 
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        main()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == INTERNAL_ERROR_EXIT_CODE
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == INTERNAL_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
 
 
 def test_blank_env_var():
-    os.environ["LAUNCH_TRAINING_SCRIPT"] = SCRIPT
-    os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
-    os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = ""
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        main()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = ""
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
 
 
 def test_faulty_file_path():
-    os.environ["LAUNCH_TRAINING_SCRIPT"] = SCRIPT
-    os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
     with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
         faulty_path = os.path.join(tempdir, "non_existent_file.pkl")
         TRAIN_KWARGS = {
             **BASE_PEFT_KWARGS,
             **{"training_data_path": faulty_path, "output_dir": tempdir},
         }
-        message_bytes = pickle.dumps(TRAIN_KWARGS)
-        base64_bytes = base64.b64encode(message_bytes)
-        serialized_args = base64_bytes.decode("ascii")
+        serialized_args = serialize_args(TRAIN_KWARGS)
         os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             main()
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_bad_base_model_path():
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {
+            **BASE_PEFT_KWARGS,
+            **{"model_name_or_path": "/wrong/path"},
+        }
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
 
 
 def test_config_parsing_error():
-    os.environ["LAUNCH_TRAINING_SCRIPT"] = SCRIPT
-    os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
-
-    TRAIN_KWARGS = {
-        **BASE_PEFT_KWARGS,
-        **{"num_train_epochs": "five"},
-    }  # Intentional type error
-    message_bytes = pickle.dumps(TRAIN_KWARGS)
-    base64_bytes = base64.b64encode(message_bytes)
-    serialized_args = base64_bytes.decode("ascii")
-    os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        main()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {
+            **BASE_PEFT_KWARGS,
+            **{"num_train_epochs": "five"},
+        }  # Intentional type error
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
 
 
 def test_cleanup():
     # This runs to unset env variables that could disrupt other tests
-    os.environ.pop("LAUNCH_TRAINING_SCRIPT", None)
+    cleanup_env()
     assert True

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -56,7 +56,7 @@ BASE_PEFT_KWARGS = {
     "prompt_tuning_init_text": "hello",
     "tokenizer_name_or_path": MODEL_NAME,
     "save_strategy": "epoch",
-    "output_dir": "tmp"
+    "output_dir": "tmp",
 }
 
 
@@ -138,3 +138,9 @@ def test_config_parsing_error():
         main()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+
+
+def test_cleanup():
+    # This runs to unset env variables that could disrupt other tests
+    os.environ.pop("LAUNCH_TRAINING_SCRIPT", None)
+    assert True

--- a/tests/test_launch_script.py
+++ b/tests/test_launch_script.py
@@ -1,0 +1,111 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit Tests for accelerate_launch script.
+"""
+
+# Standard
+import base64
+import os
+import pickle
+import tempfile
+from unittest import mock
+
+# Third Party
+import pytest
+
+# First Party
+from build.accelerate_launch import main
+from build.utils import USER_ERROR_EXIT_CODE, INTERNAL_ERROR_EXIT_CODE
+from tests.data import TWITTER_COMPLAINTS_DATA
+
+MODEL_NAME = "Maykeye/TinyLLama-v0"
+BASE_PEFT_KWARGS = {
+    "model_name_or_path": MODEL_NAME,
+    "training_data_path": TWITTER_COMPLAINTS_DATA,
+    "num_train_epochs": 5,
+    "per_device_train_batch_size": 4,
+    "per_device_eval_batch_size": 4,
+    "gradient_accumulation_steps": 4,
+    "learning_rate": 0.00001,
+    "weight_decay": 0,
+    "warmup_ratio": 0.03,
+    "lr_scheduler_type": "cosine",
+    "logging_steps": 1,
+    "include_tokens_per_second": True,
+    "packing": False,
+    "response_template": "\n### Label:",
+    "dataset_text_field": "output",
+    "use_flash_attn": False,
+    "torch_dtype": "float32",
+    "max_seq_length": 4096,
+    "peft_method": "pt",
+    "prompt_tuning_init": "RANDOM",
+    "num_virtual_tokens": 8,
+    "prompt_tuning_init_text": "hello",
+    "tokenizer_name_or_path": MODEL_NAME,
+    "save_strategy": "epoch",
+    "output_dir": "tmp",
+
+}
+
+
+def test_successful_pt():
+    """Check if we can bootstrap and peft tune causallm models"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
+        message_bytes = pickle.dumps(TRAIN_KWARGS)
+        base64_bytes = base64.b64encode(message_bytes)
+        serialized_args = base64_bytes.decode("ascii")
+
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+
+        assert main() == 0
+
+
+def test_blank_env_var():
+    os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = ""
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        main()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+
+
+def test_faulty_file_path():
+    with tempfile.TemporaryDirectory() as tempdir:
+        faulty_path = os.path.join(tempdir, "non_existent_file.pkl")
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"training_data_path": faulty_path, "output_dir": tempdir}}
+        message_bytes = pickle.dumps(TRAIN_KWARGS)
+        base64_bytes = base64.b64encode(message_bytes)
+        serialized_args = base64_bytes.decode("ascii")
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+
+
+def test_config_parsing_error():
+    with tempfile.TemporaryDirectory() as tempdir:
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"num_train_epochs": "five"}}  # Intentional type error
+        message_bytes = pickle.dumps(TRAIN_KWARGS)
+        base64_bytes = base64.b64encode(message_bytes)
+        serialized_args = base64_bytes.decode("ascii")
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+
+


### PR DESCRIPTION
When the tuning code is being launched via `accelerate_launch.py` in a kubernetes environment, we want error messages for failed tuning jobs to be surfaced in the pod status. In order to do this, these scripts must be able to catch all exceptions and write succinct error messages into the `/dev/termination-log`.