### PR TITLE
Always update setuptools to latest

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,6 +33,7 @@ RUN dnf remove -y --disableplugin=subscription-manager \
     && ln -s /usr/bin/python${PYTHON_VERSION} /bin/python \
     && python -m ensurepip --upgrade \
     && python -m pip install --upgrade pip \
+    && python -m pip install --upgrade setuptools \
     && dnf update -y \
     && dnf clean all
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
I'm noticing a high security vulnerability with setuptools.  

severityCHML | cvss | riskFactors | cve | link | hasFix | status | packageType | packageName | packageVersion | packageLicense | packageBinaryPkgs | packagePath
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
H | 8.8 | Attack complexity: low,Attack vector: network,DoS - High,Has fix,High   severity,Recent vulnerability,Remote execution | CVE-2024-6345 | https://nvd.nist.gov/vuln/detail/CVE-2024-6345 | Y | fixed in 70.0.0 | python | setuptools | 65.5.1 |   |   | /usr/local/lib/python3.11/site-packages/setuptools-65.5.1.dist-info

So I'm adding a line to the DockerFile to force an update to setuptools.

### Related issue number
Closes 1176
https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1176

### How to verify the PR
I clone my branch:
```
git clone https://github.com/jbusche/fms-hf-tuning/ -b jb-setuptools-update
cd fms-hf-tuning
```
Then I build the image:
```
docker build --progress=plain -t fms-hf-tuning:jim-updatesetuptools . -f build/Dockerfile
```
and I get: `Successfully tagged localhost/fms-hf-tuning:jim-updatesetuptools`

Now I can run the image locally and look at the setuptools version:
```
podman run --rm -it localhost/fms-hf-tuning:jim-updatesetuptools /bin/bash

pip list |grep setup
setuptools               72.1.0
```
I also used Twistlock to scan the image and it came up clean for setuptools.


### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass