### PR TITLE
fix: logger is unbound error

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -547,7 +547,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
             exp_metadata,
         )
     except Exception as e:  # pylint: disable=broad-except
-        logger.error(traceback.format_exc())
+        print(traceback.format_exc())
         write_termination_log(
             f"Exception raised during training. This may be a problem with your input: {e}"
         )

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -510,6 +510,7 @@ def parse_arguments(parser, json_config=None):
 
 def main(**kwargs):  # pylint: disable=unused-argument
     parser = get_parser()
+    logger = logging.getLogger()
     job_config = get_json_config()
     # accept arguments via command-line or JSON
     try:
@@ -547,7 +548,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
             exp_metadata,
         )
     except Exception as e:  # pylint: disable=broad-except
-        print(traceback.format_exc())
+        logger.error(traceback.format_exc())
         write_termination_log(
             f"Exception raised during training. This may be a problem with your input: {e}"
         )


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Fixes https://github.com/foundation-model-stack/fms-hf-tuning/issues/307

### Related issue number

https://github.com/foundation-model-stack/fms-hf-tuning/issues/307

### How to verify the PR

```
python3 -m tuning.sft_trainer --output_dir foo --use_flash_attn false --bnb_qlora true
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass