### PR TITLE
fix: Added correct link in main readme for the trainer-controller readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Trainer controller is a framework for controlling the trainer loop using user-de
 
 This framework helps users define rules to capture scenarios like criteria for stopping an ongoing training (E.g validation loss reaching a certain target, validation loss increasing with epoch, training loss values for last 100 steps increasing etc).
 
-For details about how you can use set a custom stopping criteria and perform custom operations, see [examples/trainer_controller/README.md](examples/trainer_controller/README.md)
+For details about how you can use set a custom stopping criteria and perform custom operations, see [examples/trainercontroller_configs/Readme.md](examples/trainercontroller_configs/Readme.md)
 
 ## More Examples
 


### PR DESCRIPTION
### Description of the change

Link to trainer controller readme broken.

### Related issue number

"Closes #253"

### How to verify the PR

Click on the trainer controller readme link in this [section](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main?tab=readme-ov-file#trainer-controller-framework).

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added. [NA]
- [X] I have ensured all unit tests pass