### PR TITLE
fix: merging of model for multi-gpu

### DIFF
--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -98,12 +98,13 @@ def main():
                 export_path,
             )
 
-            create_merged_model(
-                checkpoint_models=full_checkpoint_dir,
-                export_path=export_path,
-                base_model=model_args.model_name_or_path,
-                save_tokenizer=True,
-            )
+            if os.path.exists(os.path.join(full_checkpoint_dir, "adapter_config.json")):
+                create_merged_model(
+                    checkpoint_models=full_checkpoint_dir,
+                    export_path=export_path,
+                    base_model=model_args.model_name_or_path,
+                    save_tokenizer=True,
+                )
         else:
             # copy last checkpoint into mounted output dir
             pt_checkpoint_dir = get_highest_checkpoint(training_args.output_dir)

--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -142,7 +142,10 @@ def main():
                     export_path,
                 )
 
-                if os.path.exists(os.path.join(full_checkpoint_dir, "adapter_config.json")):
+                # ensure checkpoint dir has correct files, important with multi-gpu tuning
+                if os.path.exists(
+                    os.path.join(full_checkpoint_dir, "adapter_config.json")
+                ):
                     create_merged_model(
                         checkpoint_models=full_checkpoint_dir,
                         export_path=export_path,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->
Fixes error in merging lora tuned checkpoint when running on multi-GPU. 
```
File "/app/launch_training.py", line 89, in main
    create_merged_model(
  File "/usr/local/lib/python3.11/site-packages/tuning/utils/merge_model_utils.py", line 70, in create_merged_model
    model = PeftModel.from_pretrained(model, checkpoint_model)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/peft/peft_model.py", line 328, in from_pretrained
    PeftConfig._get_peft_type(
  File "/usr/local/lib/python3.11/site-packages/peft/config.py", line 203, in _get_peft_type
    raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
ValueError: Can't find 'adapter_config.json' at '/tmp/tmppvqpid1c/checkpoint-1670'
```

When running lora tuning on multi-GPU, the tempdir is created for the number of GPUs running on with the top level checkpoint directories, however the actual checkpoint only exists in one of the temp dirs. For example you can see in a running example:
```
$  ls /tmp
fms-hf-tuning  tmp5mdh06bv  tmp90e3l6to  tmplp0k_bkf  tmpv6g500ew  torchelastic_ngc8krfe
tmp3evs8vcg    tmp8yw4a4p_  tmp9dp47ap_  tmpu4z3hd3o  tmpvkvbq3kt

# checkpoint dirs created but are empty
$ ls /tmp/tmp90e3l6to
checkpoint-1000  checkpoint-1625  checkpoint-2375  checkpoint-3000  checkpoint-375   checkpoint-4375  checkpoint-625
checkpoint-1125  checkpoint-1750  checkpoint-250   checkpoint-3125  checkpoint-3750  checkpoint-4500  checkpoint-750
checkpoint-125	 checkpoint-1875  checkpoint-2500  checkpoint-3250  checkpoint-3875  checkpoint-4625  checkpoint-875
checkpoint-1250  checkpoint-2000  checkpoint-2625  checkpoint-3375  checkpoint-4000  checkpoint-4750
checkpoint-1375  checkpoint-2125  checkpoint-2750  checkpoint-3500  checkpoint-4125  checkpoint-4875
checkpoint-1500  checkpoint-2250  checkpoint-2875  checkpoint-3625  checkpoint-4250  checkpoint-500
$ ls /tmp/tmp90e3l6to/checkpoint-1000/
rng_state_3.pth

# only one of the temp dirs actually has the checkpoint in it
$ ls /tmp/tmp9dp47ap_
checkpoint-1000  checkpoint-1625  checkpoint-2375  checkpoint-3000  checkpoint-375   checkpoint-4375  checkpoint-625
checkpoint-1125  checkpoint-1750  checkpoint-250   checkpoint-3125  checkpoint-3750  checkpoint-4500  checkpoint-750
checkpoint-125	 checkpoint-1875  checkpoint-2500  checkpoint-3250  checkpoint-3875  checkpoint-4625  checkpoint-875
checkpoint-1250  checkpoint-2000  checkpoint-2625  checkpoint-3375  checkpoint-4000  checkpoint-4750  training_logs.jsonl
checkpoint-1375  checkpoint-2125  checkpoint-2750  checkpoint-3500  checkpoint-4125  checkpoint-4875
checkpoint-1500  checkpoint-2250  checkpoint-2875  checkpoint-3625  checkpoint-4250  checkpoint-500
$ ls /tmp/tmp9dp47ap_/checkpoint-1000/
README.md		   optimizer.bin	   scheduler.pt		    tokenizer_config.json
adapter_config.json	   pytorch_model_fsdp.bin  special_tokens_map.json  trainer_state.json
adapter_model.safetensors  rng_state_0.pth	   tokenizer.json	    training_args.bin
```

Same error fixed before in PR #114  with copying over the final loss logs.

Note that this isn't an issue for multi-GPU FT since that runs `shutil.copytree()` which can copy the empty directories and the real checkpoint directory.

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Testing PR currently, the other changes are causing FSDP errors when running with multi-GPU

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass