### PR TITLE
python3.9 CVE fixes and aim removal to pass FIPS tolerance

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -126,8 +126,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade pip && \
     python -m pip install wheel && \
     python -m pip install "$(head bdist_name)" && \
-    # Due to FIPS tolerance issues, removing aim at this time
-    #python -m pip install "$(head bdist_name)[aim]" && \
+    python -m pip install "$(head bdist_name)[aim]" && \
     python -m pip install "$(head bdist_name)[flash-attn]" && \
     # Clean up the wheel module. It's only needed by flash-attn install
     python -m pip uninstall wheel -y && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -39,8 +39,7 @@ ARG SET_NUM_PROCESSES_TO_NUM_GPUS=True
 
 USER root
 
-RUN dnf update -y \
-    && dnf remove -y --disableplugin=subscription-manager \
+RUN dnf remove -y --disableplugin=subscription-manager \
         subscription-manager \
         # we install newer version of requests via pip
         python3.11-requests \
@@ -112,10 +111,14 @@ ENV LIBRARY_PATH="$CUDA_HOME/lib64/stubs"
 RUN dnf install -y python3.11 git \
     && ln -s /usr/bin/python3.11 /bin/python \
     && python -m ensurepip --upgrade \
+    && dnf update -y \
     && dnf clean all
 
 # Removes the example private key to avoid high severity vulnerability warning
 RUN rm -f /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem
+
+# Removes the python3.9 code to eliminate possible CVEs.  Also removes dnf
+RUN rpm -e $(dnf repoquery python3-* -q --installed) dnf python3 yum crypto-policies-scripts
 
 WORKDIR /tmp
 COPY --from=wheel /tmp/*.whl /tmp/bdist_name /tmp/
@@ -123,7 +126,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade pip && \
     python -m pip install wheel && \
     python -m pip install "$(head bdist_name)" && \
-    python -m pip install "$(head bdist_name)[aim]" && \
+    # Due to FIPS tolerance issues, removing aim at this time
+    #python -m pip install "$(head bdist_name)[aim]" && \
     python -m pip install "$(head bdist_name)[flash-attn]" && \
     # Clean up the wheel module. It's only needed by flash-attn install
     python -m pip uninstall wheel -y && \

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -20,23 +20,77 @@ for the encoded config string to parse.
 # Standard
 import os
 import logging
+import subprocess
+import sys
+import traceback
 
 # Third Party
 from accelerate.commands.launch import launch_command
 
 # Local
-from build.utils import process_accelerate_launch_args, get_job_config
+from build.utils import (
+    process_accelerate_launch_args,
+    get_job_config,
+    write_termination_log,
+    USER_ERROR_EXIT_CODE,
+    INTERNAL_ERROR_EXIT_CODE,
+)
 
 
 def main():
     LOGLEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
     logging.basicConfig(level=LOGLEVEL)
 
-    job_config = get_job_config()
+    ##########
+    #
+    # Parse arguments
+    #
+    ##########
+    try:
+        job_config = get_job_config()
 
-    args = process_accelerate_launch_args(job_config)
-    logging.debug("accelerate launch parsed args: %s", args)
-    launch_command(args)
+        args = process_accelerate_launch_args(job_config)
+        logging.debug("accelerate launch parsed args: %s", args)
+    except FileNotFoundError as e:
+        logging.error(traceback.format_exc())
+        write_termination_log("Unable to load file: {}".format(e))
+        sys.exit(USER_ERROR_EXIT_CODE)
+    except (TypeError, ValueError, EnvironmentError) as e:
+        logging.error(traceback.format_exc())
+        write_termination_log(
+            f"Exception raised during training. This may be a problem with your input: {e}"
+        )
+        sys.exit(USER_ERROR_EXIT_CODE)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error(traceback.format_exc())
+        write_termination_log(f"Unhandled exception during training. {e}")
+        sys.exit(INTERNAL_ERROR_EXIT_CODE)
+
+    ##########
+    #
+    # Launch training
+    #
+    ##########
+    try:
+        launch_command(args)
+    except subprocess.CalledProcessError as e:
+        # If the subprocess throws an exception, the base exception is hidden in the subprocess call
+        # and is difficult to access at this level. However, that is not an issue because
+        # launch_training.py would have already written the exception message to termination log.
+        logging.error(traceback.format_exc())
+        # The exit code that launch_training.py threw is captured in e.returncode
+
+        return_code = e.returncode
+        if return_code not in [INTERNAL_ERROR_EXIT_CODE, USER_ERROR_EXIT_CODE]:
+            return_code = INTERNAL_ERROR_EXIT_CODE
+            write_termination_log(f"Unhandled exception during training. {e}")
+        sys.exit(return_code)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error(traceback.format_exc())
+        write_termination_log(f"Unhandled exception during training. {e}")
+        sys.exit(INTERNAL_ERROR_EXIT_CODE)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -21,6 +21,12 @@ for the encoded config string to parse.
 import os
 import tempfile
 import shutil
+import sys
+import traceback
+
+# Third Party
+from huggingface_hub.utils._validators import HFValidationError
+from torch.cuda import OutOfMemoryError
 
 # First Party
 import logging
@@ -29,7 +35,13 @@ import logging
 from tuning import sft_trainer
 from tuning.utils.merge_model_utils import create_merged_model
 from tuning.config.tracker_configs import TrackerConfigFactory
-from build.utils import process_launch_training_args, get_job_config
+from build.utils import (
+    process_launch_training_args,
+    get_job_config,
+    write_termination_log,
+    USER_ERROR_EXIT_CODE,
+    INTERNAL_ERROR_EXIT_CODE,
+)
 
 
 def get_highest_checkpoint(dir_path):
@@ -53,78 +65,132 @@ def main():
 
     logging.info("Initializing launch training script")
 
-    job_config = get_job_config()
+    try:
+        job_config = get_job_config()
+        logging.debug("Input params parsed: %s", job_config)
 
-    logging.debug("Input params parsed: %s", job_config)
-
-    (
-        model_args,
-        data_args,
-        training_args,
-        tune_config,
-        merge_model,
-        file_logger_config,
-        aim_config,
-    ) = process_launch_training_args(job_config)
+        (
+            model_args,
+            data_args,
+            training_args,
+            tune_config,
+            merge_model,
+            file_logger_config,
+            aim_config,
+        ) = process_launch_training_args(job_config)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error(traceback.format_exc())
+        write_termination_log(
+            f"Exception raised during training. This may be a problem with your input: {e}"
+        )
+        sys.exit(USER_ERROR_EXIT_CODE)
 
     original_output_dir = training_args.output_dir
     with tempfile.TemporaryDirectory() as tempdir:
         training_args.output_dir = tempdir
-        tracker_config_args = TrackerConfigFactory(
-            file_logger_config=file_logger_config, aim_config=aim_config
-        )
-        sft_trainer.train(
-            model_args=model_args,
-            data_args=data_args,
-            train_args=training_args,
-            peft_config=tune_config,
-            tracker_configs=tracker_config_args,
-        )
+        try:
+            tracker_config_args = TrackerConfigFactory(
+                file_logger_config=file_logger_config, aim_config=aim_config
+            )
+            sft_trainer.train(
+                model_args=model_args,
+                data_args=data_args,
+                train_args=training_args,
+                peft_config=tune_config,
+                tracker_configs=tracker_config_args,
+            )
+        except (MemoryError, OutOfMemoryError) as e:
+            logging.error(traceback.format_exc())
+            write_termination_log(f"OOM error during training. {e}")
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
+        except FileNotFoundError as e:
+            logging.error(traceback.format_exc())
+            write_termination_log("Unable to load file: {}".format(e))
+            sys.exit(USER_ERROR_EXIT_CODE)
+        except HFValidationError as e:
+            logging.error(traceback.format_exc())
+            write_termination_log(
+                f"There may be a problem with loading the model. Exception: {e}"
+            )
+            sys.exit(USER_ERROR_EXIT_CODE)
+        except (TypeError, ValueError, EnvironmentError) as e:
+            logging.error(traceback.format_exc())
+            write_termination_log(
+                f"Exception raised during training. This may be a problem with your input: {e}"
+            )
+            sys.exit(USER_ERROR_EXIT_CODE)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.error(traceback.format_exc())
+            write_termination_log(f"Unhandled exception during training: {e}")
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
         if merge_model:
-            export_path = os.getenv(
-                "LORA_MERGE_MODELS_EXPORT_PATH", original_output_dir
-            )
+            try:
+                export_path = os.getenv(
+                    "LORA_MERGE_MODELS_EXPORT_PATH", original_output_dir
+                )
 
-            # get the highest checkpoint dir (last checkpoint)
-            lora_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
-            full_checkpoint_dir = os.path.join(
-                training_args.output_dir, lora_checkpoint_dir
-            )
+                # get the highest checkpoint dir (last checkpoint)
+                lora_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
+                full_checkpoint_dir = os.path.join(
+                    training_args.output_dir, lora_checkpoint_dir
+                )
 
-            logging.info(
-                "Merging lora tuned checkpoint %s with base model into output path: %s",
-                lora_checkpoint_dir,
-                export_path,
-            )
+                logging.info(
+                    "Merging lora tuned checkpoint %s with base model into output path: %s",
+                    lora_checkpoint_dir,
+                    export_path,
+                )
 
-            create_merged_model(
-                checkpoint_models=full_checkpoint_dir,
-                export_path=export_path,
-                base_model=model_args.model_name_or_path,
-                save_tokenizer=True,
-            )
+                create_merged_model(
+                    checkpoint_models=full_checkpoint_dir,
+                    export_path=export_path,
+                    base_model=model_args.model_name_or_path,
+                    save_tokenizer=True,
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logging.error(traceback.format_exc())
+                write_termination_log(
+                    f"Exception encountered merging base model with checkpoint. {e}"
+                )
+                sys.exit(INTERNAL_ERROR_EXIT_CODE)
         else:
-            # copy last checkpoint into mounted output dir
-            pt_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
-            logging.info(
-                "Copying last checkpoint %s into output dir %s",
-                pt_checkpoint_dir,
-                original_output_dir,
-            )
-            shutil.copytree(
-                os.path.join(training_args.output_dir, pt_checkpoint_dir),
-                original_output_dir,
-                dirs_exist_ok=True,
-            )
+            try:
+                # copy last checkpoint into mounted output dir
+                pt_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)
+                logging.info(
+                    "Copying last checkpoint %s into output dir %s",
+                    pt_checkpoint_dir,
+                    original_output_dir,
+                )
+                shutil.copytree(
+                    os.path.join(training_args.output_dir, pt_checkpoint_dir),
+                    original_output_dir,
+                    dirs_exist_ok=True,
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logging.error(traceback.format_exc())
+                write_termination_log(
+                    f"Exception encountered writing output model to storage: {e}"
+                )
+                sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
         # copy over any loss logs
-        train_logs_filepath = os.path.join(
-            training_args.output_dir,
-            tracker_config_args.file_logger_config.training_logs_filename,
-        )
-        if os.path.exists(train_logs_filepath):
-            shutil.copy(train_logs_filepath, original_output_dir)
+        try:
+            train_logs_filepath = os.path.join(
+                training_args.output_dir,
+                tracker_config_args.file_logger_config.training_logs_filename,
+            )
+            if os.path.exists(train_logs_filepath):
+                shutil.copy(train_logs_filepath, original_output_dir)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.error(traceback.format_exc())
+            write_termination_log(
+                f"Exception encountered in capturing training logs: {e}"
+            )
+            sys.exit(INTERNAL_ERROR_EXIT_CODE)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -190,7 +190,8 @@ def main():
                 shutil.copy(train_logs_filepath, original_output_dir)
             # The .complete file will signal to users that we are finished copying
             # files over
-            Path(os.path.join(original_output_dir, ".complete")).touch()
+            if os.path.exists(original_output_dir):
+                Path(os.path.join(original_output_dir, ".complete")).touch()
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -18,6 +18,7 @@ for the encoded config string to parse.
 """
 
 # Standard
+from pathlib import Path
 import os
 import tempfile
 import shutil
@@ -183,6 +184,9 @@ def main():
             )
             if os.path.exists(train_logs_filepath):
                 shutil.copy(train_logs_filepath, original_output_dir)
+            # The .complete file will signal to users that we are finished copying
+            # files over
+            Path(os.path.join(original_output_dir, ".complete")).touch()
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -143,12 +143,16 @@ def main():
                     export_path,
                 )
 
-                create_merged_model(
-                    checkpoint_models=full_checkpoint_dir,
-                    export_path=export_path,
-                    base_model=model_args.model_name_or_path,
-                    save_tokenizer=True,
-                )
+                # ensure checkpoint dir has correct files, important with multi-gpu tuning
+                if os.path.exists(
+                    os.path.join(full_checkpoint_dir, "adapter_config.json")
+                ):
+                    create_merged_model(
+                        checkpoint_models=full_checkpoint_dir,
+                        export_path=export_path,
+                        base_model=model_args.model_name_or_path,
+                        save_tokenizer=True,
+                    )
             except Exception as e:  # pylint: disable=broad-except
                 logging.error(traceback.format_exc())
                 write_termination_log(

--- a/build/utils.py
+++ b/build/utils.py
@@ -27,6 +27,24 @@ from accelerate.commands.launch import launch_command_parser
 # Local
 from tuning.config import configs, peft_config, tracker_configs
 
+# The USER_ERROR_EXIT_CODE will be thrown when the process must exit
+# as result of a user input error. User-related errors should be
+# >= 1 and <=127 due to how some kubernetes operators interpret them.
+USER_ERROR_EXIT_CODE = 1
+# The INTERNAL_ERROR_EXIT_CODE will be thrown when training
+# abnormally terminates, and it is not clearly fault of the user.
+# System-level errors should be >= 128 and <= 254
+INTERNAL_ERROR_EXIT_CODE = 203
+
+
+def write_termination_log(text):
+    log_file = os.environ.get("TERMINATION_LOG_FILE", "/dev/termination-log")
+    try:
+        with open(log_file, "a", encoding="utf-8") as handle:
+            handle.write(text)
+    except Exception as e:  # pylint: disable=broad-except
+        logging.warning("Unable to write termination log due to error {}".format(e))
+
 
 def txt_to_obj(txt):
     base64_bytes = txt.encode("ascii")
@@ -203,7 +221,8 @@ def process_accelerate_launch_args(job_config_dict):
         )
 
     # Add training_script
-    accelerate_launch_args.append("/app/launch_training.py")
+    script = os.environ.get("LAUNCH_TRAINING_SCRIPT", "/app/launch_training.py")
+    accelerate_launch_args.append(script)
 
     logging.debug("accelerate_launch_args: %s", accelerate_launch_args)
     args = parser.parse_args(args=accelerate_launch_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["wheel", "packaging", "ninja", "scikit-learn>=1.0, <2.0"]
+dev = ["wheel", "packaging", "ninja", "scikit-learn>=1.0, <2.0", "boto3"]
 flash-attn = ["flash-attn"]
 aim = ["aim==3.19.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 "trl",
 "peft>=0.8.0",
 "datasets>=2.15.0",
-"fire"
+"fire",
+"simpleeval",
 ]
 
 [project.optional-dependencies]

--- a/scripts/alpaca_to_sft_format.py
+++ b/scripts/alpaca_to_sft_format.py
@@ -1,0 +1,104 @@
+# Standard
+import argparse
+import os
+
+# Third Party
+import datasets
+
+# Prompt template to be used by default
+SIMPLE_PROMPT = "Input:\n{input}\n\n### Response:"
+
+# Prompt template to be used if --verbose is provided
+VERBOSE_PROMPT_INPUT = (
+    # pylint: disable=line-too-long
+    "Below is an instruction that describes a task, paired with an input that provides further context. "
+    "Write a response that appropriately completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:"
+)
+VERBOSE_PROMPT_NO_INPUT = (
+    "Below is an instruction that describes a task. "
+    "Write a response that appropriately completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n### Response:"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the arguments and ensure everything is valid.
+
+    Returns:
+        argparse.Namespace
+            Parsed arguments object.
+    """
+    parser = argparse.ArgumentParser(
+        description="Converts Alpaca formatted data files into SFT formatted files."
+    )
+    parser.add_argument(
+        "--verbose",
+        help="Indicates whether or not the verbose format should be used.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--files",
+        help="Alpaca formatted files to be converted to SFT format.",
+        nargs="+",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def format_alpaca_fn_simple(example: str) -> dict[str, str]:
+    """Format a single example using the simple template format.
+
+    Args:
+        example: str
+            Example to be formatted.
+
+    Returns:
+        dict[str, str]
+            Dictionary containing the formatted example.
+    """
+    output = SIMPLE_PROMPT.format_map(example)
+    output = f"{output} {example['output']}"
+    return {"output": output}
+
+
+def format_alpaca_fn_verbose(example: str) -> dict[str, str]:
+    """Format a single example using the verbose template format.
+
+    Args:
+        example: str
+            Example to be formatted.
+
+    Returns:
+        dict[str, str]
+            Dictionary containing the formatted example.
+    """
+    output = (
+        VERBOSE_PROMPT_INPUT.format_map(example)
+        if example.get("input", "") != ""
+        else VERBOSE_PROMPT_NO_INPUT.format_map(example)
+    )
+    output = f"{output} {example['output']}"
+    return {"output": output}
+
+
+if __name__ == "__main__":
+    parsed_args = parse_args()
+    format_alpaca_fn = (
+        format_alpaca_fn_verbose if parsed_args.verbose else format_alpaca_fn_simple
+    )
+
+    for file_path in parsed_args.files:
+        if not os.path.isfile(file_path):
+            raise ValueError(f"alpaca dataset f{file_path} does not exist!")
+        base_path, file_name = os.path.split(file_path)
+        export_path = os.path.join(base_path, f"sft_format_{file_name}")
+        print(
+            f"Converting alpaca format file: {file_path} to SFT trainer training format"
+        )
+        ds = datasets.load_dataset("json", data_files=file_path)
+        alpaca_ds = ds["train"].map(
+            format_alpaca_fn, remove_columns=["instruction", "input"]
+        )
+        alpaca_ds.to_json(export_path)
+        print(f"Exported SFT format data to {export_path}")

--- a/scripts/evaluation.md
+++ b/scripts/evaluation.md
@@ -1,0 +1,93 @@
+# Data Formatting / Evaluation
+This doc describes how to pull & format datasets into something that can be run against this repository for evaluation.
+
+## Pulling and Converting Datasets Into Alpaca Format
+In order to pull and format the datasets, you'll need to set the following environment variables:
+
+```bash
+export S3_ACCESS_KEY_ID={YOUR S3 KEY}
+export S3_SECRET_ACCESS_KEY={YOUR S3 SECRET ACCESS KEY}
+export S3_ENDPOINT={YOUR S3 ENDPOINT}
+```
+
+Next, pull and format the datasets. In order to run the data formatting & evaluation, you'll need a few extra dependencies, namely `boto3` and `scikit-learn`, which you can pull from the dev dependencies.
+
+NOTE: If you are running this from inside of a container with the library already installed, the easiest way to run evaluation is to copy & install the project's dev dependencies e.g., with `pip3 install .[dev]`, inside of a virtual environment in the container.
+
+To pull and format the datasets into Alpaca format, run the following command.
+```bash
+python3 pull_and_format_datasets.py
+```
+
+Make sure you see everything under `formatted`! It should look something like this. Note that the numeric prefix for train/test files indicates how many samples were randomly sampled into the Alpaca formatted file:
+```bash
+ls -R formatted_data/
+
+formatted_data/:
+Entities  cc_tone  tsa_mams
+
+formatted_data/Entities:
+1000_IBM_NET_2019_DELIVERABLE_VERSION_C_train.json  IBM_NET_2019_DELIVERABLE_VERSION_C_dev.json
+500_IBM_NET_2019_DELIVERABLE_VERSION_C_test.json
+
+formatted_data/cc_tone:
+1000_train.json  500_test.json
+
+formatted_data/tsa_mams:
+1000_train.json  500_test.json validation.json
+```
+
+## Converting Alpaca Format Datasets Into SFT Format
+
+In order to run a tuning on the datasets, you'll need to convert the Alpaca format datasets into the SFT format. You can do this by with `alpaca_to_sft_format.py`; pass each Alpaca formatted file that you want to convert as part of the `--files` argument, as shown below.
+
+```bash
+python3 alpaca_to_sft_format.py \
+    --files \
+    formatted_data/cc_tone/1000_train.json \
+    formatted_data/Entities/1000_IBM_NET_2019_DELIVERABLE_VERSION_C_train.json \
+    formatted_data/tsa_mams/1000_train.json
+```
+
+Now, you should have a `sft_format_{file_name}` in the same location as each of your aforementioned files. E.g.,
+```bash
+ls formatted_data/cc_tone/
+
+1000_train.json # Alpaca format - don't worry about this one anymore
+500_test.json # You will use this one for evaluation
+sft_format_1000_train.json # You will use this one for tuning
+
+# And anything for validation, you can ignore
+```
+
+### Adding New Datasets to Pull / Format Script
+The above command pulls and formats different datasets in the Alpaca format. In general, this needs to be updated per dataset being consumed, as it is dependent on the raw format of the dataset being converted.
+
+To add a new dataset, you'll need to add a new entry to the `DATASET_INFOS` in `pull_and_format_datasets.py`, which includes:
+
+- The location in the COS instance to pull from; it's assumed that all datasets live in the same COS instance
+- A formatting function which loads the raw dataset and exports it in the expected format for the task being considered; there are currently examples for entities/TSA and tone. Running the script and inspecting the Alpaca formatted examples for these datasets is the quickest way to understand the format for those tasks. Succinctly:
+    - For tone, the output per example is the labels separated by `, `, e.g., `"polite, excited, satisfied, sympathetic"`
+    - For TSA/entities, the output per example is the entities in the format `<entity>: <type>` join by `, `, e.g., `engineer: JobTitle, Thursday: Date`, or `"atmosphere: positive, drinks: neutral"`
+
+### Running a Tuning
+There are some resources for how to run a tuning against a cluster that you can find in the [wiki](https://github.com/foundation-model-stack/fms-hf-tuning/wiki/Installing-and-Testing-OpenShift-fms%E2%80%90hf%E2%80%90tuning-Stack#6-testing) which should be useful. If you are planning to run a tuning / evaluation from inside of a running container with GPUs available, the easiest way to configure your tuning job is to create a local `config.json` with your training specs that is analogous to the mounted configmap, and repoint the `SFT_TRAINER_CONFIG_JSON_PATH` env var to that local config. After doing this, you can trigger a tuning by running `python3 /app/accelerate_launch.py`.
+
+There are a few good things to be careful of here:
+
+- When tuning, make sure to use `"\n### Response:"` as your response template
+- If you see a bunch of warnings like `Could not find response key `[19371, 27]` in the following instance:`, you're doing something wrong! Most likely offenders are pointing tuning at the Alpaca data, or using the response template. This should not happen.
+- Make sure your `SFT_TRAINER_CONFIG_JSON_PATH` is pointing at the right place if you're inside of a pod with a mounted configmap, otherwise your tuning will be pointing at the wrong config!
+
+### Running Evaluation
+To run the evaluation, point the evaluation script at your exported model and test data. For example:
+
+```bash
+python3 run_evaluation.py \
+    --model <YOUR_TUNED_MODEL>  \
+    --delimiter , \
+    --data_path formatted_data/cc_tone/500_test.json \
+    --max_new_tokens 100
+```
+
+To understand the files created by the evaluation, check out the comments in this [PR](https://github.com/foundation-model-stack/fms-hf-tuning/pull/102).

--- a/scripts/pull_and_format_datasets.py
+++ b/scripts/pull_and_format_datasets.py
@@ -1,0 +1,228 @@
+"""Pulls and formats data into alpaca format. Not that each specific dataset needs its own
+formatter, since it is dependent on the format of the raw dataset being processed.
+"""
+
+# Standard
+from shutil import rmtree
+from typing import Any, Optional
+import json
+import os
+import random
+
+# Third Party
+import boto3
+
+S3_ACCESS_KEY_ID = os.getenv("S3_ACCESS_KEY_ID")
+S3_SECRET_ACCESS_KEY = os.getenv("S3_SECRET_ACCESS_KEY")
+S3_ENDPOINT = os.getenv("S3_ENDPOINT")
+if S3_ACCESS_KEY_ID is None or S3_SECRET_ACCESS_KEY is None or S3_ENDPOINT is None:
+    raise ValueError(
+        "Error - must set env vars: S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, and S3_ENDPOINT"
+    )
+
+##### data formatters
+def format_and_export_cc_tone_file(
+    file_path: str, export_path: str, num_samples: Optional[int]
+):
+    """Formats the tone dataset by comma separated labels in the output.
+
+    Args:
+        file_path: str
+            Path to tone file to be formatted.
+        export_path: str
+            Path to export the formatted data to.
+        num_samples: Optional[int]
+            Number of samples to be included in the formatted file.
+    """
+    with open(file_path, "r", encoding="utf-8") as tone_file:
+        data = [json.loads(line) for line in tone_file.readlines() if line]
+
+    export_path = export_path.split(".")[0] + ".json"
+    if num_samples:
+        data = random.sample(data, num_samples)
+        # Update the file name to prepend num samples
+        base_path, export_name = os.path.split(export_path)
+        export_path = os.path.join(base_path, f"{num_samples}_{export_name}")
+
+    formatted_data = [
+        {
+            "instruction": "",
+            "input": datum["text"],
+            "output": ", ".join(datum["labels"]),
+        }
+        for datum in data
+    ]
+    with open(export_path, "w", encoding="utf-8") as export_file:
+        json.dump(formatted_data, export_file, sort_keys=True, indent=4)
+
+
+def format_and_export_entities_file(
+    file_path: str, export_path: str, num_samples: Optional[int]
+):
+    """Formats the entites/TSA datasets by setting the output to literal "None"
+    if no target is extracted, and a comma separated list in the format
+                                {text} : {type}
+    for each extracted object.
+    Example for entities: "waitress: JobTitle"
+    Example for TSA: "waitress: positive"
+
+    Args:
+        file_path: str
+            Path to tone file to be formatted.
+        export_path: str
+            Path to export the formatted data to.
+        num_samples: Optional[int]
+            Number of samples to be included in the formatted file.
+    """
+
+    def get_entites_output_text(datum):
+        mentions = datum["mentions"]
+        if not mentions:
+            return "None"
+        mention_strs = [
+            f"{mention['text']}: {mention['type']}".replace(",", "\\,")
+            for mention in mentions
+        ]
+        return ", ".join(mention_strs)
+
+    with open(file_path, "r", encoding="utf-8") as entities_file:
+        data = json.load(entities_file)
+    if num_samples:
+        data = random.sample(data, num_samples)
+        # Update the file name to prepend num samples
+        base_path, export_name = os.path.split(export_path)
+        export_path = os.path.join(base_path, f"{num_samples}_{export_name}")
+
+    formatted_data = [
+        {
+            "instruction": "",
+            "input": datum["text"],
+            "output": get_entites_output_text(datum),
+        }
+        for datum in data
+    ]
+    with open(export_path, "w", encoding="utf-8") as export_file:
+        json.dump(formatted_data, export_file, sort_keys=True, indent=4)
+
+
+# Where we will put the downloaded data
+DOWNLOAD_DIR = "unformatted_data"
+# Where we will put the formatted data files to
+EXPORT_DIR = "formatted_data"
+
+COS_LOCATION_KEY = "cos_location"
+FORMAT_FUNC_KEY = "format_func"
+SUBSAMPLE_KEY = "subsample_info"
+DATASET_INFOS = [
+    {
+        COS_LOCATION_KEY: "fm-validation-staging-models-and-datasets/datasets/unitxt/cc_tone",
+        FORMAT_FUNC_KEY: format_and_export_cc_tone_file,
+        SUBSAMPLE_KEY: {
+            "train.jsonl": 1000,
+            "test.jsonl": 500,
+        },
+    },
+    {
+        # pylint: disable=line-too-long
+        COS_LOCATION_KEY: "fm-validation-staging-models-and-datasets/datasets/unitxt/en/Extraction/Entities",
+        FORMAT_FUNC_KEY: format_and_export_entities_file,
+        SUBSAMPLE_KEY: {
+            "IBM_NET_2019_DELIVERABLE_VERSION_C_train.json": 1000,
+            "IBM_NET_2019_DELIVERABLE_VERSION_C_test.json": 500,
+        },
+    },
+    {
+        COS_LOCATION_KEY: "fm-validation-staging-models-and-datasets/datasets/unitxt/tsa_mams",
+        FORMAT_FUNC_KEY: format_and_export_entities_file,
+        SUBSAMPLE_KEY: {
+            "train.json": 1000,
+            "test.json": 500,
+        },
+    },
+]
+
+
+def create_data_dirs():
+    """Create the directories to contain formatted/unformatted data."""
+    print("Creating data directories...")
+    if os.path.exists(DOWNLOAD_DIR):
+        rmtree(DOWNLOAD_DIR)
+    if os.path.exists(EXPORT_DIR):
+        rmtree(EXPORT_DIR)
+    os.mkdir(DOWNLOAD_DIR)
+    os.mkdir(EXPORT_DIR)
+
+
+def download_datasets(dataset_infos: list[dict[str, Any]]):
+    """Download the datasets to local disk.
+
+    Args:
+        dataset_infos: list[dict[str, Any]]
+            Structure containing information about each dataset we need to download
+            and where it lives in the connected S3 instance.
+    """
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=S3_ACCESS_KEY_ID,
+        aws_secret_access_key=S3_SECRET_ACCESS_KEY,
+        endpoint_url=S3_ENDPOINT,
+    )
+    for dataset_info in dataset_infos:
+        first_slash_idx = dataset_info[COS_LOCATION_KEY].find("/")
+        bucket_name = dataset_info[COS_LOCATION_KEY][:first_slash_idx]
+        cos_path = dataset_info[COS_LOCATION_KEY][first_slash_idx + 1 :]
+        # Make the subdir to download files into...
+        download_subdir = os.path.join(DOWNLOAD_DIR, cos_path.split(os.sep)[-1])
+        os.mkdir(download_subdir)
+        print(f"Downloading files for {download_subdir}")
+        # Download the unformatted data files...
+        bucket = s3.Bucket(bucket_name)
+        for obj in bucket.objects.filter(Prefix=cos_path):
+            if obj.key[-1] == "/":
+                continue
+            target_path = os.path.join(download_subdir, obj.key.split("/")[-1])
+            bucket.download_file(obj.key, target_path)
+
+
+def apply_data_formatters(dataset_infos: list[dict[str, Any]]):
+    """Formats each of the downloaded datasets.
+
+    Args:
+        dataset_infos: list[dict[str, Any]]
+            Structure containing information about each dataset we need to format.
+    """
+    for dataset_info in dataset_infos:
+        subdir = dataset_info[COS_LOCATION_KEY].split(os.sep)[-1]
+        download_subdir = os.path.join(DOWNLOAD_DIR, subdir)
+        # Make the dir to export files to
+        export_subdir = os.path.join(EXPORT_DIR, subdir)
+        os.mkdir(export_subdir)
+
+        data_files = [
+            os.path.join(download_subdir, filename)
+            for filename in os.listdir(download_subdir)
+        ]
+        for data_file in data_files:
+            # Apply this datasets formatter to the data file
+            export_path = os.path.join(
+                EXPORT_DIR, data_file[data_file.index(os.sep) + 1 :]
+            )
+            dataset_info[SUBSAMPLE_KEY]
+            # This is silly :)
+            filename = os.path.split(data_file)[-1]
+            num_samples = (
+                dataset_info[SUBSAMPLE_KEY][filename]
+                if filename in dataset_info[SUBSAMPLE_KEY]
+                else None
+            )
+            if num_samples:
+                print(f"--> File: {data_file} will be subsampled to {num_samples}")
+                # make sure the split is deterministic
+                random.seed(42)
+            dataset_info[FORMAT_FUNC_KEY](data_file, export_path, num_samples)
+
+
+if __name__ == "__main__":
+    create_data_dirs()
+    download_datasets(DATASET_INFOS)
+    apply_data_formatters(DATASET_INFOS)

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -1,0 +1,172 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit Tests for accelerate_launch script.
+"""
+
+# Standard
+import base64
+import os
+import pickle
+import tempfile
+
+# Third Party
+import pytest
+
+# First Party
+from build.accelerate_launch import main
+from build.utils import INTERNAL_ERROR_EXIT_CODE, USER_ERROR_EXIT_CODE
+from tests.data import TWITTER_COMPLAINTS_DATA
+
+SCRIPT = "build/launch_training.py"
+MODEL_NAME = "Maykeye/TinyLLama-v0"
+BASE_PEFT_KWARGS = {
+    "model_name_or_path": MODEL_NAME,
+    "training_data_path": TWITTER_COMPLAINTS_DATA,
+    "num_train_epochs": 5,
+    "per_device_train_batch_size": 4,
+    "per_device_eval_batch_size": 4,
+    "gradient_accumulation_steps": 4,
+    "learning_rate": 0.00001,
+    "weight_decay": 0,
+    "warmup_ratio": 0.03,
+    "lr_scheduler_type": "cosine",
+    "logging_steps": 1,
+    "include_tokens_per_second": True,
+    "packing": False,
+    "response_template": "\n### Label:",
+    "dataset_text_field": "output",
+    "use_flash_attn": False,
+    "torch_dtype": "float32",
+    "max_seq_length": 4096,
+    "peft_method": "pt",
+    "prompt_tuning_init": "RANDOM",
+    "num_virtual_tokens": 8,
+    "prompt_tuning_init_text": "hello",
+    "tokenizer_name_or_path": MODEL_NAME,
+    "save_strategy": "epoch",
+    "output_dir": "tmp",
+}
+
+
+def serialize_args(args_json):
+    message_bytes = pickle.dumps(args_json)
+    base64_bytes = base64.b64encode(message_bytes)
+    return base64_bytes.decode("ascii")
+
+
+def setup_env(tempdir):
+    os.environ["LAUNCH_TRAINING_SCRIPT"] = SCRIPT
+    os.environ["PYTHONPATH"] = "./:$PYTHONPATH"
+    os.environ["TERMINATION_LOG_FILE"] = tempdir + "/termination-log"
+
+
+def cleanup_env():
+    os.environ.pop("LAUNCH_TRAINING_SCRIPT", None)
+    os.environ.pop("PYTHONPATH", None)
+    os.environ.pop("TERMINATION_LOG_FILE", None)
+
+
+def test_successful_pt():
+    """Check if we can bootstrap and peft tune causallm models"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+
+        assert main() == 0
+        assert os.path.exists(tempdir + "/termination-log") is False
+
+
+def test_bad_script_path():
+    """Check for appropriate error for an invalid training script location"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {**BASE_PEFT_KWARGS, **{"output_dir": tempdir}}
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        os.environ["LAUNCH_TRAINING_SCRIPT"] = "/not/here"
+
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == INTERNAL_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_blank_env_var():
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = ""
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_faulty_file_path():
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        faulty_path = os.path.join(tempdir, "non_existent_file.pkl")
+        TRAIN_KWARGS = {
+            **BASE_PEFT_KWARGS,
+            **{"training_data_path": faulty_path, "output_dir": tempdir},
+        }
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_bad_base_model_path():
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {
+            **BASE_PEFT_KWARGS,
+            **{"model_name_or_path": "/wrong/path"},
+        }
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_config_parsing_error():
+    with tempfile.TemporaryDirectory() as tempdir:
+        setup_env(tempdir)
+        TRAIN_KWARGS = {
+            **BASE_PEFT_KWARGS,
+            **{"num_train_epochs": "five"},
+        }  # Intentional type error
+        serialized_args = serialize_args(TRAIN_KWARGS)
+        os.environ["SFT_TRAINER_CONFIG_JSON_ENV_VAR"] = serialized_args
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main()
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == USER_ERROR_EXIT_CODE
+        assert os.stat(tempdir + "/termination-log").st_size > 0
+
+
+def test_cleanup():
+    # This runs to unset env variables that could disrupt other tests
+    cleanup_env()
+    assert True

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -88,6 +88,7 @@ def test_successful_pt():
 
         assert main() == 0
         assert os.path.exists(tempdir + "/termination-log") is False
+        assert os.path.exists(os.path.join(tempdir, ".complete")) is True
 
 
 def test_bad_script_path():

--- a/tests/data/trainercontroller/__init__.py
+++ b/tests/data/trainercontroller/__init__.py
@@ -29,6 +29,9 @@ TRAINER_CONFIG_EXPOSED_METRICS_YAML = os.path.join(_DATA_DIR, "exposed_metrics.y
 TRAINER_CONFIG_INCORRECT_SOURCE_EVENT_EXPOSED_METRICS_YAML = os.path.join(
     _DATA_DIR, "incorrect_source_event_exposed_metrics.yaml"
 )
+TRAINER_CONFIG_TEST_INVALID_TYPE_RULE_YAML = os.path.join(
+    _DATA_DIR, "loss_with_invalid_type_rule.yaml"
+)
 TRAINER_CONFIG_TEST_MALICIOUS_OS_RULE_YAML = os.path.join(
     _DATA_DIR, "loss_with_malicious_os_rule.yaml"
 )

--- a/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
+++ b/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
@@ -1,0 +1,10 @@
+controller-metrics:
+  - name: loss
+    class: Loss
+controllers:
+  - name: loss-controller-wrong-os-rule
+    triggers:
+      - on_log
+    rule: "2+2"
+    operations:
+      - hfcontrols.should_training_stop

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,9 +42,4 @@ def causal_lm_train_kwargs(train_kwargs):
         tuning_config = lora_config
     elif train_kwargs.get("peft_method") == "pt":
         tuning_config = prompt_tuning_config
-    return (
-        model_args,
-        data_args,
-        training_args,
-        tuning_config
-    )
+    return (model_args, data_args, training_args, tuning_config)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -37,11 +37,14 @@ def causal_lm_train_kwargs(train_kwargs):
         lora_config,
         prompt_tuning_config,
     ) = parser.parse_dict(train_kwargs, allow_extra_keys=True)
+    tuning_config = None
+    if train_kwargs.get("peft_method") == "lora":
+        tuning_config = lora_config
+    elif train_kwargs.get("peft_method") == "pt":
+        tuning_config = prompt_tuning_config
     return (
         model_args,
         data_args,
         training_args,
-        lora_config
-        if train_kwargs.get("peft_method") == "lora"
-        else prompt_tuning_config,
+        tuning_config
     )

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -277,6 +277,9 @@ def test_run_causallm_ft_and_inference():
         model_args, data_args, training_args, tune_config = causal_lm_train_kwargs(
             BASE_FT_KWARGS
         )
+        # Just assuring no tuning config is passed for PT or LoRA
+        assert tune_config is None
+
         sft_trainer.train(model_args, data_args, training_args, tune_config)
 
         # validate ft tuning configs
@@ -294,6 +297,7 @@ def test_run_causallm_ft_and_inference():
         assert "### Text: @NortonSupport Thanks much.\n\n### Label:" in output_inference
 
 
+############################# Helper functions #############################
 def _validate_training(tempdir, check_eval=False):
     assert any(x.startswith("checkpoint-") for x in os.listdir(tempdir))
     train_logs_file_path = "{}/training_logs.jsonl".format(tempdir)
@@ -331,6 +335,7 @@ def _validate_adapter_config(adapter_config, peft_type, base_kwargs):
     )
 
 
+############################# Other Tests #############################
 ### Tests for a variety of edge cases and potentially problematic cases;
 # some of these test directly test validation within external dependencies
 # and validate errors that we expect to get from them which might be unintuitive.

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -68,7 +68,7 @@ BASE_LORA_KWARGS = copy.deepcopy(BASE_PEFT_KWARGS)
 BASE_LORA_KWARGS["peft_method"] = "lora"
 
 BASE_FT_KWARGS = copy.deepcopy(BASE_PEFT_KWARGS)
-del BASE_FT_KWARGS["peft_method"]
+BASE_FT_KWARGS["peft_method"] = None
 del BASE_FT_KWARGS["prompt_tuning_init"]
 del BASE_FT_KWARGS["prompt_tuning_init_text"]
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -34,6 +34,7 @@ from tests.helpers import causal_lm_train_kwargs
 
 # Local
 from tuning import sft_trainer
+from tuning.config import peft_config
 
 MODEL_NAME = "Maykeye/TinyLLama-v0"
 BASE_PEFT_KWARGS = {
@@ -95,6 +96,15 @@ def test_helper_causal_lm_train_kwargs():
     assert tune_config.prompt_tuning_init_text == "hello"
     assert tune_config.tokenizer_name_or_path == MODEL_NAME
     assert tune_config.num_virtual_tokens == 8
+
+    model_args, data_args, training_args, tune_config = causal_lm_train_kwargs(
+        BASE_FT_KWARGS
+    )
+    assert tune_config is None
+    model_args, data_args, training_args, tune_config = causal_lm_train_kwargs(
+        BASE_LORA_KWARGS
+    )
+    assert isinstance(tune_config, peft_config.LoraConfig)
 
 
 def test_run_train_requires_output_dir():

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -68,9 +68,9 @@ BASE_LORA_KWARGS = copy.deepcopy(BASE_PEFT_KWARGS)
 BASE_LORA_KWARGS["peft_method"] = "lora"
 
 BASE_FT_KWARGS = copy.deepcopy(BASE_PEFT_KWARGS)
-BASE_FT_KWARGS["peft_method"] = ""
-BASE_FT_KWARGS["prompt_tuning_init"] = ""
-BASE_FT_KWARGS["prompt_tuning_init_text"] = ""
+del BASE_FT_KWARGS["peft_method"]
+del BASE_FT_KWARGS["prompt_tuning_init"]
+del BASE_FT_KWARGS["prompt_tuning_init_text"]
 
 
 def test_helper_causal_lm_train_kwargs():
@@ -282,8 +282,6 @@ def test_run_causallm_ft_and_inference():
         # validate ft tuning configs
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
-        adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING", BASE_FT_KWARGS)
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path)

--- a/tests/utils/test_evaluator.py
+++ b/tests/utils/test_evaluator.py
@@ -1,0 +1,166 @@
+# Copyright The IBM Tuning Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+# Standard
+from typing import Tuple
+
+# Third Party
+import numpy as np
+import pytest
+
+# Local
+from tuning.utils.evaluator import get_evaluator
+
+
+def test_mailicious_inputs_to_eval():
+    """Tests the malicious rules"""
+    rules: list[Tuple[str, bool, str]] = [
+        # Valid rules
+        ("", False, "flags['is_training'] == False"),
+        ("", False, "not flags['is_training']"),
+        ("", True, "-10 < loss"),
+        ("", True, "+1000 > loss"),
+        ("", True, "~1000 < loss"),
+        ("", True, "(10 + 10) < loss"),
+        ("", True, "(20 - 10) < loss"),
+        ("", True, "(20/10) < loss"),
+        ("", True, "(20 % 10) < loss"),
+        ("", False, "loss < 1.0"),
+        ("", False, "(loss < 1.0)"),
+        ("", False, "loss*loss < 1.0"),
+        ("", False, "loss*loss*loss < 1.0"),
+        ("", False, "(loss*loss)*loss < 1.0"),
+        ("", True, "int(''.join(['3', '4'])) < loss"),
+        ("", True, "loss < 9**9"),
+        ("", False, "loss < sqrt(xs[0]*xs[0] + xs[1]*xs[1])"),
+        ("", True, "len(xs) > 2"),
+        ("", True, "loss < abs(-100)"),
+        ("", True, "loss == flags.aaa.bbb[0].ccc"),
+        ("", True, "array3d[0][1][1] == 4"),
+        ("", True, "numpyarray[0][1][1] == 4"),
+        (
+            "",
+            True,
+            "len(xs) == 4 and xs[0] == 1 and (xs[1] == 0 or xs[2] == 0) and xs[3] == 2",
+        ),
+        # Invalid rules
+        (
+            "'aaa' is not defined for expression 'loss == aaa.bbb[0].ccc'",
+            False,
+            "loss == aaa.bbb[0].ccc",
+        ),
+        ("0", False, "loss == flags[0].ccc"),  # KeyError
+        (
+            "Attribute 'ddd' does not exist in expression 'loss == flags.ddd[0].ccc'",
+            False,
+            "loss == flags.ddd[0].ccc",
+        ),
+        (
+            "Sorry, access to __attributes  or func_ attributes is not available. (__class__)",
+            False,
+            "'x'.__class__",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            # Try to instantiate and call Quitter
+            "().__class__.__base__.__subclasses__()[141]('', '')()",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            # pylint: disable=line-too-long
+            "[x for x in ().__class__.__base__.__subclasses__() if x.__name__ == 'Quitter'][0]('', '')()",
+        ),
+        (
+            "Function 'getattr' not defined, for expression 'getattr((), '__class__')'.",
+            False,
+            "getattr((), '__class__')",
+        ),
+        (
+            "Function 'getattr' not defined, for expression 'getattr((), '_' '_class_' '_')'.",
+            False,
+            "getattr((), '_' '_class_' '_')",
+        ),
+        (
+            "Sorry, I will not evalute something that long.",
+            False,
+            '["hello"]*10000000000',
+        ),
+        (
+            "Sorry, I will not evalute something that long.",
+            False,
+            "'i want to break free'.split() * 9999999999",
+        ),
+        (
+            "Lambda Functions not implemented",
+            False,
+            "(lambda x='i want to break free'.split(): x * 9999999999)()",
+        ),
+        (
+            "Sorry, NamedExpr is not available in this evaluator",
+            False,
+            "(x := 'i want to break free'.split()) and (x * 9999999999)",
+        ),
+        ("Sorry! I don't want to evaluate 9 ** 387420489", False, "9**9**9**9"),
+        (
+            "Function 'mymetric1' not defined, for expression 'mymetric1() > loss'.",
+            True,
+            "mymetric1() > loss",
+        ),
+        (
+            "Function 'mymetric2' not defined, for expression 'mymetric2(loss) > loss'.",
+            True,
+            "mymetric2(loss) > loss",
+        ),
+    ]
+    metrics = {
+        "loss": 42.0,
+        "flags": {"is_training": True, "aaa": {"bbb": [{"ccc": 42.0}]}},
+        "xs": [1, 0, 0, 2],
+        "array3d": [
+            [
+                [1, 2],
+                [3, 4],
+            ],
+            [
+                [5, 6],
+                [7, 8],
+            ],
+        ],
+        "numpyarray": (np.arange(8).reshape((2, 2, 2)) + 1),
+    }
+
+    evaluator = get_evaluator(metrics=metrics)
+
+    for validation_error, expected_rule_is_true, rule in rules:
+        rule_parsed = evaluator.parse(expr=rule)
+        if validation_error == "":
+            actual_rule_is_true = evaluator.eval(
+                expr=rule,
+                previously_parsed=rule_parsed,
+            )
+            assert (
+                actual_rule_is_true == expected_rule_is_true
+            ), "failed to execute the rule"
+        else:
+            with pytest.raises(Exception) as exception_handler:
+                evaluator.eval(
+                    expr=rule,
+                    previously_parsed=rule_parsed,
+                )
+            assert str(exception_handler.value) == validation_error

--- a/tuning/trainercontroller/control.py
+++ b/tuning/trainercontroller/control.py
@@ -18,6 +18,7 @@
 # Standard
 from dataclasses import dataclass
 from typing import List, Optional
+import ast
 
 # Local
 from tuning.trainercontroller.operations import Operation
@@ -36,5 +37,6 @@ class Control:
     """Stores the name of control, rule byte-code corresponding actions"""
 
     name: str
-    rule: Optional[object] = None  # stores bytecode of the compiled rule
+    rule_str: str
+    rule: Optional[ast.AST] = None  # stores the abstract syntax tree of the parsed rule
     operation_actions: Optional[List[OperationAction]] = None

--- a/tuning/utils/evaluator.py
+++ b/tuning/utils/evaluator.py
@@ -1,0 +1,20 @@
+# Standard
+from math import sqrt
+
+# Third Party
+from simpleeval import DEFAULT_FUNCTIONS, DEFAULT_NAMES, EvalWithCompoundTypes
+
+
+def get_evaluator(metrics: dict) -> EvalWithCompoundTypes:
+    """Returns an evaluator that can be used to evaluate simple Python expressions."""
+    all_names = {
+        **metrics,
+        **DEFAULT_NAMES.copy(),
+    }
+    all_funcs = {
+        "abs": abs,
+        "len": len,
+        "sqrt": sqrt,
+        **DEFAULT_FUNCTIONS.copy(),
+    }
+    return EvalWithCompoundTypes(functions=all_funcs, names=all_names)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
- Removing the AIM component for now so FIPS tolerance works.
- Moving the dnf update to the end as I noticed it missed at least one package that was later installed.
- Removing the old python3.9 items (and dnf) as we're using python3.11 and the legacy python3.9 is causing CVE violations.  Attempts at upgrading python3.9 was causing many conflicts.

<!-- Please summarize the changes -->

### Related issue number
Closes issue https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/828
<!-- For example: "Closes #1234" -->

### How to verify the PR
I'm testing this on my Fyre FIPS OpenShift Cluster using the steps outlined in the wiki here:
https://github.com/foundation-model-stack/fms-hf-tuning/wiki/Installing-and-Testing-OpenShift-fms%E2%80%90hf%E2%80%90tuning-Stack

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested
TBD, in process now.

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass