### PR TITLE
feat: support custom tokenizer

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -70,7 +70,6 @@ PEFT_PT_ARGS = peft_config.PromptTuningConfig(
     prompt_tuning_init="RANDOM",
     num_virtual_tokens=8,
     prompt_tuning_init_text="hello",
-    tokenizer_name_or_path=MODEL_NAME,
 )
 
 PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
@@ -175,7 +174,7 @@ def test_run_causallm_pt_and_inference():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
+        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -208,7 +207,7 @@ def test_run_causallm_pt_and_inference_with_formatting_data():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
+        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -239,7 +238,7 @@ def test_run_causallm_pt_and_inference_JSON_file_formatter():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING", PEFT_PT_ARGS)
+        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -261,7 +260,6 @@ def test_run_causallm_pt_init_text():
         tuning_config = peft_config.PromptTuningConfig(
             prompt_tuning_init="TEXT",
             prompt_tuning_init_text="hello",
-            tokenizer_name_or_path=MODEL_NAME,
         )
 
         sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, tuning_config)
@@ -270,7 +268,7 @@ def test_run_causallm_pt_init_text():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING", tuning_config)
+        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
 
 
 invalid_params_map = [
@@ -364,7 +362,7 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "LORA", base_lora_args)
+        _validate_adapter_config(adapter_config, "LORA")
 
         for module in expected:
             assert module in adapter_config.get("target_modules")
@@ -431,17 +429,9 @@ def _get_adapter_config(dir_path):
         return json.load(f)
 
 
-def _validate_adapter_config(adapter_config, peft_type, tuning_config):
+def _validate_adapter_config(adapter_config, peft_type):
     assert adapter_config.get("task_type") == "CAUSAL_LM"
     assert adapter_config.get("peft_type") == peft_type
-    assert (
-        (
-            adapter_config.get("tokenizer_name_or_path")
-            == tuning_config.tokenizer_name_or_path
-        )
-        if peft_type == "PROMPT_TUNING"
-        else True
-    )
 
 
 ############################# Other Tests #############################

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -174,7 +174,12 @@ def test_run_causallm_pt_and_inference():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
+        # tokenizer_name_or_path from model arguments is passed
+        # while preparing the prompt tuning config which
+        # defaults to model_name_or_path if not explicitly set.
+        _validate_adapter_config(
+            adapter_config, "PROMPT_TUNING", MODEL_ARGS.tokenizer_name_or_path
+        )
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -207,7 +212,12 @@ def test_run_causallm_pt_and_inference_with_formatting_data():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
+        # tokenizer_name_or_path from model arguments is passed
+        # while preparing the prompt tuning config which
+        # defaults to model_name_or_path if not explicitly set.
+        _validate_adapter_config(
+            adapter_config, "PROMPT_TUNING", MODEL_ARGS.tokenizer_name_or_path
+        )
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -238,7 +248,12 @@ def test_run_causallm_pt_and_inference_JSON_file_formatter():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
+        # tokenizer_name_or_path from model arguments is passed
+        # while preparing the prompt tuning config which
+        # defaults to model_name_or_path if not explicitly set.
+        _validate_adapter_config(
+            adapter_config, "PROMPT_TUNING", MODEL_ARGS.tokenizer_name_or_path
+        )
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -268,7 +283,12 @@ def test_run_causallm_pt_init_text():
         _validate_training(tempdir)
         checkpoint_path = _get_checkpoint_path(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
-        _validate_adapter_config(adapter_config, "PROMPT_TUNING")
+        # tokenizer_name_or_path from model arguments is passed
+        # while preparing the prompt tuning config which
+        # defaults to model_name_or_path if not explicitly set.
+        _validate_adapter_config(
+            adapter_config, "PROMPT_TUNING", MODEL_ARGS.tokenizer_name_or_path
+        )
 
 
 invalid_params_map = [
@@ -429,9 +449,14 @@ def _get_adapter_config(dir_path):
         return json.load(f)
 
 
-def _validate_adapter_config(adapter_config, peft_type):
+def _validate_adapter_config(adapter_config, peft_type, tokenizer_name_or_path=None):
     assert adapter_config.get("task_type") == "CAUSAL_LM"
     assert adapter_config.get("peft_type") == peft_type
+    assert (
+        (adapter_config.get("tokenizer_name_or_path") == tokenizer_name_or_path)
+        if peft_type == "PROMPT_TUNING"
+        else True
+    )
 
 
 ############################# Other Tests #############################

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -45,6 +45,17 @@ class ModelArguments:
                 the given number after tokenizer modifications."
         },
     )
+    tokenizer_name_or_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Path to custom tokenizer.\
+                    If not provided it defaults to model_name_or_path"
+        },
+    )
+
+    def __post_init__(self):
+        if not self.tokenizer_name_or_path:
+            self.tokenizer_name_or_path = self.model_name_or_path
 
 
 @dataclass

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -70,13 +70,9 @@ class PromptTuningConfig:
         prompt_tuning_init_text (`str`, *optional*):
             The text to initialize the prompt embedding. \
             Only used if `prompt_tuning_init` is `TEXT`.
-        tokenizer_name_or_path (`str`, *optional*):
-            The name or path of the tokenizer. \
-            Only used if `prompt_tuning_init` is `TEXT`.
         num_virtual_tokens (`int`): The number of virtual tokens to use.
     """
 
     prompt_tuning_init: str = "TEXT"
     num_virtual_tokens: int = 8
     prompt_tuning_init_text: str = "Classify if the tweet is a complaint or not:"
-    tokenizer_name_or_path: str = "llama-7b-hf"

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -171,13 +171,15 @@ def train(
 
     # TODO: Move these to a config as well
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.model_name_or_path, cache_dir=train_args.cache_dir, use_fast=True
+        model_args.tokenizer_name_or_path, cache_dir=train_args.cache_dir, use_fast=True
     )
 
     # Calculate and save additional metrics to track later.
     additional_metrics["model_load_time"] = time.time() - model_load_time
 
-    peft_config = get_hf_peft_config(task_type, peft_config)
+    peft_config = get_hf_peft_config(
+        task_type, peft_config, model_args.tokenizer_name_or_path
+    )
 
     # TODO: understand if we need to hardcode these here or just use defaults in model
     if isinstance(tokenizer, (LlamaTokenizer, LlamaTokenizerFast)):

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -71,11 +71,12 @@ def create_tuning_config(peft_method, **kwargs):
     return tune_config
 
 
-def get_hf_peft_config(task_type, tuning_config):
+def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     """Return HF PEFT config for tuning based on type of tuning config passed
     Args:
         task_type: str
         tuning_config: peft_config.LoraConfig | peft_config.PromptTuningConfig | None
+        tokenizer_name_or_path: str
     Return: HF PEFT config or None
     """
     if isinstance(tuning_config, peft_config.LoraConfig):
@@ -85,7 +86,9 @@ def get_hf_peft_config(task_type, tuning_config):
         hf_peft_config = LoraConfig(task_type=task_type, **lora_config)
     elif isinstance(tuning_config, peft_config.PromptTuningConfig):
         hf_peft_config = PromptTuningConfig(
-            task_type=task_type, **asdict(tuning_config)
+            task_type=task_type,
+            tokenizer_name_or_path=tokenizer_name_or_path,
+            **asdict(tuning_config),
         )
     else:
         hf_peft_config = None  # full parameter tuning


### PR DESCRIPTION
## Description

Currently we presume the tokenizer is always available at `model_name_or_path`https://github.com/foundation-model-stack/fms-hf-tuning/blob/b655e1ae6f0e7cf7f93933c0cc2dd72023a8d0f3/tuning/sft_trainer.py#L174. So, the handy solution for this is to simply introduce new argument `tokenizer_name_or_path` in the model arguments https://github.com/foundation-model-stack/fms-hf-tuning/blob/b655e1ae6f0e7cf7f93933c0cc2dd72023a8d0f3/tuning/config/configs.py#L34. However, this isn't the case for us since that argument is already being used in PEFT PT config https://github.com/foundation-model-stack/fms-hf-tuning/blob/b655e1ae6f0e7cf7f93933c0cc2dd72023a8d0f3/tuning/config/peft_config.py#L82

### Approach 1
Given the premise, one approach would be to use the argument `tokenizer_name_or_path` from PEFT PT config dataclass as is to set the tokenizer if None we fall back to `model_name_or_path`. However, passing this info as part of the PEFT config for a different purpose (not related to PEFT) would raise confusion within the code needs access to the tuning_config object and as well falling back piece of code would be outside the dataclass post_init logic.

### Approach 2
Another approach would be to move the argument `tokenizer_name_or_path` from PEFT PT config dataclass to model arguments dataclass. However, for obvious reasons`tokenizer_name_or_path` is needed in the PEFT PT data class to use it while preparing PEFT config and adding this argument from model arguments dataclass to PEFT config class is not workable since dataclasses do not include those variables that are outside the class definition while using `asdict`
https://github.com/foundation-model-stack/fms-hf-tuning/blob/b655e1ae6f0e7cf7f93933c0cc2dd72023a8d0f3/tuning/utils/config_utils.py#L87-L88 

### Approach 3 (currently implemented in this PR)
Simply maintain two separate variables for both the purposes and point out the differences in the respective help docs.

### Usage

simply pass `--custom_tokenizer_name_or_path <path to tokenizer>` otherwise it defaults to `model_name_or_path`


### Testing

Command
```bash
torchrun --nnodes="${WORLD_SIZE}" --node_rank="${RANK}" --nproc_per_node="4" --rdzv_id="101" --rdzv_endpoint="${MASTER_ADDR}:${MASTER_PORT}" ./tuning/sft_trainer.py --fsdp="full_shard auto_wrap"  --fsdp_config="/app/test/data/config.json" --output_dir="/app/test/data/output" --model_name_or_path="TinyLlama/TinyLlama-1.1B-Chat-v1.0" --custom_tokenizer_name_or_path="TinyLlama/TinyLlama-1.1B-Chat-v1.0" --training_data_path="/app/test/data/data.jsonl" --num_train_epochs 4  --per_device_train_batch_size 1  --per_device_eval_batch_size 1  --gradient_accumulation_steps 1  --evaluation_strategy "no"  --save_strategy "epoch"  --learning_rate 1e-5  --warmup_ratio 0.03  --lr_scheduler_type "cosine"  --logging_steps 1  --include_tokens_per_second  --packing False  --response_template "\n### Response:"  --dataset_text_field "output" --use_flash_attn False --torch_dtype float16
```

logs
<img width="1722" alt="Screenshot 2024-07-03 at 11 15 08 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/32696997-3c3f-4d66-a392-a4777dbb5849">

Output checkpoints

<img width="1273" alt="Screenshot 2024-07-03 at 11 16 14 PM" src="https://github.com/foundation-model-stack/fms-hf-tuning/assets/15800200/b8d2e0c5-d42f-40d5-adb8-5334c440d079">


Closes #190

