### PR TITLE
feat: Added additional events such as on_step_begin, on_optimizer_step, on_substep_end

### DIFF
--- a/tuning/trainercontroller/callback.py
+++ b/tuning/trainercontroller/callback.py
@@ -582,3 +582,45 @@ class TrainerControllerCallback(TrainerCallback):
         kwargs["state"] = state
         kwargs["control"] = control
         self._actions_on_event(event_name="on_save", **kwargs)
+
+    def on_step_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        # Training arguments, state and controls are folded into kwargs to be passed off to
+        # handlers
+        kwargs["args"] = args
+        kwargs["state"] = state
+        kwargs["control"] = control
+        self._actions_on_event(event_name="on_step_begin", **kwargs)
+
+    def on_optimizer_step(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        # Training arguments, state and controls are folded into kwargs to be passed off to
+        # handlers
+        kwargs["args"] = args
+        kwargs["state"] = state
+        kwargs["control"] = control
+        self._actions_on_event(event_name="on_optimizer_step", **kwargs)
+
+    def on_substep_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        # Training arguments, state and controls are folded into kwargs to be passed off to
+        # handlers
+        kwargs["args"] = args
+        kwargs["state"] = state
+        kwargs["control"] = control
+        self._actions_on_event(event_name="on_substep_end", **kwargs)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Some events like on_step_begin, on_optimizer_step, on_substep_end have been added to the trainer controller callback.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

By using the events in the trainer controller configuration as `trigger`. For example:
  ```
  controller_metrics:
    - name: trainer_state
      class: TrainingState
  controllers:
    - name: stop_on_training_loss_on_save
      triggers:
        - on_optimizer_step
      rule: trainer_state["epoch"] >= 0.5
      operations:
        - hfcontrols.should_training_stop
  ```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass