### PR TITLE
Move default operations and metrics to variables

### DIFF
--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -62,7 +62,7 @@ CONTROLLER_TRIGGERS_KEY = "triggers"
 CONTROLLER_OPERATIONS_KEY = OPERATIONS_KEY
 
 # Default operations / metrics to register
-DEFAULT_OPERATIONS = {'operations': [{'name': 'hfcontrols', 'class': 'HFControls'}]}
+DEFAULT_OPERATIONS = {"operations": [{"name": "hfcontrols", "class": "HFControls"}]}
 DEFAULT_METRICS = None
 
 # pylint: disable=too-many-instance-attributes

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -63,7 +63,7 @@ CONTROLLER_OPERATIONS_KEY = OPERATIONS_KEY
 
 # Default operations / metrics to register
 DEFAULT_OPERATIONS = {"operations": [{"name": "hfcontrols", "class": "HFControls"}]}
-DEFAULT_METRICS = None
+DEFAULT_METRICS = {}
 
 # pylint: disable=too-many-instance-attributes
 class TrainerControllerCallback(TrainerCallback):

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -16,7 +16,6 @@
 # https://spdx.dev/learn/handling-license-info/
 
 # Standard
-from importlib import resources as impresources
 from typing import Dict, List, Union
 import inspect
 import os
@@ -34,7 +33,6 @@ from transformers.utils import logging
 import yaml
 
 # Local
-from tuning.trainercontroller import controllermetrics, operations
 from tuning.trainercontroller.control import Control, OperationAction, Rule
 from tuning.trainercontroller.controllermetrics import (
     handlers as default_metric_handlers,
@@ -63,6 +61,9 @@ CONTROLLER_PATIENCE_CONFIG_KEY = "patience"
 CONTROLLER_TRIGGERS_KEY = "triggers"
 CONTROLLER_OPERATIONS_KEY = OPERATIONS_KEY
 
+# Default operations / metrics to register
+DEFAULT_OPERATIONS = {'operations': [{'name': 'hfcontrols', 'class': 'HFControls'}]}
+DEFAULT_METRICS = None
 
 # pylint: disable=too-many-instance-attributes
 class TrainerControllerCallback(TrainerCallback):
@@ -102,23 +103,15 @@ class TrainerControllerCallback(TrainerCallback):
         if OPERATIONS_KEY not in self.trainer_controller_config:
             self.trainer_controller_config[OPERATIONS_KEY] = []
 
-        # Initialize the list of metrics from default `metrics.yaml` in the \
-        # controllermetric package. In addition, any metrics mentioned in \
-        # the trainer controller config are added to this list.
-        default_metrics_config_yaml = (
-            impresources.files(controllermetrics) / "metrics.yaml"
-        )
-        with default_metrics_config_yaml.open("r") as f:
-            default_metrics_config = yaml.safe_load(f)
         if (
-            default_metrics_config is not None
-            and CONTROLLER_METRICS_KEY in default_metrics_config
-            and len(default_metrics_config[CONTROLLER_METRICS_KEY]) > 0
+            DEFAULT_METRICS is not None
+            and CONTROLLER_METRICS_KEY in DEFAULT_METRICS
+            and len(DEFAULT_METRICS[CONTROLLER_METRICS_KEY]) > 0
         ):
             self_controller_metrics = self.trainer_controller_config[
                 CONTROLLER_METRICS_KEY
             ]
-            default_controller_metrics: list[dict] = default_metrics_config[
+            default_controller_metrics: list[dict] = DEFAULT_METRICS[
                 CONTROLLER_METRICS_KEY
             ]
             for metric_obj in default_controller_metrics:
@@ -131,21 +124,13 @@ class TrainerControllerCallback(TrainerCallback):
                 if not found:
                     self_controller_metrics.append(metric_obj)
 
-        # Initialize the list of operations from default `operations.yaml` \
-        # in the operations package. In addition, any operations mentioned \
-        # in the trainer controller config are added to this list.
-        default_operations_config_yaml = (
-            impresources.files(operations) / "operations.yaml"
-        )
-        with default_operations_config_yaml.open("r") as f:
-            default_operations_config = yaml.safe_load(f)
         if (
-            default_operations_config is not None
-            and OPERATIONS_KEY in default_operations_config
-            and len(default_operations_config[OPERATIONS_KEY]) > 0
+            DEFAULT_OPERATIONS is not None
+            and OPERATIONS_KEY in DEFAULT_OPERATIONS
+            and len(DEFAULT_OPERATIONS[OPERATIONS_KEY]) > 0
         ):
             self_controller_operations = self.trainer_controller_config[OPERATIONS_KEY]
-            default_controller_operations: list[dict] = default_operations_config[
+            default_controller_operations: list[dict] = DEFAULT_OPERATIONS[
                 OPERATIONS_KEY
             ]
             for op_obj in default_controller_operations:

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -104,7 +104,7 @@ class TrainerControllerCallback(TrainerCallback):
             self.trainer_controller_config[OPERATIONS_KEY] = []
 
         if (
-            DEFAULT_METRICS is not None
+            DEFAULT_METRICS
             and CONTROLLER_METRICS_KEY in DEFAULT_METRICS
             and len(DEFAULT_METRICS[CONTROLLER_METRICS_KEY]) > 0
         ):
@@ -125,7 +125,7 @@ class TrainerControllerCallback(TrainerCallback):
                     self_controller_metrics.append(metric_obj)
 
         if (
-            DEFAULT_OPERATIONS is not None
+            DEFAULT_OPERATIONS
             and OPERATIONS_KEY in DEFAULT_OPERATIONS
             and len(DEFAULT_OPERATIONS[OPERATIONS_KEY]) > 0
         ):

--- a/tuning/trainercontroller/operations/operations.yaml
+++ b/tuning/trainercontroller/operations/operations.yaml
@@ -1,3 +1,0 @@
-operations:
-  - name: hfcontrols
-    class: HFControls


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
This pull request moves the defaults for metrics / operations into variables instead of yaml files. The main reason for doing this is for convenience of distribution; the current `build` in the Dockerfile ([here](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/build/Dockerfile#L122)) does *not* bundle the default yaml files into the wheel, which crashes the controller framework upon startup.

There are workarounds in the distribution side, e.g., we could write a `setup.py` to include assets that aren't python files etc, but IMO it makes more sense to just keep the defaults in variables that can be easily found, since the yaml files are only read once at initialization time anyway.


Note that as part of this, we're also changing default metrics to `{}` instead of `None` to make the linter happier

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR
1. Build the Dockerfile with `docker build -t fms-hf-tuning:dev . -f build/Dockerfile`
2. Try running the controller framework on a tiny model. For example...

a. Make a directory named `tc_test_resources`.
b. Create the following files:

i. `tc_test_resources/config.json`
```json
{
    "model_name_or_path": "Maykeye/TinyLLama-v0",
    "training_data_path": "/tc_test_resources/twitter_complaints_small.json",
    "validation_data_path": "/tc_test_resources/twitter_complaints_small.json",
    "output_dir": "/tc_test_resources/tc_test_model",
    "num_train_epochs": 20.0,
    "per_device_train_batch_size": 4,
    "per_device_eval_batch_size": 4,
    "gradient_accumulation_steps": 1,
    "evaluation_strategy": "epoch",
    "save_strategy": "epoch",
    "learning_rate": 1e-5,
    "response_template": "\n### Label:",
    "dataset_text_field": "output",
    "peft_method": "pt",
    "num_virtal_tokens": 100,
    "prompt_tuning_init_text": "Classify if the tweet is a complaint or not:",
    "trainer_controller_config_file": "/tc_test_resources/exit_if_epoch_num_exceeds_one.yaml"
}
```

ii. `/tc_test_resources/twitter_complaints_small.json`
```json
{"Tweet text":"@HMRCcustomers No this is my first job","ID":0,"Label":2,"text_label":"no complaint","output":"### Text: @HMRCcustomers No this is my first job\n\n### Label: no complaint"}
{"Tweet text":"@KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.","ID":1,"Label":2,"text_label":"no complaint","output":"### Text: @KristaMariePark Thank you for your interest! If you decide to cancel, you can call Customer Care at 1-800-NYTIMES.\n\n### Label: no complaint"}
{"Tweet text":"If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService","ID":2,"Label":1,"text_label":"complaint","output":"### Text: If I can't get my 3rd pair of @beatsbydre powerbeats to work today I'm doneski man. This is a slap in my balls. Your next @Bose @BoseService\n\n### Label: complaint"}
{"Tweet text":"@EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.","ID":3,"Label":1,"text_label":"complaint","output":"### Text: @EE On Rosneath Arial having good upload and download speeds but terrible latency 200ms. Why is this.\n\n### Label: complaint"}
{"Tweet text":"Couples wallpaper, so cute. :) #BrothersAtHome","ID":4,"Label":2,"text_label":"no complaint","output":"### Text: Couples wallpaper, so cute. :) #BrothersAtHome\n\n### Label: no complaint"}
{"Tweet text":"@mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG","ID":5,"Label":2,"text_label":"no complaint","output":"### Text: @mckelldogs This might just be me, but-- eyedrops? Artificial tears are so useful when you're sleep-deprived and sp\u2026 https:\/\/t.co\/WRtNsokblG\n\n### Label: no complaint"}
{"Tweet text":"@Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?","ID":6,"Label":2,"text_label":"no complaint","output":"### Text: @Yelp can we get the exact calculations for a business rating (for example if its 4 stars but actually 4.2) or do we use a 3rd party site?\n\n### Label: no complaint"}
{"Tweet text":"@nationalgridus I have no water and the bill is current and paid. Can you do something about this?","ID":7,"Label":1,"text_label":"complaint","output":"### Text: @nationalgridus I have no water and the bill is current and paid. Can you do something about this?\n\n### Label: complaint"}
{"Tweet text":"Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora","ID":8,"Label":1,"text_label":"complaint","output":"### Text: Never shopping at @MACcosmetics again. Every time I go in there, their employees are super rude\/condescending. I'll take my $$ to @Sephora\n\n### Label: complaint"}
{"Tweet text":"@JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd","ID":9,"Label":2,"text_label":"no complaint","output":"### Text: @JenniferTilly Merry Christmas to as well. You get more stunning every year \ufffd\ufffd\n\n### Label: no complaint"}
```

iii. `/tc_test_resources/exit_if_epoch_num_exceeds_one.yaml`

```yaml
controller_metrics:
  - name: trainer_state
    class: TrainingState
  - name: evalmetric
    class: EvalMetrics
controllers:
  - name: exit_if_epoch_num_exceeds_one
    triggers:
      - on_epoch_end
    rule: trainer_state["epoch"] > 1
    operations:
      - hfcontrols.should_training_stop
```

c. Start an interactive session mounting the absolute path to the dir holding the files you just made
```bash
TC_RESOURCE_DIR={...}
docker run -it -v $TC_RESOURCE_DIR:/tc_test_resources docker.io/library/fms-hf-tuning:dev bash
```

d. Point to the new config and run accelerate launch
```
export SFT_TRAINER_CONFIG_JSON_PATH=/tc_test_resources/config.json
python accelerate_launch.py 
```

You'll see the controller framework is working properly because it will terminate training when the condition is satisfied, i.e., 2 epochs have passed, even though we asked to train for 20.
### Was the PR tested
Ran instructions above ^