### PR TITLE
Fix additional callbacks

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -23,6 +23,7 @@ import tempfile
 
 # Third Party
 from datasets.exceptions import DatasetGenerationError
+from transformers.trainer_callback import TrainerCallback
 import pytest
 import torch
 import transformers
@@ -620,8 +621,6 @@ def test_bad_torch_dtype():
 
 def test_run_with_additional_callbacks():
     """Ensure that train() can work with additional_callbacks"""
-    # Third Party
-    from transformers.trainer_callback import TrainerCallback
 
     with tempfile.TemporaryDirectory() as tempdir:
         train_args = copy.deepcopy(TRAIN_ARGS)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -616,3 +616,22 @@ def test_bad_torch_dtype():
 
         with pytest.raises(ValueError):
             sft_trainer.train(model_args, DATA_ARGS, train_args, PEFT_PT_ARGS)
+
+
+def test_run_with_additional_callbacks():
+    """Ensure that train() can work with additional_callbacks"""
+    # Third Party
+    from transformers.trainer_callback import TrainerCallback
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args.output_dir = tempdir
+        model_args = copy.deepcopy(MODEL_ARGS)
+
+        sft_trainer.train(
+            model_args,
+            DATA_ARGS,
+            train_args,
+            PEFT_PT_ARGS,
+            additional_callbacks=[TrainerCallback()],
+        )

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -150,7 +150,7 @@ def train(
 
     # Add any extra callback if passed by users
     if additional_callbacks is not None:
-        trainer_callbacks.append(additional_callbacks)
+        trainer_callbacks.extend(additional_callbacks)
 
     framework = AccelerationFrameworkConfig.from_dataclasses(
         quantized_lora_config, fusedops_kernels_config


### PR DESCRIPTION


<!-- Thank you for the contribution! -->

### Description of the change

Fixes a small bug in the method of train() sft_trainer.py where trainer_callbacks would append an array of user provided callbacks instead of concatenating the 2 arrays.

Without this change you get this exception:

```
self = <transformers.trainer_callback.CallbackHandler object at 0x32b558fa0>
event = 'on_init_end'
args = TrainingArguments(output_dir='/var/folders/p_/lhp3_gn503l7djn80tdzkf3h0000gn/T/tmpu2qek8_i', overwrite_output_dir=Fals...t_modules=None, batch_eval_metrics=False, cache_dir=None, max_seq_length=4096, packing=False, trackers=['file_logger'])
state = TrainerState(epoch=None, global_step=0, max_steps=0, logging_steps=500, eval_steps=500, save_steps=500, train_batch_si..., 'should_epoch_stop': False, 'should_save': False, 'should_evaluate': False, 'should_log': False}, 'attributes': {}}})
control = TrainerControl(should_training_stop=False, should_epoch_stop=False, should_save=False, should_evaluate=False, should_log=False)
kwargs = {}
callback = [<transformers.trainer_callback.TrainerCallback object at 0x30f3508e0>]
result = None

    def call_event(self, event, args, state, control, **kwargs):
        for callback in self.callbacks:
>           result = getattr(callback, event)(
                args,
                state,
                control,
                model=self.model,
                tokenizer=self.tokenizer,
                optimizer=self.optimizer,
                lr_scheduler=self.lr_scheduler,
                train_dataloader=self.train_dataloader,
                eval_dataloader=self.eval_dataloader,
                **kwargs,
            )
E           AttributeError: 'list' object has no attribute 'on_init_end'

../venv/lib/python3.10/site-packages/transformers/trainer_callback.py:498: AttributeError
```

### Related issue number

Contributes to #142

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Invoke the train() method with an `additional_callbacks` parameter that's an array containing at least 1 callback.

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass