### PR TITLE
Replace shutil.copytree()

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -124,10 +124,9 @@ def main():
                 pt_checkpoint_dir,
                 original_output_dir,
             )
-            shutil.copytree(
+            shutil.copyfile(
                 os.path.join(tempdir, pt_checkpoint_dir),
-                original_output_dir,
-                dirs_exist_ok=True,
+                original_output_dir
             )
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -72,7 +72,7 @@ def copytree(source, destination, symlinks=False, ignore=None):
                 mode = stat.S_IMODE(st.st_mode)
                 # apply them to the destination file
                 os.lchmod(destination_file, mode)
-            except:
+            except Exception as e:  # pylint: disable=broad-except
                 pass  # Not fatal.
         elif os.path.isdir(source_file):
             # recursive call for subdirectories

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -47,39 +47,40 @@ from tuning.utils.error_logging import (
 
 ERROR_LOG = "/dev/termination-log"
 
-def copytree(source, destination, symlinks = False, ignore = None):
-  
-  if not os.path.exists(destination):
-    os.makedirs(destination)
-    shutil.copystat(source, destination)
-  file_list = os.listdir(source)
-  # If we want to ignore any files
-  if ignore:
-    exclude = ignore(source, file_list)
-    file_list = [a_file for a_file in file_list if a_file not in exclude]
-  # Have a list of directory objects, now iterate over them.
-  for item in file_list:
-    source_file = os.path.join(source, item)
-    destination_file = os.path.join(destination, item)
-    if symlinks and os.path.islink(source_file):
-      if os.path.lexists(destination_file):
-        os.remove(destination_file)
-      os.symlink(os.readlink(source_file), destination_file)
-      # Improvement over shutil.copytree: BAD CHMOD IS NOT FATAL.
-      try:
-        # get the permissions on the source file
-        st = os.lstat(source_file)
-        mode = stat.S_IMODE(st.st_mode)
-        # apply them to the destination file 
-        os.lchmod(destination_file, mode)
-      except:
-        pass # Not fatal.
-    elif os.path.isdir(source_file):
-      # recursive call for subdirectories
-      copytree(source_file, destination_file, symlinks, ignore)
-    else:
-      # straight copy.
-      shutil.copy2(source_file, destination_file)
+
+def copytree(source, destination, symlinks=False, ignore=None):
+    if not os.path.exists(destination):
+        os.makedirs(destination)
+        shutil.copystat(source, destination)
+    file_list = os.listdir(source)
+    # If we want to ignore any files
+    if ignore:
+        exclude = ignore(source, file_list)
+        file_list = [a_file for a_file in file_list if a_file not in exclude]
+    # Have a list of directory objects, now iterate over them.
+    for item in file_list:
+        source_file = os.path.join(source, item)
+        destination_file = os.path.join(destination, item)
+        if symlinks and os.path.islink(source_file):
+            if os.path.lexists(destination_file):
+                os.remove(destination_file)
+            os.symlink(os.readlink(source_file), destination_file)
+            # Improvement over shutil.copytree: BAD CHMOD IS NOT FATAL.
+            try:
+                # get the permissions on the source file
+                st = os.lstat(source_file)
+                mode = stat.S_IMODE(st.st_mode)
+                # apply them to the destination file
+                os.lchmod(destination_file, mode)
+            except:
+                pass  # Not fatal.
+        elif os.path.isdir(source_file):
+            # recursive call for subdirectories
+            copytree(source_file, destination_file, symlinks, ignore)
+        else:
+            # straight copy.
+            shutil.copy2(source_file, destination_file)
+
 
 def main():
     LOGLEVEL = os.environ.get("LOG_LEVEL", "WARNING").upper()
@@ -158,10 +159,7 @@ def main():
                 pt_checkpoint_dir,
                 original_output_dir,
             )
-            copytree(
-                os.path.join(tempdir, pt_checkpoint_dir),
-                original_output_dir
-            )
+            copytree(os.path.join(tempdir, pt_checkpoint_dir), original_output_dir)
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -72,7 +72,7 @@ def copytree(source, destination, symlinks=False, ignore=None):
                 mode = stat.S_IMODE(st.st_mode)
                 # apply them to the destination file
                 os.lchmod(destination_file, mode)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 pass  # Not fatal.
         elif os.path.isdir(source_file):
             # recursive call for subdirectories


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

<!-- Please summarize the changes -->

### Summary
Custom implementation of `shutil.copytree()` that does not error out in the event file metadata cannot be transferred.  

It was reported that if the `output_dir` parameter was set to the root of a NFS mount, `shutil.copytree()` would error out due to failure of the file metadata to transfer due to permissioning on the root volume. This error was successfully reproduced. Output files were successfully written to the root drive, but the copy failed due to file metadata not being written.

Code submitted in this PR should fix. There are a few issues with this implementation that will need to be addressed:

1. There did not seem to be another option in the shutil package that copied the contents of a directory. `copyfile` and `copy2` both copy individual files. `copy2` was used here to preserve the file metadata when possible. In the event the file metadata cannot be preserved, do not error out.

2.  Is there a better place to put this new function rather than in `accelerate_launch.py`?


### How to verify the PR

Execute a tuning session where `output_dir` is set to the root volume of a NFS drive. Tuning session should complete without error and all tuning artifacts should be created in the root directory.

### Was the PR tested

No unit tests were added. The following test plan was executed successfully:

1. Verify the original error by using a SFT tuning session with the output set to a root NFS mount. Verify the tuning session errors out as expected (**COMPLETED SUCCESSFULLY**)
2. Verifying the fix is in place, repeat the above, ensuring the tuning session does not error out and all expected tuning artifacts are created in the expected location. (**COMPLETED SUCCESSFULLY**)
3. Repeat, with the target directory not being the root NFS directory, but a subdirectory off root. Verify all expected tuning artifacts are created in the expected location. (**COMPLETED SUCCESSFULLY**)
4. Repeat with a COS bucket mount, rather than a NFS mount. Verify all expected tuning artifacts are created in the expected location. (**COMPLETED SUCCESSFULLY**)

Documentation of all of the above (deploy files, log files, and screenshots) can be provided upon request.

If we need to add unit tests for this, or better document the results of the above test cases, please advise.

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass