### PR TITLE
deps: Update transformers lower bound version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 dependencies = [
 "numpy>=1.26.4,<2.0",
 "accelerate>=0.20.3,<0.40",
-"transformers>=4.41.0,<5.0,!=4.38.2",
+"transformers>4.41,<5.0",
 "torch>=2.2.0,<3.0",
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

set the transformers version greater than 4.41 as it may have severe performance degradation. (@Ssukriti) 
set upper limit of transformers to 5.0, and removing this version constraint (!=4.38.2)

### Related issue number

Fix of #246 

### How to verify the PR

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass