### PR TITLE
fix: setting log level in save()

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -468,7 +468,7 @@ def test_run_causallm_ft_save_with_save_model_dir_save_strategy_no():
         # validate that no checkpoints created
         assert not any(x.startswith("checkpoint-") for x in os.listdir(tempdir))
 
-        sft_trainer.save(tempdir, trainer)
+        sft_trainer.save(tempdir, trainer, "debug")
         assert any(x.endswith(".safetensors") for x in os.listdir(tempdir))
         _test_run_inference(checkpoint_path=tempdir)
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -379,7 +379,7 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
     if log_level == "passive":
         log_level = "WARNING"
 
-    logger.setLevel(log_level)
+    logger.setLevel(log_level.upper())
 
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -373,6 +373,8 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
             Path to save the model to.
         trainer: SFTTrainer
             Instance of SFTTrainer used for training to save the model.
+        log_level: str
+            Optional threshold to set save save logger to, default warning.
     """
     logger = logging.getLogger("sft_trainer_save")
     # default value from TrainingArguments


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Bug where log level set in `save()` fails if lowercase values passed in for log_level. This fixes the issue and adds a small addition to unit tests to ensure this change fixes it.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass