### PR TITLE
feat: Add a dockerfile argument to enable aimstack

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -105,7 +105,7 @@ ARG USER
 ARG USER_UID
 
 ## Enable Aimstack if requested via ENABLE_AIM set to "true"
-ARG ENABLE_AIM
+ARG ENABLE_AIM=false
 
 RUN dnf install -y git && \
     # perl-Net-SSLeay.x86_64 and server_key.pem are installed with git as dependencies
@@ -132,7 +132,7 @@ RUN --mount=type=cache,target=/home/${USER}/.cache/pip,uid=${USER_UID} \
     python -m pip install --user wheel && \
     python -m pip install --user "$(head bdist_name)" && \
     python -m pip install --user "$(head bdist_name)[flash-attn]" && \
-    if [[ "${ENABLE_AIM}" == "true" ]]; then\
+    if [[ "${ENABLE_AIM}" == "true" ]]; then \
         python -m pip install --user "$(head bdist_name)[aim]"; \
     fi && \
     # Clean up the wheel module. It's only needed by flash-attn install

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -104,6 +104,9 @@ ARG WHEEL_VERSION
 ARG USER
 ARG USER_UID
 
+## Enable Aimstack if requested via ENABLE_AIM set to "true"
+ARG ENABLE_AIM
+
 RUN dnf install -y git && \
     # perl-Net-SSLeay.x86_64 and server_key.pem are installed with git as dependencies
     # Twistlock detects it as H severity: Private keys stored in image
@@ -129,6 +132,9 @@ RUN --mount=type=cache,target=/home/${USER}/.cache/pip,uid=${USER_UID} \
     python -m pip install --user wheel && \
     python -m pip install --user "$(head bdist_name)" && \
     python -m pip install --user "$(head bdist_name)[flash-attn]" && \
+    if [[ "${ENABLE_AIM}" == "true" ]]; then\
+        python -m pip install --user "$(head bdist_name)[aim]"; \
+    fi && \
     # Clean up the wheel module. It's only needed by flash-attn install
     python -m pip uninstall wheel build -y && \
     # Cleanup the bdist whl file
@@ -146,6 +152,14 @@ RUN mkdir /app && \
     chown -R $USER:0 /app /tmp && \
     chmod -R g+rwX /app /tmp
 
+# Need a better way to address these hacks
+RUN if [[ "${ENABLE_AIM}" == "true" ]] ; then \
+        touch /.aim_profile && \
+        chmod -R 777 /.aim_profile; \
+    fi
+RUN mkdir /.cache && \
+    chmod -R 777 /.cache
+
 # Copy scripts and default configs
 COPY build/accelerate_launch.py fixtures/accelerate_fsdp_defaults.yaml /app/
 COPY build/utils.py /app/build/
@@ -153,12 +167,6 @@ RUN chmod +x /app/accelerate_launch.py
 
 ENV FSDP_DEFAULTS_FILE_PATH="/app/accelerate_fsdp_defaults.yaml"
 ENV SET_NUM_PROCESSES_TO_NUM_GPUS="True"
-
-# Need a better way to address this hack
-RUN touch /.aim_profile && \
-    chmod -R 777 /.aim_profile && \
-    mkdir /.cache && \
-    chmod -R 777 /.cache
 
 WORKDIR /app
 USER ${USER}


### PR DESCRIPTION
### Description of the change

Add a dockerfile argument to enable aimstack

### Related issue number

NA

### How to verify the PR

Run with a dockerfile built with and without the argument `ENABLE_AIM`

### Was the PR tested

Tested the PR with both scenarios, `ENABLE_AIM` does not set and `ENABLE_AIM=true`


Tested without `ENABLE_AIM` argument

