### PR TITLE
fix: multiple runid creation bug with distributed training

### DIFF
--- a/tuning/trackers/aimstack_tracker.py
+++ b/tuning/trackers/aimstack_tracker.py
@@ -63,8 +63,10 @@ class RunIDExporterAimCallback(AimCallback):
         Args:
             For the arguments see reference to transformers.TrainingCallback
         """
-        # pylint: disable=unused-argument
-        self.setup()  # initialize aim's run_hash
+        super().on_init_end(args, state, control, **kwargs)
+
+        if not self._run:
+            return
 
         # Change default run hash path to output directory if not specified
         if self.run_id_export_path is None:


### PR DESCRIPTION
<!-- Thank you for the contribution! -->
### Description of the change

Fixes a bug where multiple runid were being created with accelerate.

Before - 

![Screenshot from 2024-08-06 14-21-31](https://github.com/user-attachments/assets/750acc99-1b80-46e6-b95e-d36822f76fcb)


After - 

![image](https://github.com/user-attachments/assets/65b6ffe8-baac-4e19-a60a-a2336c95cf1e)


<!-- Please summarize the changes -->

### Related issue number

N/A

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass