### PR TITLE
Set default value of target_modules to be None in LoraConfig

### DIFF
--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -52,10 +52,9 @@ def test_get_hf_peft_config_returns_lora_config_correctly():
     assert (
         config.lora_dropout == 0.05
     )  # default value from local peft_config.LoraConfig
-    assert config.target_modules == {
-        "q_proj",
-        "v_proj",
-    }  # default value from local peft_config.LoraConfig
+    assert (
+        config.target_modules is None
+    )  # default value from local peft_config.LoraConfig
     assert config.init_lora_weights is True  # default value from HF peft.LoraConfig
     assert (
         config.megatron_core == "megatron.core"

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -46,7 +46,7 @@ class LoraConfig:
     r: int = 8
     lora_alpha: int = 32
     target_modules: List[str] = field(
-        default_factory=lambda: ["q_proj", "v_proj"],
+        default=None,
         metadata={
             "help": "The names of the modules to apply LORA to. LORA selects modules which either \
             completely match or "


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Original issue (from Slack):
> By default target_modules None should work, and it will use the default values [HF has here](https://github.com/huggingface/peft/blob/7b1c08d2b5e13d3c99b7d6ee83eab90e1216d4ba/src/peft/utils/constants.py#L70) for each architecture when not specified  . In [PEFT LoraConfig](https://huggingface.co/docs/peft/en/package_reference/lora#peft.LoraConfig) default is None.
> In our Config also we should set it to None in [tuning/config/peft_config.py](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/tuning/config/peft_config.py#L48) and ensure it still works with None through unit tests.

In short, changed
`default_factory=lambda: ["q_proj", "v_proj"],` to `default=None,` in the LoraConfig class.

### Related issue number
N/A

### How to verify the PR
Run unit tests.
Additionally, you can run tuning on a model, and on the output model check target_modules in adapter_config.json matches the intended target_modules of the model used.

### Was the PR tested
- [ ] I have added >=1 unit test(s) for every new method I have added. 
- [x] I have ensured all unit tests pass

If you have any questions or concerns, please respond below. Thanks!