### PR TITLE
Support custom embedding layer resizing to the desired multiple

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -178,7 +178,7 @@ def test_run_causallm_pt_and_inference():
         _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
 
         # Load the model
-        loaded_model = TunedCausalLM.load(checkpoint_path)
+        loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
 
         # Run inference on the text
         output_inference = loaded_model.run(
@@ -211,7 +211,7 @@ def test_run_causallm_pt_and_inference_with_formatting_data():
         _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
 
         # Load the model
-        loaded_model = TunedCausalLM.load(checkpoint_path)
+        loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
 
         # Run inference on the text
         output_inference = loaded_model.run(
@@ -242,7 +242,7 @@ def test_run_causallm_pt_and_inference_JSON_file_formatter():
         _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
 
         # Load the model
-        loaded_model = TunedCausalLM.load(checkpoint_path)
+        loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
 
         # Run inference on the text
         output_inference = loaded_model.run(
@@ -370,7 +370,7 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
             assert module in adapter_config.get("target_modules")
 
         # Load the model
-        loaded_model = TunedCausalLM.load(checkpoint_path)
+        loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
 
         # Run inference on the text
         output_inference = loaded_model.run(

--- a/tests/utils/test_embedding_resize.py
+++ b/tests/utils/test_embedding_resize.py
@@ -1,0 +1,76 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+# Third Party
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+# Local
+from tuning.data import tokenizer_data_utils
+
+MODEL_NAME = "Maykeye/TinyLLama-v0"
+
+
+def _inference(
+    tokenizer: AutoTokenizer,
+    model: AutoModelForCausalLM,
+    input_text: str,
+    max_new_tokens: int,
+) -> str:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokenized_input = tokenizer(input_text, return_tensors="pt").to(device)
+    generated_output = model.generate(
+        **tokenized_input,
+        max_new_tokens=max_new_tokens,
+    )
+    return tokenizer.decode(generated_output[0], skip_special_tokens=True)
+
+
+def test_output_unaltered_across_embedding_resizes():
+    input_text = "### Text: @NortonSupport Thanks much.\n\n### Label:"
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model_not_resized = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+    model_resized = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+    tokenizer_data_utils.tokenizer_and_embedding_resize(
+        special_tokens_dict={}, tokenizer=tokenizer, model=model_resized, multiple_of=8
+    )
+
+    tokenizer_data_utils.tokenizer_and_embedding_resize(
+        special_tokens_dict={},
+        tokenizer=tokenizer,
+        model=model_not_resized,
+        multiple_of=1,
+    )
+
+    # embedding size of the resized model should be a multiple of 8
+    assert model_resized.get_output_embeddings().out_features % 8 == 0
+
+    output_from_model_not_resized = _inference(
+        model=model_not_resized,
+        tokenizer=tokenizer,
+        input_text=input_text,
+        max_new_tokens=50,
+    )
+    output_from_model_resized = _inference(
+        model=model_not_resized,
+        tokenizer=tokenizer,
+        input_text=input_text,
+        max_new_tokens=50,
+    )
+
+    assert output_from_model_not_resized == output_from_model_resized

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -38,11 +38,11 @@ class ModelArguments:
         metadata={"help": "Use Flash attention v2 from transformers, default is True"},
     )
     torch_dtype: Optional[Union[torch.dtype, str]] = torch.bfloat16
-    embedding_size_multiple: Optional[int] = field(
+    embedding_size_multiple_of: Optional[int] = field(
         default=8,
         metadata={
-            "help": "Resize model embedding layer to the given nearest multiple after \
-                tokenizer modifications."
+            "help": "Resize model embedding layer to the nearest multiple of \
+                the given number after tokenizer modifications."
         },
     )
 

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -38,6 +38,7 @@ class ModelArguments:
         metadata={"help": "Use Flash attention v2 from transformers, default is True"},
     )
     torch_dtype: Optional[Union[torch.dtype, str]] = torch.bfloat16
+    embedding_size_multiple: Optional[int] = 8
 
 
 @dataclass

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -41,7 +41,8 @@ class ModelArguments:
     embedding_size_multiple: Optional[int] = field(
         default=8,
         metadata={
-            "help": "Resize model embedding layer to the given nearest multiple after tokenizer modifications."
+            "help": "Resize model embedding layer to the given nearest multiple after \
+                tokenizer modifications."
         },
     )
 

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -38,7 +38,12 @@ class ModelArguments:
         metadata={"help": "Use Flash attention v2 from transformers, default is True"},
     )
     torch_dtype: Optional[Union[torch.dtype, str]] = torch.bfloat16
-    embedding_size_multiple: Optional[int] = 8
+    embedding_size_multiple: Optional[int] = field(
+        default=8,
+        metadata={
+            "help": "Resize model embedding layer to the given nearest multiple after tokenizer modifications."
+        },
+    )
 
 
 @dataclass

--- a/tuning/data/tokenizer_data_utils.py
+++ b/tuning/data/tokenizer_data_utils.py
@@ -24,11 +24,11 @@ def tokenizer_and_embedding_resize(
     special_tokens_dict: Dict,
     tokenizer: transformers.PreTrainedTokenizer,
     model: transformers.PreTrainedModel,
-    multiple: int = 8,
+    multiple_of: int = 8,
 ):
     """Resize tokenizer and embedding."""
     num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
-    embedding_size = int(multiple * math.ceil(len(tokenizer) / multiple))
+    embedding_size = int(multiple_of * math.ceil(len(tokenizer) / multiple_of))
     num_new_tokens = num_new_tokens + embedding_size - len(tokenizer)
     model.resize_token_embeddings(embedding_size)
     if num_new_tokens > 0:

--- a/tuning/data/tokenizer_data_utils.py
+++ b/tuning/data/tokenizer_data_utils.py
@@ -14,6 +14,7 @@
 
 # Standard
 from typing import Dict
+import math
 
 # Third Party
 import transformers
@@ -23,14 +24,13 @@ def tokenizer_and_embedding_resize(
     special_tokens_dict: Dict,
     tokenizer: transformers.PreTrainedTokenizer,
     model: transformers.PreTrainedModel,
+    multiple: int = 8,
 ):
-    """Resize tokenizer and embedding.
-
-    TODO: In the future, make sure we can have vocab size divisible by 64.
-    """
+    """Resize tokenizer and embedding."""
     num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
-    model.resize_token_embeddings(len(tokenizer))
-
+    embedding_size = int(multiple * math.ceil(len(tokenizer) / multiple))
+    num_new_tokens = num_new_tokens + embedding_size - len(tokenizer)
+    model.resize_token_embeddings(embedding_size)
     if num_new_tokens > 0:
         input_embeddings = model.get_input_embeddings().weight.data
         output_embeddings = model.get_output_embeddings().weight.data

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -228,6 +228,7 @@ def train(
         special_tokens_dict=special_tokens_dict,
         tokenizer=tokenizer,
         model=model,
+        multiple=model_args.embedding_size_multiple,
     )
 
     # Configure the collator and validate args related to packing prior to formatting the dataset

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -228,7 +228,7 @@ def train(
         special_tokens_dict=special_tokens_dict,
         tokenizer=tokenizer,
         model=model,
-        multiple=model_args.embedding_size_multiple,
+        multiple_of=model_args.embedding_size_multiple_of,
     )
 
     # Configure the collator and validate args related to packing prior to formatting the dataset


### PR DESCRIPTION
### Description of the change

Allow resizing the model's embedding layer to the given multiple after addition of the tokenizer's new tokens for better memory efficiency.

### Related issue number

Closes #193

### How to verify the PR

You can use the embedding multiple option readily by passing the argument. 

```
--embedding_size_multiple_of <multiple> # 8 or 64 etc
```

### Was the PR tested

Sample training working and completed uses the `--embedding_size_multiple_of 64` option

<img width="1728" alt="Screenshot 2024-07-02 at 2 04 15 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/7e3ac920-d49f-4c83-895e-7542ea87ef2f">

Memory usage while training

<img width="807" alt="Screenshot 2024-07-02 at 1 39 52 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/a3eb1bf7-12e0-486e-a83c-a1fd99d78f65">

Difference in memory with a bad multiple `--embedding_size_multiple_of 13`

<img width="827" alt="Screenshot 2024-07-02 at 3 24 12 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/c6725358-011b-41c5-8aa7-b46f4fb34bff">

Saved checkpoints
<img width="1728" alt="Screenshot 2024-07-02 at 2 04 15 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/4310aca1-05e2-4bb7-a14a-f382d87cc264">


