### PR TITLE
feat: logging control operation

### DIFF
--- a/examples/trainercontroller_configs/log_controller.yaml
+++ b/examples/trainercontroller_configs/log_controller.yaml
@@ -1,11 +1,11 @@
 controller_metrics:
-  - name: state
+  - name: trainer_state
     class: TrainingState
 operations:
   - name: logcontrolstep
     class: LogControl
     arguments:
-      log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
+      log_format: 'This is a test log format [{event_name}] => {trainer_state}'
       log_level: WARNING
 controllers:
   - name: log-controller-step

--- a/examples/trainercontroller_configs/log_controller.yaml
+++ b/examples/trainercontroller_configs/log_controller.yaml
@@ -6,7 +6,7 @@ operations:
     class: LogControl
     arguments:
       log_format: 'This is a test log format [{event_name}] => {trainer_state}'
-      log_level: WARNING
+      log_level: warning
 controllers:
   - name: log-controller-step
     triggers:

--- a/examples/trainercontroller_configs/log_controller.yaml
+++ b/examples/trainercontroller_configs/log_controller.yaml
@@ -1,0 +1,16 @@
+controller_metrics:
+  - name: state
+    class: TrainingState
+operations:
+  - name: logcontrolstep
+    class: LogControl
+    arguments:
+      log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
+      log_level: WARNING
+controllers:
+  - name: log-controller-step
+    triggers:
+      - on_step_end
+    rule: 'True'
+    operations:
+      - logcontrolstep.should_log

--- a/tests/data/trainercontroller/__init__.py
+++ b/tests/data/trainercontroller/__init__.py
@@ -78,3 +78,4 @@ TRAINER_CONFIG_TEST_THRESHOLDED_TRAINING_LOSS_YAML = os.path.join(
     _DATA_DIR, "thresholded-training-loss.yaml"
 )
 TRAINER_CONFIG_TEST_ON_SAVE_YAML = os.path.join(_DATA_DIR, "on-save.yaml")
+TRAINER_CONFIG_LOG_CONTROLLER_YAML = os.path.join(_DATA_DIR, "log_controller.yaml")

--- a/tests/data/trainercontroller/log_controller.yaml
+++ b/tests/data/trainercontroller/log_controller.yaml
@@ -1,11 +1,11 @@
 controller_metrics:
-  - name: state
+  - name: trainer_state
     class: TrainingState
 operations:
   - name: logcontrolstep
     class: LogControl
     arguments:
-      log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
+      log_format: 'This is a test log format [{event_name}] => {trainer_state}'
       log_level: warning
 controllers:
   - name: log-controller-step

--- a/tests/data/trainercontroller/log_controller.yaml
+++ b/tests/data/trainercontroller/log_controller.yaml
@@ -1,0 +1,16 @@
+controller_metrics:
+  - name: state
+    class: TrainingState
+operations:
+  - name: logcontrolstep
+    class: LogControl
+    arguments:
+      log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
+      log_level: WARNING
+controllers:
+  - name: log-controller-step
+    triggers:
+      - on_step_end
+    rule: 'True'
+    operations:
+      - logcontrolstep.should_log

--- a/tests/data/trainercontroller/log_controller.yaml
+++ b/tests/data/trainercontroller/log_controller.yaml
@@ -6,7 +6,7 @@ operations:
     class: LogControl
     arguments:
       log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
-      log_level: WARNING
+      log_level: warning
 controllers:
   - name: log-controller-step
     triggers:

--- a/tests/data/trainercontroller/loss_on_threshold_with_trainer_state.yaml
+++ b/tests/data/trainercontroller/loss_on_threshold_with_trainer_state.yaml
@@ -1,5 +1,5 @@
 controller_metrics:
-  - name: state
+  - name: trainer_state
     class: TrainingState
   - name: training_loss
     class: Loss
@@ -7,6 +7,6 @@ controllers:
   - name: loss_controller
     triggers:
       - on_log
-    rule: training_loss['loss'] < 2 and state["epoch"] >= 0.5
+    rule: training_loss['loss'] < 2 and trainer_state["epoch"] >= 0.5
     operations:
       - hfcontrols.should_training_stop

--- a/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
+++ b/tests/data/trainercontroller/loss_with_invalid_type_rule.yaml
@@ -1,5 +1,5 @@
 controller_metrics:
-  - name: loss
+  - name: training_loss
     class: Loss
 controllers:
   - name: loss_controller_wrong_os_rule

--- a/tests/data/trainercontroller/on-save.yaml
+++ b/tests/data/trainercontroller/on-save.yaml
@@ -1,10 +1,10 @@
 controller_metrics:
-  - name: state
+  - name: trainer_state
     class: TrainingState
 controllers:
   - name: stop_on_training_loss_on_save
     triggers:
       - on_save
-    rule: state["epoch"] >= 0.5
+    rule: trainer_state["epoch"] >= 0.5
     operations:
       - hfcontrols.should_training_stop

--- a/tests/trainercontroller/test_tuning_trainercontroller.py
+++ b/tests/trainercontroller/test_tuning_trainercontroller.py
@@ -145,6 +145,10 @@ def test_thresholded_training_loss_on_save():
     test_data = _setup_data()
     tc_callback = tc.TrainerControllerCallback(td.TRAINER_CONFIG_TEST_ON_SAVE_YAML)
     control = TrainerControl(should_training_stop=False)
+    # Trigger on_init_end to perform registration of handlers to events
+    tc_callback.on_init_end(
+        args=test_data.args, state=test_data.states[2], control=control
+    )
     # Trigger rule and test the condition
     tc_callback.on_save(args=test_data.args, state=test_data.states[2], control=control)
     assert control.should_training_stop is True

--- a/tests/trainercontroller/test_tuning_trainercontroller.py
+++ b/tests/trainercontroller/test_tuning_trainercontroller.py
@@ -137,6 +137,7 @@ def test_thresholded_training_loss():
     tc_callback.on_log(args=test_data.args, state=test_data.states[2], control=control)
     assert control.should_training_stop is True
 
+
 def test_thresholded_training_loss_on_save():
     """Tests the thresholded training loss example in
     `examples/trainer-controller-configs/on-save.yaml`
@@ -147,6 +148,7 @@ def test_thresholded_training_loss_on_save():
     # Trigger rule and test the condition
     tc_callback.on_save(args=test_data.args, state=test_data.states[2], control=control)
     assert control.should_training_stop is True
+
 
 def test_log_controller(caplog):
     """Tests the expose metric scenario example in
@@ -163,6 +165,7 @@ def test_log_controller(caplog):
         args=test_data.args, state=test_data.states[2], control=control
     )
     assert "This is a test log format" in caplog.text
+
 
 def test_non_decreasing_training_loss():
     """Tests the non-decreasing training loss example in

--- a/tests/trainercontroller/test_tuning_trainercontroller.py
+++ b/tests/trainercontroller/test_tuning_trainercontroller.py
@@ -137,7 +137,6 @@ def test_thresholded_training_loss():
     tc_callback.on_log(args=test_data.args, state=test_data.states[2], control=control)
     assert control.should_training_stop is True
 
-
 def test_thresholded_training_loss_on_save():
     """Tests the thresholded training loss example in
     `examples/trainer-controller-configs/on-save.yaml`
@@ -145,14 +144,25 @@ def test_thresholded_training_loss_on_save():
     test_data = _setup_data()
     tc_callback = tc.TrainerControllerCallback(td.TRAINER_CONFIG_TEST_ON_SAVE_YAML)
     control = TrainerControl(should_training_stop=False)
-    # Trigger on_init_end to perform registration of handlers to events
-    tc_callback.on_init_end(
-        args=test_data.args, state=test_data.states[2], control=control
-    )
     # Trigger rule and test the condition
     tc_callback.on_save(args=test_data.args, state=test_data.states[2], control=control)
     assert control.should_training_stop is True
 