```
[dushyantbehl@experimentsplatform fms-hf-tuning]$ docker build -t fms-hf-tuning:dev . -f build/Dockerfile
[+] Building 562.1s (30/30) FINISHED                                                                                                                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.1s
 => => transferring dockerfile: 6.51kB                                                                                                                                                                                                                   0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)                                                                                                                                                                          0.1s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi:latest                                                                                                                                                                              1.3s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => CACHED [internal] settings cache mount permissions                                                                                                                                                                                                   0.0s
 => [base 1/3] FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:1ee4d8c50d14d9c9e9229d9a039d793fcbc9aa803806d194c957a397cf1d2b17                                                                                                                  13.8s
 => => resolve registry.access.redhat.com/ubi9/ubi:latest@sha256:1ee4d8c50d14d9c9e9229d9a039d793fcbc9aa803806d194c957a397cf1d2b17                                                                                                                        0.0s
 => => sha256:1ee4d8c50d14d9c9e9229d9a039d793fcbc9aa803806d194c957a397cf1d2b17 1.47kB / 1.47kB                                                                                                                                                           0.0s
 => => sha256:763f30167f92ec2af02bf7f09e75529de66e98f05373b88bef3c631cdcc39ad8 429B / 429B                                                                                                                                                               0.0s
 => => sha256:159a1e67312ef50059357047ebe2a365afea904504fca9561abb385ecd942d62 6.43kB / 6.43kB                                                                                                                                                           0.0s
 => => sha256:cc296d75b61273dcb0db7527435a4c3bd03f7723d89a94d446d3d52849970460 79.43MB / 79.43MB                                                                                                                                                         1.5s
 => => extracting sha256:cc296d75b61273dcb0db7527435a4c3bd03f7723d89a94d446d3d52849970460                                                                                                                                                               11.9s
 => [internal] load build context                                                                                                                                                                                                                        0.4s
 => => transferring context: 1.18MB                                                                                                                                                                                                                      0.4s
 => [base 2/3] RUN dnf remove -y --disableplugin=subscription-manager         subscription-manager     && dnf install -y python3.11 procps     && ln -s /usr/bin/python3.11 /bin/python     && python -m ensurepip --upgrade     && python -m pip inst  16.4s
 => [base 3/3] RUN useradd -u 1000 tuning -m -g 0 --system &&     chmod g+rx /home/tuning                                                                                                                                                                0.6s 
 => [release-base 1/1] RUN rpm -e $(dnf repoquery python3-* -q --installed) dnf python3 yum crypto-policies-scripts                                                                                                                                      2.1s 
 => [cuda-base 1/1] RUN dnf config-manager        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo     && dnf install -y         cuda-cudart-12-1-12.1.55-1         cuda-compat-12-1-530.30.02-1     &&  9.3s 
 => [release  1/10] RUN mkdir -p /licenses                                                                                                                                                                                                               0.5s 
 => [release  2/10] COPY LICENSE /licenses/                                                                                                                                                                                                              0.1s 
 => [release  3/10] RUN mkdir /app &&     chown -R tuning:0 /app /tmp &&     chmod -R g+rwX /app /tmp                                                                                                                                                    0.5s 
 => [release  4/10] RUN if [[ "${ENABLE_AIM}" == "true" ]] ; then         touch /.aim_profile &&         chmod -R 777 /.aim_profile;     fi                                                                                                              0.5s 
 => [release  5/10] RUN mkdir /.cache &&     chmod -R 777 /.cache                                                                                                                                                                                        0.7s
 => [release  6/10] COPY build/accelerate_launch.py fixtures/accelerate_fsdp_defaults.yaml /app/                                                                                                                                                         0.2s
 => [release  7/10] COPY build/utils.py /app/build/                                                                                                                                                                                                      0.1s
 => [release  8/10] RUN chmod +x /app/accelerate_launch.py                                                                                                                                                                                               0.5s
 => [release  9/10] WORKDIR /app                                                                                                                                                                                                                         0.1s
 => [cuda-devel 1/1] RUN dnf config-manager        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo     && dnf install -y         cuda-command-line-tools-12-1-12.1.0-1         cuda-libraries-devel-  197.8s
 => [python-installations 1/8] RUN dnf install -y git &&     rm -f /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem &&     dnf clean all                                                                                                          11.7s 
 => [python-installations 2/8] WORKDIR /tmp                                                                                                                                                                                                              0.1s 
 => [python-installations 3/8] RUN --mount=type=cache,target=/home/tuning/.cache/pip,uid=1000     python -m pip install --user build                                                                                                                     1.5s 
 => [python-installations 4/8] COPY --chown=tuning:root tuning tuning                                                                                                                                                                                    0.1s 
 => [python-installations 5/8] COPY .git .git                                                                                                                                                                                                            0.1s 
 => [python-installations 6/8] COPY pyproject.toml pyproject.toml                                                                                                                                                                                        0.1s 
 => [python-installations 7/8] RUN if [[ -z "" ]];     then python -m build --wheel --outdir /tmp;     else pip download fms-hf-tuning== --dest /tmp --only-binary=:all: --no-deps;     fi &&     ls /tmp/*.whl >/tmp/bdist_name                         3.8s 
 => [python-installations 8/8] RUN --mount=type=cache,target=/home/tuning/.cache/pip,uid=1000     python -m pip install --user wheel &&     python -m pip install --user "$(head bdist_name)" &&     python -m pip install --user "$(head bdist_name)  154.4s 
 => [release 10/10] COPY --from=python-installations /home/tuning/.local /home/tuning/.local                                                                                                                                                            39.8s 
 => exporting to image                                                                                                                                                                                                                                  85.9s 
 => => exporting layers                                                                                                                                                                                                                                 85.8s 
 => => writing image sha256:91d6aeae2b7391243cff36eee99fa61b81cb478f61726591bcfcf8343a308737                                                                                                                                                             0.0s 
 => => naming to docker.io/library/fms-hf-tuning:dev                                                                                                                                                                                                     0.0s 
                                                                                                                                                                                                                                                              
 9 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 46)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 53)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 77)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 101)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 144)
 - UndefinedVar: Usage of undefined variable '$CUDA_HOME' (line 72)
 - UndefinedVar: Usage of undefined variable '$CUDA_HOME' (line 72)
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 72)
```

Verification with `pip freeze`

```
[dushyantbehl@experimentsplatform fms-hf-tuning]$ docker run -it fms-hf-tuning:dev /bin/bash
[tuning@0c6af3eccb7f app]$ pip freeze | grep aim
[tuning@0c6af3eccb7f app]$ exit
exit
```


Tested With `ENABLE_AIM=true` build arg

```
[dushyantbehl@experimentsplatform fms-hf-tuning]$ docker build -t fms-hf-tuning-aim:dev . -f build/Dockerfile --build-arg ENABLE_AIM=true
[+] Building 312.5s (30/30) FINISHED                                                                                                                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 6.51kB                                                                                                                                                                                                                   0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)                                                                                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 46)                                                                                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 53)                                                                                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 77)                                                                                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 101)                                                                                                                                                                         0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 144)                                                                                                                                                                         0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi:latest                                                                                                                                                                              0.3s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => CACHED [internal] settings cache mount permissions                                                                                                                                                                                                   0.0s
 => [internal] load build context                                                                                                                                                                                                                        0.0s
 => => transferring context: 11.14kB                                                                                                                                                                                                                     0.0s
 => [base 1/3] FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:1ee4d8c50d14d9c9e9229d9a039d793fcbc9aa803806d194c957a397cf1d2b17                                                                                                                   0.0s
 => CACHED [base 2/3] RUN dnf remove -y --disableplugin=subscription-manager         subscription-manager     && dnf install -y python3.11 procps     && ln -s /usr/bin/python3.11 /bin/python     && python -m ensurepip --upgrade     && python -m pi  0.0s
 => CACHED [base 3/3] RUN useradd -u 1000 tuning -m -g 0 --system &&     chmod g+rx /home/tuning                                                                                                                                                         0.0s
 => CACHED [cuda-base 1/1] RUN dnf config-manager        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo     && dnf install -y         cuda-cudart-12-1-12.1.55-1         cuda-compat-12-1-530.30.02-1  0.0s
 => CACHED [cuda-devel 1/1] RUN dnf config-manager        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo     && dnf install -y         cuda-command-line-tools-12-1-12.1.0-1         cuda-libraries-d  0.0s
 => [python-installations 1/8] RUN dnf install -y git &&     rm -f /usr/share/doc/perl-Net-SSLeay/examples/server_key.pem &&     dnf clean all                                                                                                          11.2s
 => [python-installations 2/8] WORKDIR /tmp                                                                                                                                                                                                              0.2s
 => [python-installations 3/8] RUN --mount=type=cache,target=/home/tuning/.cache/pip,uid=1000     python -m pip install --user build                                                                                                                     1.2s 
 => [python-installations 4/8] COPY --chown=tuning:root tuning tuning                                                                                                                                                                                    0.1s 
 => [python-installations 5/8] COPY .git .git                                                                                                                                                                                                            0.1s 
 => [python-installations 6/8] COPY pyproject.toml pyproject.toml                                                                                                                                                                                        0.1s 
 => [python-installations 7/8] RUN if [[ -z "" ]];     then python -m build --wheel --outdir /tmp;     else pip download fms-hf-tuning== --dest /tmp --only-binary=:all: --no-deps;     fi &&     ls /tmp/*.whl >/tmp/bdist_name                         3.8s 
 => [python-installations 8/8] RUN --mount=type=cache,target=/home/tuning/.cache/pip,uid=1000     python -m pip install --user wheel &&     python -m pip install --user "$(head bdist_name)" &&     python -m pip install --user "$(head bdist_name)  136.9s 
 => CACHED [release-base 1/1] RUN rpm -e $(dnf repoquery python3-* -q --installed) dnf python3 yum crypto-policies-scripts                                                                                                                               0.0s 
 => CACHED [release  1/10] RUN mkdir -p /licenses                                                                                                                                                                                                        0.0s 
 => CACHED [release  2/10] COPY LICENSE /licenses/                                                                                                                                                                                                       0.0s 
 => CACHED [release  3/10] RUN mkdir /app &&     chown -R tuning:0 /app /tmp &&     chmod -R g+rwX /app /tmp                                                                                                                                             0.0s 
 => CACHED [release  4/10] RUN if [[ "${ENABLE_AIM}" == "true" ]] ; then         touch /.aim_profile &&         chmod -R 777 /.aim_profile;     fi                                                                                                       0.0s 
 => CACHED [release  5/10] RUN mkdir /.cache &&     chmod -R 777 /.cache                                                                                                                                                                                 0.0s 
 => CACHED [release  6/10] COPY build/accelerate_launch.py fixtures/accelerate_fsdp_defaults.yaml /app/                                                                                                                                                  0.0s
 => CACHED [release  7/10] COPY build/utils.py /app/build/                                                                                                                                                                                               0.0s
 => CACHED [release  8/10] RUN chmod +x /app/accelerate_launch.py                                                                                                                                                                                        0.0s
 => CACHED [release  9/10] WORKDIR /app                                                                                                                                                                                                                  0.0s
 => [release 10/10] COPY --from=python-installations /home/tuning/.local /home/tuning/.local                                                                                                                                                            42.9s
 => exporting to image                                                                                                                                                                                                                                  90.4s
 => => exporting layers                                                                                                                                                                                                                                 90.4s
 => => writing image sha256:40e46b9deee9bf1b7cf9e7feb093e57e0b7105f81589ba4cadb5f509c0ab24b0                                                                                                                                                             0.0s
 => => naming to docker.io/library/fms-hf-tuning-aim:dev                                                                                                                                                                                                 0.0s

 9 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 46)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 53)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 77)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 101)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 144)
 - UndefinedVar: Usage of undefined variable '$CUDA_HOME' (line 72)
 - UndefinedVar: Usage of undefined variable '$CUDA_HOME' (line 72)
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 72)

```

Verification with `pip freeze`

```
[dushyantbehl@experimentsplatform fms-hf-tuning]$ docker run -it fms-hf-tuning-aim:dev /bin/bash
[tuning@737ad308731f app]$ pip freeze | grep aim
aim==3.23.0
aim-ui==3.23.0
aimrecords==0.0.7
aimrocks==0.5.2
[tuning@737ad308731f app]$ exit
exit
```