### PR TITLE
Replace shutil.copytree() to fix permission error

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -35,6 +35,7 @@ from build.utils import (
     process_accelerate_launch_args,
     serialize_args,
     get_highest_checkpoint,
+    copytree,
 )
 from tuning.utils.config_utils import get_json_config
 from tuning.config.tracker_configs import FileLoggingTrackerConfig
@@ -124,11 +125,7 @@ def main():
                 pt_checkpoint_dir,
                 original_output_dir,
             )
-            shutil.copytree(
-                os.path.join(tempdir, pt_checkpoint_dir),
-                original_output_dir,
-                dirs_exist_ok=True,
-            )
+            copytree(os.path.join(tempdir, pt_checkpoint_dir), original_output_dir)
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -35,7 +35,7 @@ from build.utils import (
     process_accelerate_launch_args,
     serialize_args,
     get_highest_checkpoint,
-    copytree,
+    copy_checkpoint,
 )
 from tuning.utils.config_utils import get_json_config
 from tuning.config.tracker_configs import FileLoggingTrackerConfig
@@ -125,7 +125,9 @@ def main():
                 pt_checkpoint_dir,
                 original_output_dir,
             )
-            copytree(os.path.join(tempdir, pt_checkpoint_dir), original_output_dir)
+            copy_checkpoint(
+                os.path.join(tempdir, pt_checkpoint_dir), original_output_dir
+            )
         except Exception as e:  # pylint: disable=broad-except
             logging.error(traceback.format_exc())
             write_termination_log(

--- a/build/utils.py
+++ b/build/utils.py
@@ -24,18 +24,17 @@ from accelerate.commands.launch import launch_command_parser
 import shutil
 
 
-def copytree(source, destination):
+def copy_checkpoint(source, destination):
     if not os.path.exists(destination):
         os.makedirs(destination)
         shutil.copystat(source, destination)
-    file_list = os.listdir(source)
     # Have a list of directory objects, now iterate over them.
-    for item in file_list:
+    for item in os.listdir(source):
         source_file = os.path.join(source, item)
         destination_file = os.path.join(destination, item)
         if os.path.isdir(source_file):
             # recursive call for subdirectories
-            copytree(source_file, destination_file)
+            copy_checkpoint(source_file, destination_file)
         else:
             # straight copy.
             shutil.copy2(source_file, destination_file)

--- a/build/utils.py
+++ b/build/utils.py
@@ -21,6 +21,24 @@ import base64
 # Third Party
 import torch
 from accelerate.commands.launch import launch_command_parser
+import shutil
+
+
+def copytree(source, destination):
+    if not os.path.exists(destination):
+        os.makedirs(destination)
+        shutil.copystat(source, destination)
+    file_list = os.listdir(source)
+    # Have a list of directory objects, now iterate over them.
+    for item in file_list:
+        source_file = os.path.join(source, item)
+        destination_file = os.path.join(destination, item)
+        if os.path.isdir(source_file):
+            # recursive call for subdirectories
+            copytree(source_file, destination_file)
+        else:
+            # straight copy.
+            shutil.copy2(source_file, destination_file)
 
 
 def get_highest_checkpoint(dir_path):

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -20,9 +20,12 @@ from unittest.mock import patch
 
 # Third Party
 import pytest
+import shutil
+import filecmp
 
 # Local
 from build.utils import process_accelerate_launch_args
+from build.utils import copy_checkpoint
 
 HAPPY_PATH_DUMMY_CONFIG_PATH = os.path.join(
     os.path.dirname(__file__), "dummy_job_config.json"
@@ -108,3 +111,110 @@ def test_process_accelerate_launch_custom_config_file(patch_path_exists):
     temp_job_config = {"accelerate_launch_args": {"config_file": dummy_config_path}}
     args = process_accelerate_launch_args(temp_job_config)
     assert args.config_file == dummy_config_path
+
+
+class CopyCheckpointTestConfig:
+
+    def __init__(self, test_root):
+
+        assert os.path.isdir(test_root)
+
+        self.test_root = test_root
+        self.source_dir = os.path.join(self.test_root, "test_copytree_source")
+        self.source_sub_dir = os.path.join(self.source_dir, "subdir1")
+
+        if os.path.isdir(self.source_dir):
+            shutil.rmtree(self.source_dir)
+
+        os.mkdir(self.source_dir)
+        open(os.path.join(self.source_dir, "tf1.txt"), "a").close()
+        open(os.path.join(self.source_dir, "tf2.txt"), "a").close()
+        open(os.path.join(self.source_dir, "tf3.txt"), "a").close()
+
+        os.mkdir(self.source_sub_dir)
+        open(os.path.join(self.source_sub_dir, "tf4.txt"), "a").close()
+        open(os.path.join(self.source_sub_dir, "tf5.txt"), "a").close()
+        open(os.path.join(self.source_sub_dir, "tf6.txt"), "a").close()
+
+    def are_dir_trees_equal(self, dir1, dir2):
+
+        dirs_cmp = filecmp.dircmp(dir1, dir2)
+        if (
+            len(dirs_cmp.left_only) > 0
+            or len(dirs_cmp.right_only) > 0
+            or len(dirs_cmp.funny_files) > 0
+        ):
+            return False
+        (_, mismatch, errors) = filecmp.cmpfiles(
+            dir1, dir2, dirs_cmp.common_files, shallow=False
+        )
+        if len(mismatch) > 0 or len(errors) > 0:
+            return False
+        for common_dir in dirs_cmp.common_dirs:
+            new_dir1 = os.path.join(dir1, common_dir)
+            new_dir2 = os.path.join(dir2, common_dir)
+            if not self.are_dir_trees_equal(new_dir1, new_dir2):
+                return False
+        return True
+
+
+def test_copy_checkpoint_dest_dir_does_not_exist():
+
+    # Init source directory
+    config = CopyCheckpointTestConfig("/tmp")
+
+    target_dir_does_not_exist = os.path.join(config.test_root, "test_copytree_target")
+
+    # Execute the copy
+    copy_checkpoint(config.source_dir, target_dir_does_not_exist)
+    assert config.are_dir_trees_equal(config.source_dir, target_dir_does_not_exist)
+
+    # Cleanup
+    shutil.rmtree(config.source_dir)
+    shutil.rmtree(target_dir_does_not_exist)
+
+
+def test_copy_checkpoint_dest_dir_does_exist():
+
+    # Init source directory
+    config = CopyCheckpointTestConfig("/tmp")
+
+    # Init target directory
+    target_dir_does_exist = os.path.join(config.test_root, "test_copytree_target2")
+    os.mkdir(target_dir_does_exist)
+
+    # Execute the copy
+    copy_checkpoint(config.source_dir, target_dir_does_exist)
+    assert config.are_dir_trees_equal(config.source_dir, target_dir_does_exist)
+
+    # Cleanup
+    shutil.rmtree(config.source_dir)
+    shutil.rmtree(target_dir_does_exist)
+
+
+def test_copy_checkpoint_dest_dir_not_writeable():
+
+    # Init source directory
+    config = CopyCheckpointTestConfig("/tmp")
+
+    # Init target directory
+    target_dir_not_writeable = os.path.join(
+        config.test_root, "test_copytree_notwriteable"
+    )
+
+    os.makedirs(target_dir_not_writeable, mode=0o446)
+
+    # Execute the copy. Should FAIL
+    with pytest.raises(Exception) as e:
+        copy_checkpoint(config.source_dir, target_dir_not_writeable)
+    assert "Permission denied:" in str(e.value)
+
+    # Cleanup
+    shutil.rmtree(config.source_dir)
+    shutil.rmtree(target_dir_not_writeable)
+
+
+def test_copy_checkpoint_source_dir_does_not_exist():
+    with pytest.raises(Exception) as e:
+        copy_checkpoint("/doesnotexist", "/tmp")
+    assert "No such file or directory" in str(e.value)

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -219,10 +219,6 @@ def test_copy_checkpoint_dest_dir_does_exist():
         os.remove(os.path.join(target_dir_does_exist, "tf9.txt"))
         assert config.are_dir_trees_equal(config.source_dir, target_dir_does_exist)
 
-        # Cleanup
-        shutil.rmtree(config.source_dir)
-        shutil.rmtree(target_dir_does_exist)
-
 
 def test_copy_checkpoint_dest_dir_not_writeable():
 
@@ -241,10 +237,6 @@ def test_copy_checkpoint_dest_dir_not_writeable():
         with pytest.raises(PermissionError) as e:
             copy_checkpoint(config.source_dir, target_dir_not_writeable)
         assert "Permission denied:" in str(e.value)
-
-        # Cleanup
-        shutil.rmtree(config.source_dir)
-        shutil.rmtree(target_dir_not_writeable)
 
 
 def test_copy_checkpoint_source_dir_does_not_exist():

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -21,7 +21,6 @@ import tempfile
 
 # Third Party
 import pytest
-import shutil
 import filecmp
 
 # Local

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -195,8 +195,14 @@ def test_copy_checkpoint_dest_dir_does_exist():
     os.mkdir(target_dir_does_exist)
     # Add a file to the target. This file will be overwritten during the copy.
     open(os.path.join(target_dir_does_exist, "tf1.txt"), "a").close()
+    # Add a file to the target. This file does not exist in source.
+    open(os.path.join(target_dir_does_exist, "tf9.txt"), "a").close()
     # Execute the copy
     copy_checkpoint(config.source_dir, target_dir_does_exist)
+    # Validate the file that did not exist in source is still there.
+    assert os.path.exists(os.path.join(target_dir_does_exist, "tf9.txt"))
+    # Remove it so we can validate the dir trees are equal.
+    os.remove(os.path.join(target_dir_does_exist, "tf9.txt"))
     assert config.are_dir_trees_equal(config.source_dir, target_dir_does_exist)
 
     # Cleanup

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -137,14 +137,22 @@ class CopyCheckpointTestConfig:
             shutil.rmtree(self.source_dir)
 
         os.mkdir(self.source_dir)
-        open(os.path.join(self.source_dir, "tf1.txt"), "a").close()
-        open(os.path.join(self.source_dir, "tf2.txt"), "a").close()
-        open(os.path.join(self.source_dir, "tf3.txt"), "a").close()
+        for file_number in range(2):
+            with open(
+                os.path.join(self.source_dir, f"tf{file_number+1}.txt"),
+                "a",
+                encoding="utf-8",
+            ) as f:
+                f.close()
 
         os.mkdir(self.source_sub_dir)
-        open(os.path.join(self.source_sub_dir, "tf4.txt"), "a").close()
-        open(os.path.join(self.source_sub_dir, "tf5.txt"), "a").close()
-        open(os.path.join(self.source_sub_dir, "tf6.txt"), "a").close()
+        for file_number in range(2):
+            with open(
+                os.path.join(self.source_sub_dir, f"tf{file_number+4}.txt"),
+                "a",
+                encoding="utf-8",
+            ) as f:
+                f.close()
 
     def are_dir_trees_equal(self, dir1, dir2):
 
@@ -194,9 +202,19 @@ def test_copy_checkpoint_dest_dir_does_exist():
     target_dir_does_exist = os.path.join(config.test_root, "test_copytree_target2")
     os.mkdir(target_dir_does_exist)
     # Add a file to the target. This file will be overwritten during the copy.
-    open(os.path.join(target_dir_does_exist, "tf1.txt"), "a").close()
+    with open(
+        os.path.join(target_dir_does_exist, "tf1.txt"),
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.close()
     # Add a file to the target. This file does not exist in source.
-    open(os.path.join(target_dir_does_exist, "tf9.txt"), "a").close()
+    with open(
+        os.path.join(target_dir_does_exist, "tf9.txt"),
+        "a",
+        encoding="utf-8",
+    ) as f:
+        f.close()
     # Execute the copy
     copy_checkpoint(config.source_dir, target_dir_does_exist)
     # Validate the file that did not exist in source is still there.

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -129,7 +129,6 @@ class CopyCheckpointTestConfig:
         #         tf6.txt
 
         self.test_root = temp_root
-        print(f"ROOT: {self.test_root}")
         self.source_dir = os.path.join(self.test_root, "test_copytree_source")
         self.source_sub_dir = os.path.join(self.source_dir, "subdir1")
 
@@ -213,7 +212,6 @@ def test_copy_checkpoint_dest_dir_does_exist():
             f.close()
         # Execute the copy
         copy_checkpoint(config.source_dir, target_dir_does_exist)
-        # Validate the file that did not exist in source is still there.
         assert os.path.exists(os.path.join(target_dir_does_exist, "tf9.txt"))
         # Remove it so we can validate the dir trees are equal.
         os.remove(os.path.join(target_dir_does_exist, "tf9.txt"))


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Intended to reproduce the functionality of `shutil.copytree()`, but uses `shutil.copy2()` to get around the problem  `shutil.copytree()` has of trying to modify the directory metadata, which fails on a root NFS directory mounted and owned by root in a SFT tuning pod.

### How to verify the PR

Run a SFT tuning session where the `output_dir` is set to a root owned, everyone writable NFS volume.

### Was the PR tested

Unit tests are not submitted as part of the PR, but can be found [here](https://github.com/olson-ibm/copytree/blob/main/test/test.py). All passed.

Integration tests also completed successfully, can provide the test cases and results upon request.