+def test_log_controller(caplog):
+    """Tests the expose metric scenario example in
+    `examples/trainer-controller-configs/log_controller.yaml`
+    """
+    test_data = _setup_data()
+    tc_callback = tc.TrainerControllerCallback(td.TRAINER_CONFIG_LOG_CONTROLLER_YAML)
+    control = TrainerControl(should_log=False)
+    # Trigger on_init_end to perform registration of handlers to events
+    tc_callback.on_init_end(
+        args=test_data.args, state=test_data.states[2], control=control
+    )
+    tc_callback.on_step_end(
+        args=test_data.args, state=test_data.states[2], control=control
+    )
+    assert "This is a test log format" in caplog.text
 
 def test_non_decreasing_training_loss():
     """Tests the non-decreasing training loss example in

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -255,12 +255,12 @@ class TrainerControllerCallback(TrainerCallback):
                     for operation_action in control_action.operation_actions:
                         operation_action.instance.act(
                             action=operation_action.action,
-                            tc_metrics=self.metrics,
-                            event_name=event_name,
-                            control_name=control_action.name,
                             log_level=control_action.config[
                                 CONTROLLER_CONFIG_TRIGGER_LOG_LEVEL
                             ],
+                            tc_metrics=self.metrics,
+                            event_name=event_name,
+                            control_name=control_action.name,
                             **kwargs,
                         )
 

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -258,9 +258,9 @@ class TrainerControllerCallback(TrainerCallback):
                             log_level=control_action.config[
                                 CONTROLLER_CONFIG_TRIGGER_LOG_LEVEL
                             ],
-                            tc_metrics=self.metrics,
                             event_name=event_name,
                             control_name=control_action.name,
+                            **self.metrics,
                             **kwargs,
                         )
 

--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -255,8 +255,8 @@ class TrainerControllerCallback(TrainerCallback):
                     for operation_action in control_action.operation_actions:
                         operation_action.instance.act(
                             action=operation_action.action,
-                            event_name=event_name,
                             tc_metrics=self.metrics,
+                            event_name=event_name,
                             control_name=control_action.name,
                             log_level=control_action.config[
                                 CONTROLLER_CONFIG_TRIGGER_LOG_LEVEL

--- a/tuning/trainercontroller/controllermetrics/trainingstate.py
+++ b/tuning/trainercontroller/controllermetrics/trainingstate.py
@@ -21,9 +21,12 @@ import dataclasses
 
 # Third Party
 from transformers import TrainerState
+from transformers.utils import logging
 
 # Local
 from tuning.trainercontroller.controllermetrics.metricshandler import MetricHandler
+
+logger = logging.get_logger(__name__)
 
 
 class TrainingState(MetricHandler):
@@ -49,7 +52,7 @@ class TrainingState(MetricHandler):
                 "on_train_begin",
                 "on_evaluate",
             ],
-            **kwargs
+            **kwargs,
         )
 
     def validate(self) -> bool:
@@ -71,4 +74,5 @@ class TrainingState(MetricHandler):
         Returns:
             dict. Trainer state as a dictionary
         """
+        logger.warning(f"Trainer state: {dataclasses.asdict(state)}")
         return dataclasses.asdict(state)

--- a/tuning/trainercontroller/controllermetrics/trainingstate.py
+++ b/tuning/trainercontroller/controllermetrics/trainingstate.py
@@ -74,5 +74,4 @@ class TrainingState(MetricHandler):
         Returns:
             dict. Trainer state as a dictionary
         """
-        logger.warning(f"Trainer state: {dataclasses.asdict(state)}")
         return dataclasses.asdict(state)

--- a/tuning/trainercontroller/operations/__init__.py
+++ b/tuning/trainercontroller/operations/__init__.py
@@ -3,6 +3,7 @@ from typing import Type
 
 # Local
 from .hfcontrols import HFControls
+from .logcontrol import LogControl
 from .operation import Operation
 
 # List of operation handlers
@@ -20,3 +21,4 @@ def register(cl: Type):
 
 # Register the default operation handlers in this package here
 register(HFControls)
+register(LogControl)

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -8,14 +8,6 @@ from .operation import Operation
 logger = logging.get_logger(__name__)
 logger.setLevel(level=logging.DEBUG)
 
-VALID_LOG_LEVELS = {
-    "ERROR": logging.ERROR,
-    "WARNING": logging.WARNING,
-    "INFO": logging.INFO,
-    "DEBUG": logging.DEBUG,
-}
-
-
 class LogControl(Operation):
     """Operation that can be used to log useful information on specific events."""
 
@@ -27,11 +19,12 @@ class LogControl(Operation):
         Args:
             kwargs: List of arguments (key, value)-pairs
         """
-        if log_level not in VALID_LOG_LEVELS:
+        log_levels = logging.get_log_levels_dict()
+        if log_level not in log_levels:
             raise ValueError(
                 "Specified log_level [%s] is invalid for LogControl" % (log_level)
             )
-        self.log_level = VALID_LOG_LEVELS[log_level]
+        self.log_level = log_levels[log_level]
         self.log_format = log_format
         super().__init__(**kwargs)
 

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -31,7 +31,6 @@ class LogControl(Operation):
 
     def should_log(
         self,
-        tc_metrics: dict,
         event_name: str = None,
         control_name: str = None,
         args: TrainingArguments = None,
@@ -47,7 +46,6 @@ class LogControl(Operation):
         log_msg = self.log_format.format(
             event_name=event_name,
             control_name=control_name,
-            tc_metrics=tc_metrics,
             args=args,
             **kwargs,
         )

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -1,0 +1,61 @@
+# Third Party
+from transformers import TrainingArguments
+from transformers.utils import logging
+
+# Local
+from .operation import Operation
+
+logger = logging.get_logger(__name__)
+logger.setLevel(level=logging.DEBUG)
+
+VALID_LOG_LEVELS = {
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+}
+
+
+class LogControl(Operation):
+    """Operation that can be used to log useful information on specific events."""
+
+    def __init__(self, log_format: str, log_level: str, **kwargs):
+        """Initializes the HuggingFace controls. In this init, the fields with `should_` of the
+        transformers.TrainerControl data class are extracted, and for each of those fields, the
+        control_action() method's pointer is set, and injected as a class member function.
+
+        Args:
+            kwargs: List of arguments (key, value)-pairs
+        """
+        if log_level not in VALID_LOG_LEVELS:
+            raise ValueError(
+                "Specified log_level [%s] is invalid for LogControl" % (log_level)
+            )
+        self.log_level = VALID_LOG_LEVELS[log_level]
+        self.log_format = log_format
+        super().__init__(**kwargs)
+
+    def should_log(
+        self,
+        event_name: str,
+        tc_metrics: dict,
+        args: TrainingArguments,
+        **kwargs,
+    ):
+        """This method peeks into the stack-frame of the caller to get the action the triggered
+        a call to it. Using the name of the action, the value of the control is set.
+
+        Args:
+            control: TrainerControl. Data class for controls.
+            kwargs: List of arguments (key, value)-pairs
+        """
+        log_msg = self.log_format.format(
+            event_name=event_name,
+            tc_metrics=tc_metrics,
+            args=args,
+            **kwargs,
+        )
+        logger.log(
+            self.log_level,
+            log_msg,
+        )

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -31,9 +31,11 @@ class LogControl(Operation):
 
     def should_log(
         self,
-        event_name: str,
         tc_metrics: dict,
-        args: TrainingArguments,
+        event_name: str=None,
+        control_name: str=None,
+        log_level: str=logging.DEBUG,
+        args: TrainingArguments=None,
         **kwargs,
     ):
         """This method peeks into the stack-frame of the caller to get the action the triggered

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -34,7 +34,6 @@ class LogControl(Operation):
         tc_metrics: dict,
         event_name: str = None,
         control_name: str = None,
-        log_level: str = logging.DEBUG,
         args: TrainingArguments = None,
         **kwargs,
     ):
@@ -47,6 +46,7 @@ class LogControl(Operation):
         """
         log_msg = self.log_format.format(
             event_name=event_name,
+            control_name=control_name,
             tc_metrics=tc_metrics,
             args=args,
             **kwargs,

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -32,10 +32,10 @@ class LogControl(Operation):
     def should_log(
         self,
         tc_metrics: dict,
-        event_name: str=None,
-        control_name: str=None,
-        log_level: str=logging.DEBUG,
-        args: TrainingArguments=None,
+        event_name: str = None,
+        control_name: str = None,
+        log_level: str = logging.DEBUG,
+        args: TrainingArguments = None,
         **kwargs,
     ):
         """This method peeks into the stack-frame of the caller to get the action the triggered

--- a/tuning/trainercontroller/operations/logcontrol.py
+++ b/tuning/trainercontroller/operations/logcontrol.py
@@ -8,6 +8,7 @@ from .operation import Operation
 logger = logging.get_logger(__name__)
 logger.setLevel(level=logging.DEBUG)
 
+
 class LogControl(Operation):
     """Operation that can be used to log useful information on specific events."""
 

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -17,6 +17,8 @@ class Operation(metaclass=abc.ABCMeta):
         every action should preceed with prefix `should_`. If so, it is treated as a valid
         action.
         """
+        self._name = name
+        self.kwargs = kwargs
         self.valid_actions = {}
         self.name = name
         self.kwargs = kwargs
@@ -25,6 +27,14 @@ class Operation(metaclass=abc.ABCMeta):
         ):
             if re.search(r"^should_.+", action_name) is not None:
                 self.valid_actions[action_name] = action_method
+
+    def get_name(self) -> str:
+        """Returns the name of the operation.
+
+        Returns:
+            str
+        """
+        return self._name
 
     def validate(self, action: str) -> bool:
         """Validates the action by checking if it valid action or not.

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -73,8 +73,8 @@ class Operation(metaclass=abc.ABCMeta):
             control_name,
             event_name,
         )
-        kwargs['event_name'] = event_name
-        kwargs['control_name'] = control_name
+        kwargs["event_name"] = event_name
+        kwargs["control_name"] = control_name
         self.valid_actions[action](**kwargs)
 
     def get_actions(self) -> list[str]:

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -50,9 +50,9 @@ class Operation(metaclass=abc.ABCMeta):
     def act(
         self,
         action: str,
+        log_level: int,
         event_name: str = None,
         control_name: str = None,
-        log_level: int = logging.DEBUG,
         **kwargs,
     ):
         """Validates the action and invokes it.

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -48,7 +48,12 @@ class Operation(metaclass=abc.ABCMeta):
         return action in self.valid_actions
 
     def act(
-        self, action: str, event_name: str=None, control_name: str=None, log_level: int=logging.DEBUG, **kwargs
+        self,
+        action: str,
+        event_name: str = None,
+        control_name: str = None,
+        log_level: int = logging.DEBUG,
+        **kwargs,
     ):
         """Validates the action and invokes it.
 

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -48,7 +48,7 @@ class Operation(metaclass=abc.ABCMeta):
         return action in self.valid_actions
 
     def act(
-        self, action: str, event_name: str, control_name: str, log_level: int, **kwargs
+        self, action: str, event_name: str=None, control_name: str=None, log_level: int=logging.DEBUG, **kwargs
     ):
         """Validates the action and invokes it.
 

--- a/tuning/trainercontroller/operations/operation.py
+++ b/tuning/trainercontroller/operations/operation.py
@@ -73,6 +73,8 @@ class Operation(metaclass=abc.ABCMeta):
             control_name,
             event_name,
         )
+        kwargs['event_name'] = event_name
+        kwargs['control_name'] = control_name
         self.valid_actions[action](**kwargs)
 
     def get_actions(self) -> list[str]:


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Logging control operation to inject logs into the training loop.

### Related issue number

"Closes #179"

### How to verify the PR

Use the following trainer controller configuration to try out the logging control:
```
controller_metrics:
  - name: state
    class: TrainingState
operations:
  - name: logcontrolstep
    class: LogControl
    arguments:
      log_format: 'This is a test log format [{event_name}] => {tc_metrics[state]}'
      log_level: warning
controllers:
  - name: log-controller-step
    triggers:
      - on_step_end
    rule: 'True'
    operations:
      - logcontrolstep.should_log
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass