### PR TITLE
fix: bloom model can't run with flash-attn

### DIFF
--- a/examples/kfto-kueue-sft-trainer.yaml
+++ b/examples/kfto-kueue-sft-trainer.yaml
@@ -15,7 +15,8 @@ data:
       "gradient_accumulation_steps": 4,
       "learning_rate": 1e-05,
       "response_template": "\n### Label:",
-      "dataset_text_field": "output"
+      "dataset_text_field": "output",
+      "use_flash_attn": false
     }
 ---
 apiVersion: "kubeflow.org/v1"


### PR DESCRIPTION
Fixes the KFTO example so it is a fully functional test that users can run with. Bloom model can't run with flash-attn set.