### PR TITLE
Update trl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",
 "tqdm>=4.66.2,<5.0",
-"trl==0.8.6",
+"trl>=0.9.3,<1.0",
 "peft>=0.8.0,<0.13",
 "datasets>=2.15.0,<3.0",
 "fire>=0.5.0,<1.0",


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Updates TRL to more recent versions - some changes are needed here because there is a check inside of more recent versions of TRL to see if the train arg type is a `TrainingArguments` object, which is a naming collision between a custom class we have and the training arguments in Transformers, which are the superclass for the SFT config.

In the future, we should explore renaming this class to not be so confusing, and potentially split it up to avoid passing things not used by the trainer as part of the trainer args, since IMO these are both bad ideas. For now though, I've updated the code to just build an SFT Config out of the class & drop things that the SFT trainer doesn't know about, which is a bit ugly looking, but a contained and non-API breaking solution.

### Related issue number
https://github.com/foundation-model-stack/fms-hf-tuning/issues/206

### How to verify the PR
Unit tests pass with no arg errors from sft trainer

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass