### PR TITLE
feat: Add DataClass Arguments to Activate Padding-Free and MultiPack Plugin and FastKernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,15 +621,26 @@ The list of configurations for various `fms_acceleration` plugins:
 - [fused_ops_and_kernels](./tuning/config/acceleration_configs/fused_ops_and_kernels.py) (experimental):
   - `--fused_lora`: fused lora for more efficient LoRA training.
   - `--fast_kernels`: fast cross-entropy, rope, rms loss kernels.
+- [attention_and_distributed_packing](./tuning/config/acceleration_configs/attention_and_distributed_packing.py) (experimental):
+  - `--padding_free`: technique to process multiple examples in single batch without adding padding tokens that waste compute.
+  - `--multipack`: technique for *multi-gpu training* to balance out number of tokens processed in each device, to minimize waiting time.
 
 Notes: 
  * `quantized_lora_config` requires that it be used along with LoRA tuning technique. See [LoRA tuning section](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main?tab=readme-ov-file#lora-tuning-example) on the LoRA parameters to pass.
  * When setting `--auto_gptq triton_v2` plus note to also pass `--torch_dtype float16` and `--fp16`, or an exception will be raised. This is because these kernels only support this dtype.
- * Currently, the `fused_ops_and_kernels` is to be used used together QLoRA or GPTQ-LORA via the `quantized_lora_config`. In the future it may be made more flexible such that `fast_kernels` can even be used with full-finetuning.
  * When using `fused_ops_and_kernels` together with `quantized_lora_config`,
  make sure to appropriately set `--fused_lora auto_gptq True` or `bitsandbytes True`; the `True` sets `fast_lora==True`.
- * Currently `fused_ops_and_kernels` only supports activating `fast_loss,fast_rsm_layernorm,fast_rope_embeddings` all to `True`, so pass `--fast_kernels True True True`.
-
+ * `fused_ops_and_kernels` works for full-finetuning, LoRA, QLoRA and GPTQ-LORA, 
+    - pass `--fast_kernels True True True` for full finetuning/LoRA
+    - pass `--fast_kernels True True True --auto_gptq triton_v2 --fused_lora auto_gptq True` for GPTQ-LoRA
+    - pass `--fast_kernels True True True --bitsandbytes nf4 --fused_lora bitsandbytes True` for QLoRA
+ * Notes on Padding Free
+  - works for both *single* and *multi-gpu*. 
+  - works on both *pretokenized* and *untokenized* datasets
+  - verified against the version found in HF main, merged in via PR https://github.com/huggingface/transformers/pull/31629.
+ * Notes on Multipack
+  - works only for *multi-gpu*.
+  - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
 
 Activate `TRANSFORMERS_VERBOSITY=info` to see the huggingface trainer printouts and verify that `AccelerationFramework` is activated!
 

--- a/README.md
+++ b/README.md
@@ -635,12 +635,12 @@ Notes:
     - pass `--fast_kernels True True True --auto_gptq triton_v2 --fused_lora auto_gptq True` for GPTQ-LoRA
     - pass `--fast_kernels True True True --bitsandbytes nf4 --fused_lora bitsandbytes True` for QLoRA
  * Notes on Padding Free
-  - works for both *single* and *multi-gpu*. 
-  - works on both *pretokenized* and *untokenized* datasets
-  - verified against the version found in HF main, merged in via PR https://github.com/huggingface/transformers/pull/31629.
+    - works for both *single* and *multi-gpu*. 
+    - works on both *pretokenized* and *untokenized* datasets
+    - verified against the version found in HF main, merged in via PR https://github.com/huggingface/transformers/pull/31629.
  * Notes on Multipack
-  - works only for *multi-gpu*.
-  - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
+    - works only for *multi-gpu*.
+    - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
 
 Activate `TRANSFORMERS_VERBOSITY=info` to see the huggingface trainer printouts and verify that `AccelerationFramework` is activated!
 

--- a/tests/acceleration/spying_utils.py
+++ b/tests/acceleration/spying_utils.py
@@ -36,7 +36,7 @@ def create_mock_plugin_class_and_spy(class_name, plugin_cls):
 
     def get_callbacks_and_ready_for_train(self, *args, **kwargs):
         spy["get_ready_for_train_calls"] += 1
-        return plugin_cls.get_callbacks_and_ready_for_train(self, args, **kwargs)
+        return plugin_cls.get_callbacks_and_ready_for_train(self, *args, **kwargs)
 
     attributes = {
         "model_loader": model_loader,

--- a/tests/acceleration/test_acceleration_dataclasses.py
+++ b/tests/acceleration/test_acceleration_dataclasses.py
@@ -27,6 +27,10 @@ from tuning.config.acceleration_configs.fused_ops_and_kernels import (
     FastKernelsConfig,
     FusedLoraConfig,
 )
+from tuning.config.acceleration_configs.instruct_lab_config import (
+    InstructLabConfig,
+    PaddingFree,
+)
 from tuning.config.acceleration_configs.quantized_lora_config import (
     AutoGPTQLoraConfig,
     BNBQLoraConfig,
@@ -64,6 +68,13 @@ def test_dataclass_parse_successfully():
     )
     assert cfg.auto_gptq is None
     assert isinstance(cfg.bnb_qlora, BNBQLoraConfig)
+
+    # 3. Specifing "--padding_free" will parse a PaddingFree class
+    parser = transformers.HfArgumentParser(dataclass_types=InstructLabConfig)
+    (cfg,) = parser.parse_args_into_dataclasses(
+        ["--padding_free", "huggingface"],
+    )
+    assert isinstance(cfg.padding_free, PaddingFree)
 
 
 def test_two_dataclasses_parse_successfully_together():
@@ -133,3 +144,9 @@ def test_dataclass_will_fail_to_accept_illegal_args():
         ValueError, match="quant_type can only be either 'nf4' or 'fp4."
     ):
         BNBQLoraConfig(quant_type="fake-quant-type")
+
+    # 3 padding-free plugin only supports huggingface models
+    with pytest.raises(
+        ValueError, match="only 'huggingface' method currently supported."
+    ):
+        PaddingFree(method="invalid-method")

--- a/tests/acceleration/test_acceleration_dataclasses.py
+++ b/tests/acceleration/test_acceleration_dataclasses.py
@@ -27,8 +27,8 @@ from tuning.config.acceleration_configs.fused_ops_and_kernels import (
     FastKernelsConfig,
     FusedLoraConfig,
 )
-from tuning.config.acceleration_configs.instruct_lab_config import (
-    InstructLabConfig,
+from tuning.config.acceleration_configs.attention_and_distributed_packing import (
+    AttentionAndDistributedPackingConfig,
     PaddingFree,
 )
 from tuning.config.acceleration_configs.quantized_lora_config import (
@@ -70,7 +70,7 @@ def test_dataclass_parse_successfully():
     assert isinstance(cfg.bnb_qlora, BNBQLoraConfig)
 
     # 3. Specifing "--padding_free" will parse a PaddingFree class
-    parser = transformers.HfArgumentParser(dataclass_types=InstructLabConfig)
+    parser = transformers.HfArgumentParser(dataclass_types=AttentionAndDistributedPackingConfig)
     (cfg,) = parser.parse_args_into_dataclasses(
         ["--padding_free", "huggingface"],
     )

--- a/tests/acceleration/test_acceleration_dataclasses.py
+++ b/tests/acceleration/test_acceleration_dataclasses.py
@@ -26,6 +26,7 @@ from tuning.config.acceleration_configs import (
 from tuning.config.acceleration_configs.attention_and_distributed_packing import (
     AttentionAndDistributedPackingConfig,
     PaddingFree,
+    MultiPack,
 )
 from tuning.config.acceleration_configs.fused_ops_and_kernels import (
     FastKernelsConfig,
@@ -77,6 +78,15 @@ def test_dataclass_parse_successfully():
         ["--padding_free", "huggingface"],
     )
     assert isinstance(cfg.padding_free, PaddingFree)
+
+    # 4. Specifing "--multipack" will parse a MultiPack class
+    parser = transformers.HfArgumentParser(
+        dataclass_types=AttentionAndDistributedPackingConfig
+    )
+    (cfg,) = parser.parse_args_into_dataclasses(
+        ["--multipack", "16"],
+    )
+    assert isinstance(cfg.multipack, MultiPack)
 
 
 def test_two_dataclasses_parse_successfully_together():

--- a/tests/acceleration/test_acceleration_dataclasses.py
+++ b/tests/acceleration/test_acceleration_dataclasses.py
@@ -23,13 +23,13 @@ from tuning.config.acceleration_configs import (
     FusedOpsAndKernelsConfig,
     QuantizedLoraConfig,
 )
-from tuning.config.acceleration_configs.fused_ops_and_kernels import (
-    FastKernelsConfig,
-    FusedLoraConfig,
-)
 from tuning.config.acceleration_configs.attention_and_distributed_packing import (
     AttentionAndDistributedPackingConfig,
     PaddingFree,
+)
+from tuning.config.acceleration_configs.fused_ops_and_kernels import (
+    FastKernelsConfig,
+    FusedLoraConfig,
 )
 from tuning.config.acceleration_configs.quantized_lora_config import (
     AutoGPTQLoraConfig,
@@ -70,7 +70,9 @@ def test_dataclass_parse_successfully():
     assert isinstance(cfg.bnb_qlora, BNBQLoraConfig)
 
     # 3. Specifing "--padding_free" will parse a PaddingFree class
-    parser = transformers.HfArgumentParser(dataclass_types=AttentionAndDistributedPackingConfig)
+    parser = transformers.HfArgumentParser(
+        dataclass_types=AttentionAndDistributedPackingConfig
+    )
     (cfg,) = parser.parse_args_into_dataclasses(
         ["--padding_free", "huggingface"],
     )

--- a/tests/acceleration/test_acceleration_dataclasses.py
+++ b/tests/acceleration/test_acceleration_dataclasses.py
@@ -25,8 +25,8 @@ from tuning.config.acceleration_configs import (
 )
 from tuning.config.acceleration_configs.attention_and_distributed_packing import (
     AttentionAndDistributedPackingConfig,
-    PaddingFree,
     MultiPack,
+    PaddingFree,
 )
 from tuning.config.acceleration_configs.fused_ops_and_kernels import (
     FastKernelsConfig,

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -434,7 +434,7 @@ def test_framework_intialized_properly_foak():
         fusedops_kernels_config = FusedOpsAndKernelsConfig(
             fused_lora=FusedLoraConfig(base_layer="auto_gptq", fused_lora=True),
             fast_kernels=FastKernelsConfig(
-                fast_loss=True, fast_rsm_layernorm=True, fast_rope_embeddings=True
+                fast_loss=True, fast_rms_layernorm=True, fast_rope_embeddings=True
             ),
         )
 

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -38,13 +38,13 @@ from tuning.config.acceleration_configs import (
 from tuning.config.acceleration_configs.acceleration_framework_config import (
     ConfigAnnotation,
 )
-from tuning.config.acceleration_configs.fused_ops_and_kernels import (
-    FastKernelsConfig,
-    FusedLoraConfig,
-)
 from tuning.config.acceleration_configs.attention_and_distributed_packing import (
     AttentionAndDistributedPackingConfig,
     PaddingFree,
+)
+from tuning.config.acceleration_configs.fused_ops_and_kernels import (
+    FastKernelsConfig,
+    FusedLoraConfig,
 )
 from tuning.config.acceleration_configs.quantized_lora_config import (
     AutoGPTQLoraConfig,
@@ -513,8 +513,7 @@ def test_framework_initialize_and_trains_with_ilab():
                     model_args,
                     data_args,
                     train_args,
-                    attention_and_distributed_packing_config=\
-                        attention_and_distributed_packing_config,
+                    attention_and_distributed_packing_config=attention_and_distributed_packing_config,
                 )
 
         # spy inside the train to ensure that the ilab plugin is called
@@ -573,9 +572,9 @@ def test_padding_free_plugin_raises_error_with_untokenized_dataset():
                         model_args,
                         data_args,
                         train_args,
-                        attention_and_distributed_packing_config=\
-                        attention_and_distributed_packing_config,
+                        attention_and_distributed_packing_config=attention_and_distributed_packing_config,
                     )
+
 
 def test_error_raised_with_paddingfree_and_flash_attn_disabled():
     """Ensure error raised when padding-free is not used with flash attention"""
@@ -584,16 +583,14 @@ def test_error_raised_with_paddingfree_and_flash_attn_disabled():
         match="`--padding_free` argument was called without enabling flash attention, \
             ensure `use_flash_attn = True` to use padding-free flash attention",
     ):
-        attention_and_distributed_packing_config = \
-            AttentionAndDistributedPackingConfig(
-                padding_free=PaddingFree(method="huggingface")
-            )
+        attention_and_distributed_packing_config = AttentionAndDistributedPackingConfig(
+            padding_free=PaddingFree(method="huggingface")
+        )
         model_args = copy.deepcopy(MODEL_ARGS)
         model_args.use_flash_attn = False
         sft_trainer.train(
             model_args,
             DATA_ARGS,
             TRAIN_ARGS,
-            attention_and_distributed_packing_config=\
-                attention_and_distributed_packing_config
+            attention_and_distributed_packing_config=attention_and_distributed_packing_config,
         )

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -24,10 +24,10 @@ import pytest
 import torch
 
 # First Party
+from tests.data import TWITTER_COMPLAINTS_JSON_FORMAT, TWITTER_COMPLAINTS_TOKENIZED
 from tests.test_sft_trainer import DATA_ARGS, MODEL_ARGS, PEFT_LORA_ARGS, TRAIN_ARGS
 
 # Local
-from ..data import TWITTER_COMPLAINTS_JSON_FORMAT, TWITTER_COMPLAINTS_TOKENIZED
 from .spying_utils import create_mock_plugin_class_and_spy
 from tuning import sft_trainer
 from tuning.config.acceleration_configs import (
@@ -40,8 +40,8 @@ from tuning.config.acceleration_configs.acceleration_framework_config import (
 )
 from tuning.config.acceleration_configs.attention_and_distributed_packing import (
     AttentionAndDistributedPackingConfig,
-    PaddingFree,
     MultiPack,
+    PaddingFree,
 )
 from tuning.config.acceleration_configs.fused_ops_and_kernels import (
     FastKernelsConfig,
@@ -595,6 +595,7 @@ def test_error_raised_with_paddingfree_and_flash_attn_disabled():
             TRAIN_ARGS,
             attention_and_distributed_packing_config=attention_and_distributed_packing_config,
         )
+
 
 def test_error_raised_with_multipack_and_paddingfree_disabled():
     """Ensure error raised when padding-free is not used with flash attention"""

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -567,7 +567,7 @@ def test_error_raised_with_paddingfree_and_flash_attn_disabled():
 def test_error_raised_with_multipack_and_paddingfree_disabled():
     """Ensure error raised when padding-free is not used with multipack"""
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match="`--multipack` is currently only supported with `--padding_free`",
     ):
         attention_and_distributed_packing_config = AttentionAndDistributedPackingConfig(
@@ -621,7 +621,7 @@ def test_error_raised_with_fused_lora_enabled_without_quantized_argument():
     `--auto_gptq` or `bitsandbytes`
     """
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match="`--fused_lora` must be accompanied by a quantized base layer "
         "`--auto_gptq` or `--bitsandbytes`.",
     ):

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, replace
 from typing import Annotated
 from unittest.mock import patch
 import copy
+import os
 import tempfile
 
 # Third Party
@@ -24,7 +25,6 @@ import pytest
 import torch
 
 # First Party
-from tests.data import TWITTER_COMPLAINTS_JSON_FORMAT, TWITTER_COMPLAINTS_TOKENIZED
 from tests.test_sft_trainer import DATA_ARGS, MODEL_ARGS, PEFT_LORA_ARGS, TRAIN_ARGS
 
 # Local
@@ -52,6 +52,16 @@ from tuning.config.acceleration_configs.quantized_lora_config import (
     BNBQLoraConfig,
 )
 from tuning.utils.import_utils import is_fms_accelerate_available
+
+# for some reason the CI will raise an import error if we try to import
+# these from tests.data
+TWITTER_COMPLAINTS_JSON_FORMAT = os.path.join(
+    os.path.dirname(__file__), "../data/twitter_complaints_json.json"
+)
+TWITTER_COMPLAINTS_TOKENIZED = os.path.join(
+    os.path.dirname(__file__),
+    "../data/twitter_complaints_tokenized_with_maykeye_tinyllama_v0.json",
+)
 
 # pylint: disable=import-error
 if is_fms_accelerate_available():
@@ -491,7 +501,7 @@ def test_framework_initialize_and_trains_with_aadp():
         data_args.dataset_text_field = None
 
         # initialize a config
-        attention_and_distributed_packing_config = AttentionAndDistributedPackingConfig(
+        aadp_config = AttentionAndDistributedPackingConfig(
             padding_free=PaddingFree(method="huggingface")
         )
 
@@ -514,7 +524,7 @@ def test_framework_initialize_and_trains_with_aadp():
                     model_args,
                     data_args,
                     train_args,
-                    attention_and_distributed_packing_config=attention_and_distributed_packing_config,
+                    attention_and_distributed_packing_config=aadp_config,
                 )
 
         # spy inside the train to ensure that the ilab plugin is called
@@ -550,7 +560,7 @@ def test_padding_free_plugin_raises_error_with_untokenized_dataset():
         data_args.dataset_text_field = "output"
 
         # initialize a config
-        attention_and_distributed_packing_config = AttentionAndDistributedPackingConfig(
+        aadp_config = AttentionAndDistributedPackingConfig(
             padding_free=PaddingFree(method="huggingface")
         )
 
@@ -573,7 +583,7 @@ def test_padding_free_plugin_raises_error_with_untokenized_dataset():
                         model_args,
                         data_args,
                         train_args,
-                        attention_and_distributed_packing_config=attention_and_distributed_packing_config,
+                        attention_and_distributed_packing_config=aadp_config,
                     )
 
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -334,6 +334,7 @@ def test_parse_arguments(job_config):
         _,
         _,
         _,
+        _,
     ) = sft_trainer.parse_arguments(parser, job_config_copy)
     assert str(model_args.torch_dtype) == "torch.bfloat16"
     assert data_args.dataset_text_field == "output"
@@ -347,7 +348,7 @@ def test_parse_arguments_defaults(job_config):
     assert "torch_dtype" not in job_config_defaults
     assert job_config_defaults["use_flash_attn"] is False
     assert "save_strategy" not in job_config_defaults
-    model_args, _, training_args, _, _, _, _, _, _, _ = sft_trainer.parse_arguments(
+    model_args, _, training_args, _, _, _, _, _, _, _, _ = sft_trainer.parse_arguments(
         parser, job_config_defaults
     )
     assert str(model_args.torch_dtype) == "torch.bfloat16"
@@ -359,14 +360,14 @@ def test_parse_arguments_peft_method(job_config):
     parser = sft_trainer.get_parser()
     job_config_pt = copy.deepcopy(job_config)
     job_config_pt["peft_method"] = "pt"
-    _, _, _, _, tune_config, _, _, _, _, _ = sft_trainer.parse_arguments(
+    _, _, _, _, tune_config, _, _, _, _, _, _ = sft_trainer.parse_arguments(
         parser, job_config_pt
     )
     assert isinstance(tune_config, peft_config.PromptTuningConfig)
 
     job_config_lora = copy.deepcopy(job_config)
     job_config_lora["peft_method"] = "lora"
-    _, _, _, _, tune_config, _, _, _, _, _ = sft_trainer.parse_arguments(
+    _, _, _, _, tune_config, _, _, _, _, _, _ = sft_trainer.parse_arguments(
         parser, job_config_lora
     )
     assert isinstance(tune_config, peft_config.LoraConfig)

--- a/tuning/config/acceleration_configs/__init__.py
+++ b/tuning/config/acceleration_configs/__init__.py
@@ -15,5 +15,5 @@
 # Local
 from .acceleration_framework_config import AccelerationFrameworkConfig
 from .fused_ops_and_kernels import FusedOpsAndKernelsConfig
-from .instruct_lab_config import InstructLabConfig
+from .attention_and_distributed_packing import AttentionAndDistributedPackingConfig
 from .quantized_lora_config import QuantizedLoraConfig

--- a/tuning/config/acceleration_configs/__init__.py
+++ b/tuning/config/acceleration_configs/__init__.py
@@ -15,4 +15,5 @@
 # Local
 from .acceleration_framework_config import AccelerationFrameworkConfig
 from .fused_ops_and_kernels import FusedOpsAndKernelsConfig
+from .instruct_lab_config import InstructLabConfig
 from .quantized_lora_config import QuantizedLoraConfig

--- a/tuning/config/acceleration_configs/__init__.py
+++ b/tuning/config/acceleration_configs/__init__.py
@@ -14,6 +14,6 @@
 
 # Local
 from .acceleration_framework_config import AccelerationFrameworkConfig
-from .fused_ops_and_kernels import FusedOpsAndKernelsConfig
 from .attention_and_distributed_packing import AttentionAndDistributedPackingConfig
+from .fused_ops_and_kernels import FusedOpsAndKernelsConfig
 from .quantized_lora_config import QuantizedLoraConfig

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -22,6 +22,7 @@ import yaml
 
 # Local
 from .fused_ops_and_kernels import FastKernelsConfig, FusedLoraConfig
+from .instruct_lab_config import PaddingFree
 from .quantized_lora_config import AutoGPTQLoraConfig, BNBQLoraConfig
 from tuning.utils.import_utils import is_fms_accelerate_available
 
@@ -95,6 +96,15 @@ class AccelerationFrameworkConfig:
             key="fused_ops_and_kernels",
             experimental=True,
             required_packages=["foak"],
+        ),
+    ] = None
+
+    padding_free: Annotated[
+        PaddingFree,
+        ConfigAnnotation(
+            path="training.attention",
+            experimental=True,
+            required_packages=["ilab"],
         ),
     ] = None
 

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -22,7 +22,7 @@ import yaml
 
 # Local
 from .fused_ops_and_kernels import FastKernelsConfig, FusedLoraConfig
-from .instruct_lab_config import PaddingFree
+from .attention_and_distributed_packing import PaddingFree
 from .quantized_lora_config import AutoGPTQLoraConfig, BNBQLoraConfig
 from tuning.utils.import_utils import is_fms_accelerate_available
 
@@ -104,7 +104,7 @@ class AccelerationFrameworkConfig:
         ConfigAnnotation(
             path="training.attention",
             experimental=True,
-            required_packages=["ilab"],
+            required_packages=["aadp"],
         ),
     ] = None
 

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -22,7 +22,7 @@ import yaml
 
 # Local
 from .fused_ops_and_kernels import FastKernelsConfig, FusedLoraConfig
-from .attention_and_distributed_packing import PaddingFree
+from .attention_and_distributed_packing import PaddingFree, MultiPack
 from .quantized_lora_config import AutoGPTQLoraConfig, BNBQLoraConfig
 from tuning.utils.import_utils import is_fms_accelerate_available
 
@@ -108,6 +108,16 @@ class AccelerationFrameworkConfig:
         ),
     ] = None
 
+    multipack: Annotated[
+        MultiPack,
+        ConfigAnnotation(
+            path="training.dataloader",
+            experimental=True,
+            required_packages=["aadp"],
+        ),
+    ] = None
+
+
     @staticmethod
     def from_dataclasses(*dataclasses: Type):
         "Convert one or many FMS config dataclasses to a monolithic AccelerationConfig"
@@ -125,6 +135,7 @@ class AccelerationFrameworkConfig:
 
         # first unroll all the dataclases into a single level
         nested_dataclasses = []
+
         for dc in dataclasses:
             if dc is None:
                 continue
@@ -172,7 +183,6 @@ class AccelerationFrameworkConfig:
         return config
 
     def get_framework(self):
-
         if is_fms_accelerate_available():
 
             # to be eventually be made to be passed as a dict to Acceleration

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -84,7 +84,7 @@ class AccelerationFrameworkConfig:
         ConfigAnnotation(
             path="peft.quantization",
             key="fused_ops_and_kernels",
-            experimental=True,
+            experimental=False,
             required_packages=["foak"],
         ),
     ] = None
@@ -94,7 +94,7 @@ class AccelerationFrameworkConfig:
         ConfigAnnotation(
             path="training",
             key="fused_ops_and_kernels",
-            experimental=True,
+            experimental=False,
             required_packages=["foak"],
         ),
     ] = None

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -117,6 +117,14 @@ class AccelerationFrameworkConfig:
         ),
     ] = None
 
+    def _verify_configured_dataclasses(self):
+        if self.multipack is not None:
+            # ensure if multipack is set, padding free is also turned on as well
+            # this also ensures that the attention implementation for multipack
+            # will be flash attention as sfttrainer will enforce flash attn to be
+            # set for padding free
+            assert self.padding_free is not None, "`--multipack` is currently only supported with `--padding_free`"
+
     @staticmethod
     def from_dataclasses(*dataclasses: Type):
         "Convert one or many FMS config dataclasses to a monolithic AccelerationConfig"
@@ -179,6 +187,8 @@ class AccelerationFrameworkConfig:
             setattr(config, fi.name, dc)
             del rem_fields[fi.name]  # remove the field
 
+        # perform some checks on dataclasse
+        config._verify_configured_dataclasses()
         return config
 
     def get_framework(self):

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -123,7 +123,9 @@ class AccelerationFrameworkConfig:
             # this also ensures that the attention implementation for multipack
             # will be flash attention as sfttrainer will enforce flash attn to be
             # set for padding free
-            assert self.padding_free is not None, "`--multipack` is currently only supported with `--padding_free`"
+            assert (
+                self.padding_free is not None
+            ), "`--multipack` is currently only supported with `--padding_free`"
 
     @staticmethod
     def from_dataclasses(*dataclasses: Type):

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -92,7 +92,7 @@ class AccelerationFrameworkConfig:
     fast_kernels: Annotated[
         FastKernelsConfig,
         ConfigAnnotation(
-            path="peft.quantization",
+            path="training",
             key="fused_ops_and_kernels",
             experimental=True,
             required_packages=["foak"],
@@ -126,6 +126,15 @@ class AccelerationFrameworkConfig:
             assert (
                 self.padding_free is not None
             ), "`--multipack` is currently only supported with `--padding_free`"
+
+        # Check that fused lora must be activated with either auto_gptq or bitsandbytes
+        if self.fused_lora is not None:
+            assert (
+                self.bitsandbytes is not None or self.auto_gptq is not None
+            ), "`--fused_lora` must be accompanied by a quantized base layer"\
+                " `--auto_gptq` or `--bitsandbytes`."
+
+
 
     @staticmethod
     def from_dataclasses(*dataclasses: Type):

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -21,8 +21,8 @@ import warnings
 import yaml
 
 # Local
+from .attention_and_distributed_packing import MultiPack, PaddingFree
 from .fused_ops_and_kernels import FastKernelsConfig, FusedLoraConfig
-from .attention_and_distributed_packing import PaddingFree, MultiPack
 from .quantized_lora_config import AutoGPTQLoraConfig, BNBQLoraConfig
 from tuning.utils.import_utils import is_fms_accelerate_available
 
@@ -116,7 +116,6 @@ class AccelerationFrameworkConfig:
             required_packages=["aadp"],
         ),
     ] = None
-
 
     @staticmethod
     def from_dataclasses(*dataclasses: Type):

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -129,12 +129,10 @@ class AccelerationFrameworkConfig:
 
         # Check that fused lora must be activated with either auto_gptq or bitsandbytes
         if self.fused_lora is not None:
-            assert (
-                self.bitsandbytes is not None or self.auto_gptq is not None
-            ), "`--fused_lora` must be accompanied by a quantized base layer"\
+            assert self.bitsandbytes is not None or self.auto_gptq is not None, (
+                "`--fused_lora` must be accompanied by a quantized base layer"
                 " `--auto_gptq` or `--bitsandbytes`."
-
-
+            )
 
     @staticmethod
     def from_dataclasses(*dataclasses: Type):

--- a/tuning/config/acceleration_configs/acceleration_framework_config.py
+++ b/tuning/config/acceleration_configs/acceleration_framework_config.py
@@ -123,16 +123,18 @@ class AccelerationFrameworkConfig:
             # this also ensures that the attention implementation for multipack
             # will be flash attention as sfttrainer will enforce flash attn to be
             # set for padding free
-            assert (
-                self.padding_free is not None
-            ), "`--multipack` is currently only supported with `--padding_free`"
+            if self.padding_free is None:
+                raise ValueError(
+                    "`--multipack` is currently only supported with `--padding_free`"
+                )
 
         # Check that fused lora must be activated with either auto_gptq or bitsandbytes
         if self.fused_lora is not None:
-            assert self.bitsandbytes is not None or self.auto_gptq is not None, (
-                "`--fused_lora` must be accompanied by a quantized base layer"
-                " `--auto_gptq` or `--bitsandbytes`."
-            )
+            if self.bitsandbytes is None and self.auto_gptq is None:
+                raise ValueError(
+                    "`--fused_lora` must be accompanied by a quantized base layer"
+                    " `--auto_gptq` or `--bitsandbytes`."
+                )
 
     @staticmethod
     def from_dataclasses(*dataclasses: Type):

--- a/tuning/config/acceleration_configs/attention_and_distributed_packing.py
+++ b/tuning/config/acceleration_configs/attention_and_distributed_packing.py
@@ -17,7 +17,7 @@ class PaddingFree:
 
 
 @dataclass
-class InstructLabConfig:
+class AttentionAndDistributedPackingConfig:
 
     padding_free: PaddingFree = None
 

--- a/tuning/config/acceleration_configs/attention_and_distributed_packing.py
+++ b/tuning/config/acceleration_configs/attention_and_distributed_packing.py
@@ -15,11 +15,18 @@ class PaddingFree:
         if self.method != "huggingface":
             raise ValueError("only 'huggingface' method currently supported.")
 
+@parsable_dataclass
+@dataclass
+class MultiPack:
+
+    num_processes: int = 16
 
 @dataclass
 class AttentionAndDistributedPackingConfig:
 
     padding_free: PaddingFree = None
+
+    multipack: MultiPack = None
 
     def __post_init__(self):
         # ensure nested dataclasses initialized

--- a/tuning/config/acceleration_configs/attention_and_distributed_packing.py
+++ b/tuning/config/acceleration_configs/attention_and_distributed_packing.py
@@ -15,11 +15,13 @@ class PaddingFree:
         if self.method != "huggingface":
             raise ValueError("only 'huggingface' method currently supported.")
 
+
 @parsable_dataclass
 @dataclass
 class MultiPack:
 
     num_processes: int = 16
+
 
 @dataclass
 class AttentionAndDistributedPackingConfig:

--- a/tuning/config/acceleration_configs/fused_ops_and_kernels.py
+++ b/tuning/config/acceleration_configs/fused_ops_and_kernels.py
@@ -54,18 +54,11 @@ class FastKernelsConfig(List):
     fast_loss: bool = False
 
     # fast rms norm triton kernels
-    fast_rsm_layernorm: bool = False
+    fast_rms_layernorm: bool = False
 
     # fast RoPE embedding triton kernels
     fast_rope_embeddings: bool = False
 
-    def __post_init__(self):
-
-        if not self.fast_loss == self.fast_rsm_layernorm == self.fast_rope_embeddings:
-            raise ValueError(
-                "fast_loss, fast_rms_layernorm and fast_rope_embedding must be enabled "
-                "together. This restriction may be relaxed in the future."
-            )
 
 
 @dataclass
@@ -77,14 +70,6 @@ class FusedOpsAndKernelsConfig:
     # fast kernels
     fast_kernels: FastKernelsConfig = None
 
-    def __post_init__(self):
-        if (self.fused_lora is not None and self.fast_kernels is None) or (
-            self.fused_lora is None and self.fast_kernels is not None
-        ):
-            raise ValueError(
-                "fused lora and fast_kernels must be used together. "
-                "This restriction may be relaxed in the future."
-            )
 
         # ensure nested dataclasses initialized
         ensure_nested_dataclasses_initialized(self)

--- a/tuning/config/acceleration_configs/fused_ops_and_kernels.py
+++ b/tuning/config/acceleration_configs/fused_ops_and_kernels.py
@@ -60,7 +60,6 @@ class FastKernelsConfig(List):
     fast_rope_embeddings: bool = False
 
 
-
 @dataclass
 class FusedOpsAndKernelsConfig:
 

--- a/tuning/config/acceleration_configs/fused_ops_and_kernels.py
+++ b/tuning/config/acceleration_configs/fused_ops_and_kernels.py
@@ -70,6 +70,7 @@ class FusedOpsAndKernelsConfig:
     # fast kernels
     fast_kernels: FastKernelsConfig = None
 
+    def __post_init__(self):
 
         # ensure nested dataclasses initialized
         ensure_nested_dataclasses_initialized(self)

--- a/tuning/config/acceleration_configs/instruct_lab_config.py
+++ b/tuning/config/acceleration_configs/instruct_lab_config.py
@@ -1,0 +1,26 @@
+# Standard
+from dataclasses import dataclass
+
+# Local
+from .utils import ensure_nested_dataclasses_initialized, parsable_dataclass
+
+
+@parsable_dataclass
+@dataclass
+class PaddingFree:
+
+    method: str = "huggingface"
+
+    def __post_init__(self):
+        if self.method != "huggingface":
+            raise ValueError("only 'huggingface' method currently supported.")
+
+
+@dataclass
+class InstructLabConfig:
+
+    padding_free: PaddingFree = None
+
+    def __post_init__(self):
+        # ensure nested dataclasses initialized
+        ensure_nested_dataclasses_initialized(self)

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -142,7 +142,7 @@ def train(
                 "ensure `use_flash_attn = True` to use padding-free flash attention"
             )
 
-        if train_args.packing is True:
+        if train_args.packing:
             # We prevent Trainer from performing packing with padding_free.
             # Since the plugin computes attention efficiently without padding.
             raise ValueError(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -135,12 +135,20 @@ def train(
     if (
         attention_and_distributed_packing_config is not None
         and attention_and_distributed_packing_config.padding_free is not None
-        and model_args.use_flash_attn is False
     ):
-        raise ValueError(
-            "`--padding_free` argument was called without enabling \
-            flash attention, ensure `use_flash_attn = True` to use padding-free flash attention"
-        )
+        if model_args.use_flash_attn is False:
+            raise ValueError(
+                "`--padding_free` argument was called without enabling flash attention, "
+                "ensure `use_flash_attn = True` to use padding-free flash attention"
+            )
+
+        if train_args.packing is True:
+            # We prevent Trainer from performing packing with padding_free.
+            # Since the plugin computes attention efficiently without padding.
+            raise ValueError(
+                "`--padding_free` argument was called with `packing=True`, "
+                "Trainer should not perform packing when using `--padding_free`"
+            )
 
     task_type = "CAUSAL_LM"
     additional_metrics = {}

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -492,7 +492,7 @@ def parse_arguments(parser, json_config=None):
             Configuration for quantized LoRA (a form of PEFT).
         FusedOpsAndKernelsConfig
             Configuration for fused operations and kernels.
-        InstructLabConfig
+        AttentionAndDistributedPackingConfig
             Configuration for padding free and packing.
         dict[str, str]
             Extra AIM metadata.

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -45,7 +45,7 @@ from tuning.config import configs, peft_config
 from tuning.config.acceleration_configs import (
     AccelerationFrameworkConfig,
     FusedOpsAndKernelsConfig,
-    InstructLabConfig,
+    AttentionAndDistributedPackingConfig,
     QuantizedLoraConfig,
 )
 from tuning.config.tracker_configs import (
@@ -87,7 +87,7 @@ def train(
     exp_metadata: Optional[Dict] = None,
     quantized_lora_config: Optional[QuantizedLoraConfig] = None,
     fusedops_kernels_config: Optional[FusedOpsAndKernelsConfig] = None,
-    instruct_lab_config: Optional[InstructLabConfig] = None,
+    attention_and_distributed_packing_config: Optional[AttentionAndDistributedPackingConfig] = None,
 ):
     """Call the SFTTrainer
 
@@ -115,7 +115,7 @@ def train(
         fusedops_kernels_config: tuning.config.acceleration_configs.FusedOpsAndKernelsConfig \
             Should be used in combination with quantized_lora_config. Also currently 
             fused_lora and fast_kernels must used together (may change in future). \
-        instruct_lab_config: Used for padding free and multipack.
+        attention_and_distributed_packing_config: Used for padding-free attention and multipack.
     """
 
     train_args, logger = set_log_level(train_args, "sft_trainer_train")
@@ -129,6 +129,12 @@ def train(
         train_args.gradient_accumulation_steps <= 0
     ):
         raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
+
+    if (attention_and_distributed_packing_config.padding_free is not None and
+        model_args.use_flash_attn is False
+    ):
+        raise ValueError("`--padding_free` argument was called without enabling \
+            flash attention, ensure `use_flash_attn = True` to use padding-free flash attention")
 
     task_type = "CAUSAL_LM"
     additional_metrics = {}
@@ -181,7 +187,7 @@ def train(
             trainer_callbacks.append(cb)
 
     framework = AccelerationFrameworkConfig.from_dataclasses(
-        quantized_lora_config, fusedops_kernels_config, instruct_lab_config
+        quantized_lora_config, fusedops_kernels_config, attention_and_distributed_packing_config
     ).get_framework()
 
     model_loader = AutoModelForCausalLM.from_pretrained
@@ -439,7 +445,7 @@ def get_parser():
             AimConfig,
             QuantizedLoraConfig,
             FusedOpsAndKernelsConfig,
-            InstructLabConfig,
+            AttentionAndDistributedPackingConfig,
         )
     )
     parser.add_argument(
@@ -503,7 +509,7 @@ def parse_arguments(parser, json_config=None):
             aim_config,
             quantized_lora_config,
             fusedops_kernels_config,
-            instruct_lab_config,
+            attention_and_distributed_packing_config,
         ) = parser.parse_dict(json_config, allow_extra_keys=True)
         peft_method = json_config.get("peft_method")
         exp_metadata = json_config.get("exp_metadata")
@@ -519,7 +525,7 @@ def parse_arguments(parser, json_config=None):
             aim_config,
             quantized_lora_config,
             fusedops_kernels_config,
-            instruct_lab_config,
+            attention_and_distributed_packing_config,
             additional,
             _,
         ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
@@ -544,7 +550,7 @@ def parse_arguments(parser, json_config=None):
         aim_config,
         quantized_lora_config,
         fusedops_kernels_config,
-        instruct_lab_config,
+        attention_and_distributed_packing_config,
         exp_metadata,
     )
 
@@ -565,7 +571,7 @@ def main():
             aim_config,
             quantized_lora_config,
             fusedops_kernels_config,
-            instruct_lab_config,
+            attention_and_distributed_packing_config,
             exp_metadata,
         ) = parse_arguments(parser, job_config)
 
@@ -577,7 +583,7 @@ def main():
             model_args %s, data_args %s, training_args %s, trainer_controller_args %s, \
             tune_config %s, file_logger_config, %s aim_config %s, \
             quantized_lora_config %s, fusedops_kernels_config %s, \
-            instruct_lab_config %s exp_metadata %s",
+            attention_and_distributed_packing_config %s exp_metadata %s",
             model_args,
             data_args,
             training_args,
@@ -587,7 +593,7 @@ def main():
             aim_config,
             quantized_lora_config,
             fusedops_kernels_config,
-            instruct_lab_config,
+            attention_and_distributed_packing_config,
             exp_metadata,
         )
     except Exception as e:  # pylint: disable=broad-except
@@ -629,7 +635,7 @@ def main():
             exp_metadata=metadata,
             quantized_lora_config=quantized_lora_config,
             fusedops_kernels_config=fusedops_kernels_config,
-            instruct_lab_config=instruct_lab_config,
+            attention_and_distributed_packing_config=attention_and_distributed_packing_config,
         )
     except (MemoryError, OutOfMemoryError) as e:
         logger.error(traceback.format_exc())

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -44,8 +44,8 @@ import transformers
 from tuning.config import configs, peft_config
 from tuning.config.acceleration_configs import (
     AccelerationFrameworkConfig,
-    FusedOpsAndKernelsConfig,
     AttentionAndDistributedPackingConfig,
+    FusedOpsAndKernelsConfig,
     QuantizedLoraConfig,
 )
 from tuning.config.tracker_configs import (
@@ -87,7 +87,9 @@ def train(
     exp_metadata: Optional[Dict] = None,
     quantized_lora_config: Optional[QuantizedLoraConfig] = None,
     fusedops_kernels_config: Optional[FusedOpsAndKernelsConfig] = None,
-    attention_and_distributed_packing_config: Optional[AttentionAndDistributedPackingConfig] = None,
+    attention_and_distributed_packing_config: Optional[
+        AttentionAndDistributedPackingConfig
+    ] = None,
 ):
     """Call the SFTTrainer
 
@@ -130,11 +132,14 @@ def train(
     ):
         raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
 
-    if (attention_and_distributed_packing_config.padding_free is not None and
-        model_args.use_flash_attn is False
+    if (
+        attention_and_distributed_packing_config.padding_free is not None
+        and model_args.use_flash_attn is False
     ):
-        raise ValueError("`--padding_free` argument was called without enabling \
-            flash attention, ensure `use_flash_attn = True` to use padding-free flash attention")
+        raise ValueError(
+            "`--padding_free` argument was called without enabling \
+            flash attention, ensure `use_flash_attn = True` to use padding-free flash attention"
+        )
 
     task_type = "CAUSAL_LM"
     additional_metrics = {}
@@ -187,7 +192,9 @@ def train(
             trainer_callbacks.append(cb)
 
     framework = AccelerationFrameworkConfig.from_dataclasses(
-        quantized_lora_config, fusedops_kernels_config, attention_and_distributed_packing_config
+        quantized_lora_config,
+        fusedops_kernels_config,
+        attention_and_distributed_packing_config,
     ).get_framework()
 
     model_loader = AutoModelForCausalLM.from_pretrained

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -133,7 +133,8 @@ def train(
         raise ValueError("gradient_accumulation_steps has to be an integer >= 1")
 
     if (
-        attention_and_distributed_packing_config.padding_free is not None
+        attention_and_distributed_packing_config is not None
+        and attention_and_distributed_packing_config.padding_free is not None
         and model_args.use_flash_attn is False
     ):
         raise ValueError(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This PR adds two dataclass arguments to enable *padding free* and *multipack* for the `sft_trainer.py`, via the new `fms acceleration` [attention-and-distributed-packing](https://github.com/foundation-model-stack/fms-acceleration/tree/main/plugins/attention-and-distributed-packing) plugin and allows the current `--fastkernels` dataclass to support optimized full-finetuning:
-  `--padding_free`: technique to process multiple examples in single batch without adding padding tokens that waste compute.
-  `--multipack`: technique for *multi-gpu training* to balance out number of tokens processed in each device, to minimize waiting time.
- `--fast_kernels`: Previously limited only for QPEFT (used to raise if not activated with `--fast_lora`), Now allows for optimized full/standard LoRA finetuning.

These are extremely effective methods to improve training throughputs:
- see the section on [benchmarks](#benchmarks) below. Currently, either padding free is used **alone**, or **together** with multipack. We *do not currently support* the option of using multipack alone.
- padding free and multipack used in the *instructlab* (ILAB) work, see below on the section of the [early version](#early-version) of this plugin. For general use when producing this plugin, we have greatly simplified the user interface


<!--
and its handling to `sft_trainer.py` to use [`fms-acceleration-ilab`](https://github.com/foundation-model-stack/fms-acceleration/pull/62), a new acceleration plugin that performs padding-free flash-attention computation that improves training efficiency. 
- this is intended to be a collection of methods used in the opensource ILAB training repo https://github.com/instructlab/training
- we hope to soon include also the [multipack sampling](https://github.com/imoneoi/multipack_sampler) used to balance compute loads across multiple GPUs


**There are ongoing discussion to rename the plugin to something more generic. This PR should only be merged after the discussions are finalized and the dataclasses are renamed respectively.**
-->

**NOTE**: adhering to the design of [fms-acceleration](https://github.com/foundation-model-stack/fms-acceleration), the new plugin is **optional**, and separately installed. 
- there is no dependency on the [fms-acceleration-peft](https://github.com/foundation-model-stack/fms-acceleration/tree/main/plugins/accelerated-peft) for GPTQ LoRA. However we [have tested it with other plugins](https://github.com/foundation-model-stack/fms-acceleration/pull/66):
    * [accelerated-peft](https://github.com/foundation-model-stack/fms-acceleration/tree/main/plugins/accelerated-peft)
    * [fused-ops-and-kernels](https://github.com/foundation-model-stack/fms-acceleration/tree/main/plugins/fused-ops-and-kernels)
   
<!--
- this PR only regards the installation of command line arguments, so that if  users wish for these features to be used  with `fms-hf-tuning`, they can be appropriately activated.
-->

**Notes on Padding Free**
- works for both *single* and *multi-gpu*. 
- works on both *pretokenized* and *untokenized* datasets
- works with current transformers releases (`<=4.43`), when padding free is *not yet integrated* from our PR into Hugging Face: https://github.com/huggingface/transformers/pull/31629.
- is forward-compatible with future transformers that natively supports padding-free (`>= 4.44`).
- verified against the version found in HF main, merged in via PR https://github.com/huggingface/transformers/pull/31629.

**Notes on Multipack**
- works only for *multi-gpu*.
- currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.

**Notes on FastKernels**
- currently supports FastCrossEntropyLoss, FastRoPE, FastRMSLayerNorm but will include SwiGLU and Liger Kernels (e.g. FusedCrossEntropyLoss)  in the future
- Works for full-finetuning, LoRA and QPEFT, 
    - pass `--fast_kernels True True True` on full finetuning/LoRA runs
    - pass `--fast_kernels True True True --auto_gptq triton_v2 --fused_lora auto_gptq True` for GPTQ-LoRA
    - pass `--fast_kernels True True True --bitsandbytes nf4 --fused_lora bitsandbytes True` for QLoRA
- FastRoPE currently doesn't accept `positional_ids` but [this issue](https://github.com/foundation-model-stack/fms-acceleration/issues/33) will be addressed in the future 

#### Benchmarks

**PaddingFree and Multipack Benchmarks for Mistral 7B** 

Notes:
- *Shown below are the runtimes for running a subset of 6000 FLAN samples*.
- Tested two cases of per device batch sizes 4 and 8, for varying number gpus from 2 to 8
- Verified that untokenized dataset produces the same improvements for paddingfree and multipack

**Per Device Batch Size 4**

| Framework Config | Num Devices | Per Device Batch Size | Train Runtime (secs) | Speedups |
| -------- | ------- | ------- | ------- | ------- |
| full-FT | 2 | 4 | 1537 | baseline |
| padding-free | 2 | 4 | 859 | 1.79 x |
| padding-free + multipack | 2 | 4 | 751 | 2.05 x |
| full-FT | 4 | 4 | 932 | baseline |
| padding-free | 4 | 4 | 483 | 1.93 x |
| padding-free + multipack | 4 | 4 | 342 | 2.75 x |
| full-FT | 8 | 4 | 551 | baseline |
| padding-free | 8 | 4 | 275 | 2.00 x |
| padding-free + multipack | 8 | 4 | 163 | 3.38 x |

<!--
| Framework Config | Num Devices | Per Device Batch Size | Train Runtime (secs) | % Runtime Improvement |
| -------- | ------- | ------- | ------- | ------- |
| full-FT | 2 | 4 | 1537 | baseline |
| aadp-padding-free | 2 | 4 | 859 | 44 |
| aadp-padding-free + multipack | 2 | 4 | 751 | 51 |
| full-FT | 4 | 4 | 932 | base |
| aadp-padding-free | 4 | 4 | 483 | 48 |
| aadp-padding-free + multipack | 4 | 4 | 342 | 63 |
| full-FT | 8 | 4 | 551 | base |
| aadp-padding-free | 8 | 4 | 275 | 50 |
| aadp-padding-free + multipack | 8 | 4 | 163 | 70 |
-->

**Per Device Batch Size 8**
| Framework Config | Num Devices | Per Device Batch Size | Train Runtime (secs) | Speedup |
| -------- | ------- | ------- | ------- | ------- |
| full-FT | 2 | 8 | 1722 | baseline |
| padding-free | 2 | 8 | 678 | 2.54 x |
| padding-free + multipack | 2 | 8 | 603 | 2.86 x |
| full-FT | 4 | 8 | 1025 | baseline |
| padding-free | 4 | 8 | 380 | 2.70 x |
| padding-free + multipack | 4 | 8 | 289 | 3.55 x |
| full-FT | 8 | 8 | 611 | baseline |
| padding-free | 8 | 8 | 215 | 2.84 x |
| padding-free + multipack | 8 | 8 | 140 | 4.36 x |
 
<!--
**Per Device Batch Size 8**
| Framework Config | Num Devices | Per Device Batch Size | Train Runtime (secs) | % Runtime Improvement |
| -------- | ------- | ------- | ------- | ------- |
| full-FT | 2 | 8 | 1722 | base |
| aadp-padding-free | 2 | 8 | 678 | 60 |
| aadp-padding-free + multipack | 2 | 8 | 603 | 65 |
| full-FT | 4 | 8 | 1025 | base |
| aadp-padding-free | 4 | 8 | 380 | 62 |
| aadp-padding-free + multipack | 4 | 8 | 289 | 72 |
| full-FT | 8 | 8 | 611 | base |
| aadp-padding-free | 8 | 8 | 215 | 64 |
| aadp-padding-free + multipack | 8 | 8 | 140 | 77 |
 -->
 
**Verified Similar Improvements for Untokenized Dataset**
| Framework Config | Num Devices | Per Device Batch Size | Train Runtime (secs) | Speedups |
| -------- | ------- | ------- | ------- | ------- |
| full-FT | 2 | 4 | 1516 | baseline |
| padding-free | 2 | 4 | 848 | 1.78x |
| padding-free + multipack | 2 | 4 | 747 | 2.02x |

**Full Finetuning Benchmarks for Mistral 7B** 


#### Early Version Of This Plugin

We have an [unofficial version](https://github.com/foundation-model-stack/fms-acceleration/tree/refactor/attention) with more features than our present release. @kmehant  is currently using for ILAB work. It addition to the padding-free and multipack, it also has the additional two plugins below:

- [LossAccelerationPlugin](https://github.com/foundation-model-stack/fms-acceleration/blob/refactor/attention/plugins/accelerated-attn/src/fms_acceleration_attn/framework_plugin_loss.py): various methods of averaging losses across GPUs in distributed training, like straight per-token averaging.
- [MLPDropoutAccelerationPlugin](https://github.com/foundation-model-stack/fms-acceleration/blob/refactor/attention/plugins/accelerated-attn/src/fms_acceleration_attn/framework_plugin_mlp_dropout.py). Adding Dolomite-style residual dropout to MLP units. 

<!-- 
- [PaddingFreeAccelerationPlugin](https://github.com/foundation-model-stack/fms-acceleration/blob/refactor/attention/plugins/accelerated-attn/src/fms_acceleration_attn/framework_plugin_padding_free.py) : **Released**
- [MultipackDataloaderAccelerationPlugin](https://github.com/foundation-model-stack/fms-acceleration/blob/refactor/attention/plugins/accelerated-attn/src/fms_acceleration_attn/framework_plugin_multipack.py): *Under plans to be released soon*. the multipack dataloader
-->

To use the early version a quick hack of `sft_trainer` with pretokenized + custom tokenizer: https://github.com/fabianlim/fms-hf-tuning/tree/attn-plugin . **This will be superceded by this PR in the near future**


Use with these command line arugments:
```
	  --padding_free huggingface-injected \
	  --loss_across_gpus mean token \
```

<!-- Please summarize the changes -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->
Additional checks/tests were added to
1. Ensures parsing `--padding_free` and `multipack` is correct in `test_dataclass_parse_successfully`
2. Ensures wrong arguments to `--padding_free` are caught in `test_dataclass_will_fail_to_accept_illegal_args`
3. Ensures Plugin is successfully instantiated from dataclass in `test_framework_initialize_and_trains_with_aadp`
4. Ensure `--padding_free` must be used with flash-attn, otherwise error is raised
5. Ensure `--multi_pack` must be used with `--padding_free`, otherwise error is raised
6. Ensure `--packing True`  with `--padding_free` will raise an error
7. Ensure `--fast_kernels` works with full finetuning
8. Ensure that `--fast_lora` not called with either `--auto_gptq` or `--bitsandbytes` will raise an error

Ran the full suite of acceleration checks to verify all fms-acceleration unit tests passed
```
pytest tests/acceleration/
```
![image](https://github.com/user-attachments/assets/207f5646-66ce-4ebe-ae57-ce577213540c)

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass