### PR TITLE
Comment out aim in dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -123,7 +123,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade pip && \
     python -m pip install wheel && \
     python -m pip install "$(head bdist_name)" && \
-    python -m pip install "$(head bdist_name)[aim]" && \
+    # Due to FIPS tolerance issues, removing aim at this time
+    #python -m pip install "$(head bdist_name)[aim]" && \
     python -m pip install "$(head bdist_name)[flash-attn]" && \
     # Clean up the wheel module. It's only needed by flash-attn install
     python -m pip uninstall wheel -y && \


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
This comments out the AIM module so that it's not installed.  This has two benefits:
1. As AIM isn't FIPS tolerant yet, it's removal allows the fms-hf-training image to run on a FIPS cluster without errors.
2. The (now) unused AIM module won't be installed and end up potentially causing CVE issues later.

<!-- Please summarize the changes -->

### Related issue number
Closes issue [842](https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/842)

### How to verify the PR
I built it and ran it using these steps on my OpenShift cluster:

```
git clone https://github.com/jbusche/fms-hf-tuning -b jb-remove-aim-issue842
cd fms-hf-tuning/

docker build --progress=plain -t fms-hf-tuning:jim-0510-noaim . -f build/Dockerfile

podman login -u kubeadmin -p $(oc whoami -t) $(oc registry info) --tls-verify=false
podman tag localhost/fms-hf-tuning:jim-0510-noaim  $(oc registry info)/opendatahub/fms-hf-tuning:jim-0510-noaim
podman push  --tls-verify=false $(oc registry info)/opendatahub/fms-hf-tuning:jim-0510-noaim
```

Then I ran the following script:
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-config
  namespace: default
data:
  config.json: |
    {
      "accelerate_launch_args": {
        "num_machines": 1,
        "num_processes": 2
      },
      "model_name_or_path": "bigscience/bloom-560m",
      "training_data_path": "/etc/config/twitter_complaints_small.json",
      "output_dir": "/tmp/out",
      "num_train_epochs": 1.0,
      "per_device_train_batch_size": 4,
      "per_device_eval_batch_size": 4,
      "gradient_accumulation_steps": 4,
      "evaluation_strategy": "no",
      "save_strategy": "epoch",
      "learning_rate": 1e-5,
      "weight_decay": 0.0,
      "lr_scheduler_type": "cosine",
      "logging_steps": 1.0,
      "packing": false,
      "include_tokens_per_second": true,
      "response_template": "\n### Label:",
      "dataset_text_field": "output",
      "use_flash_attn": false,
      "torch_dtype": "float32",
      "peft_method": "pt",
      "tokenizer_name_or_path": "bigscience/bloom"
    }
  twitter_complaints_small.json: |
    {"Tweet text":"@HMRCcustomers No this is my first job","ID":0,"Label":2,"text_label":"no complaint","output":"### Text: @HMRCcustomers No this is my first job\n\n### Label: no complaint"}
    {"Tweet text":"@KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.","ID":1,"Label":2,"text_label":"no complaint","output":"### Text: @KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.\n\n### Label: no complaint"}
    {"Tweet text":"If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService","ID":2,"Label":1,"text_label":"complaint","output":"### Text: If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService\n\n### Label: complaint"}
    {"Tweet text":"@EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.","ID":3,"Label":1,"text_label":"complaint","output":"### Text: @EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.\n\n### Label: complaint"}
    {"Tweet text":"Couples wallpaper, so cute. :) #BrothersAtHome","ID":4,"Label":2,"text_label":"no complaint","output":"### Text: Couples wallpaper, so cute. :) #BrothersAtHome\n\n### Label: no complaint"}
    {"Tweet text":"@mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG","ID":5,"Label":2,"text_label":"no complaint","output":"### Text: @mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG\n\n### Label: no complaint"}
    {"Tweet text":"@Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?","ID":6,"Label":2,"text_label":"no complaint","output":"### Text: @Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?\n\n### Label: no complaint"}
    {"Tweet text":"@nationalgridus I have no water and the bill is current and paid. Can you do something about this?","ID":7,"Label":1,"text_label":"complaint","output":"### Text: @nationalgridus I have no water and the bill is current and paid. Can you do something about this?\n\n### Label: complaint"}
    {"Tweet text":"Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora","ID":8,"Label":1,"text_label":"complaint","output":"### Text: Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora\n\n### Label: complaint"}
    {"Tweet text":"@JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd","ID":9,"Label":2,"text_label":"no complaint","output":"### Text: @JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd\n\n### Label: no complaint"}
---
apiVersion: "kubeflow.org/v1"
kind: PyTorchJob
metadata:
  name: ted-kfto-sft
  namespace: default
  labels:
    kueue.x-k8s.io/queue-name: lq-trainer
spec:
  pytorchReplicaSpecs:
    Master:
      replicas: 1
      restartPolicy: Never # Do not restart the pod on failure. If you do set it to OnFailure, be sure to also set backoffLimit
      template:
        spec:
          containers:
            - name: pytorch
              # This is the temp location util image is officially released
              image: image-registry.openshift-image-registry.svc:5000/opendatahub/fms-hf-tuning:jim-0510-noaim
              imagePullPolicy: IfNotPresent
              command:
                - "python"
                - "/app/accelerate_launch.py"
              env:
                - name: SFT_TRAINER_CONFIG_JSON_PATH
                  value: /etc/config/config.json
              volumeMounts:
              - name: config-volume
                mountPath: /etc/config
          volumes:
          - name: config-volume
            configMap:
              name: my-config
              items:
              - key: config.json
                path: config.json
              - key: twitter_complaints_small.json
                path: twitter_complaints_small.json
EOF
```

and it ran to completion on the FIPS cluster:
```
oc get pods,pytorchjobs                                                                              api.fips-test.cp.fyre.ibm.com: Fri May 10 14:53:04 2024

NAME                        READY   STATUS	RESTARTS   AGE
pod/ted-kfto-sft-master-0   0/1     Completed   0          9m40s

NAME                                   STATE	   AGE
pytorchjob.kubeflow.org/ted-kfto-sft   Succeeded   9m40s
```
The logs looked good (No FIPS error messages)
```
oc logs -f ted-kfto-sft-master-0
WARNING:root:SET_NUM_PROCESSES_TO_NUM_GPUS=True, overwriting user set num_processes 2                to all GPUs available, 0.
WARNING:root:num_processes param was not passed in. Value from config file (if available) will                 be used or accelerate launch will determine number of processes automatically
WARNING:accelerate.commands.launch:The following values were not passed to `accelerate launch` and had defaults used instead:
	`--num_processes` was set to a value of `0`
	`--mixed_precision` was set to a value of `'no'`
	`--dynamo_backend` was set to a value of `'no'`
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
/usr/local/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
Generating train split: 10 examples [00:00, 2753.25 examples/s]
Map: 100%|██████████| 10/10 [00:00<00:00, 1163.05 examples/s]
Map: 100%|██████████| 10/10 [00:00<00:00, 1719.75 examples/s]
/usr/local/lib/python3.11/site-packages/trl/trainer/sft_trainer.py:318: UserWarning: You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code.
  warnings.warn(
100%|██████████| 1/1 [00:26<00:00, 26.23s/it]{'loss': 4.8081, 'grad_norm': 17.73297119140625, 'learning_rate': 0.0, 'epoch': 1.0}
100%|██████████| 1/1 [00:26<00:00, 26.23s/it]/usr/local/lib/python3.11/site-packages/peft/utils/save_and_load.py:168: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'train_runtime': 30.5609, 'train_samples_per_second': 0.327, 'train_steps_per_second': 0.033, 'train_tokens_per_second': 15.248, 'train_loss': 4.808052062988281, 'epoch': 1.0}
100%|██████████| 1/1 [00:30<00:00, 30.56s/it]
```

### Was the PR tested
Yes, as above.
<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass