### PR TITLE
fix: check if output dir exists

### DIFF
--- a/build/launch_training.py
+++ b/build/launch_training.py
@@ -190,7 +190,8 @@ def main():
                 shutil.copy(train_logs_filepath, original_output_dir)
             # The .complete file will signal to users that we are finished copying
             # files over
-            Path(os.path.join(original_output_dir, ".complete")).touch()
+            if os.path.exists(original_output_dir):
+                Path(os.path.join(original_output_dir, ".complete")).touch()
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

For multi-gpu lora tuning, the output dir may not exist yet for all the processes, thus resulting in error:
```
INFO:root:Merging lora tuned checkpoint checkpoint-1250 with base model into output path: /data/anhuong/tuning_output/llama-13b-lora-tone-multi-gpu-test-image
ERROR:root:Traceback (most recent call last):
  File "/app/launch_training.py", line 193, in main
    Path(os.path.join(original_output_dir, ".complete")).touch()
  File "/usr/lib64/python3.11/pathlib.py", line 1108, in touch
    fd = os.open(self, flags, mode)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/data/anhuong/tuning_output/llama-13b-lora-tone-multi-gpu-test-image/.complete'
```

Note that all of this should be alleviated with the upcoming refactor since this copying will only happen once outside of the multi-gpu tuning.

Built 0.1.0-rc.1 into sft-trainer image and ran to find this bug.