### PR TITLE
refactor: move removal of lm_head to save method

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -28,14 +28,10 @@ import json
 
 # Third Party
 from accelerate.commands.launch import launch_command
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from peft import PeftModel
-from torch import bfloat16
 
 # Local
 from build.utils import (
     process_accelerate_launch_args,
-    get_highest_checkpoint,
 )
 from tuning.utils.config_utils import get_json_config
 from tuning.utils.error_logging import (
@@ -43,7 +39,6 @@ from tuning.utils.error_logging import (
     USER_ERROR_EXIT_CODE,
     INTERNAL_ERROR_EXIT_CODE,
 )
-from tuning.data import tokenizer_data_utils
 
 ERROR_LOG = "/dev/termination-log"
 
@@ -126,85 +121,6 @@ def main():
     except Exception as e:  # pylint: disable=broad-except
         logging.error(traceback.format_exc())
         write_termination_log(f"Unhandled exception during training. {e}")
-        sys.exit(INTERNAL_ERROR_EXIT_CODE)
-
-    # remove lm_head from granite with llama arch models
-    try:
-        checkpoint_dir = job_config.get("save_model_dir")
-        if not checkpoint_dir:
-            checkpoint_dir = os.path.join(
-                output_dir, get_highest_checkpoint(output_dir)
-            )
-
-        use_flash_attn = job_config.get("use_flash_attn", True)
-        adapter_config_path = os.path.join(checkpoint_dir, "adapter_config.json")
-        tokenizer = AutoTokenizer.from_pretrained(checkpoint_dir)
-
-        if os.path.exists(adapter_config_path):
-            base_model_path = get_base_model_from_adapter_config(adapter_config_path)
-            base_model = AutoModelForCausalLM.from_pretrained(
-                base_model_path,
-                attn_implementation="flash_attention_2" if use_flash_attn else None,
-                torch_dtype=bfloat16 if use_flash_attn else None,
-            )
-
-            # since the peft library (PEFTModelForCausalLM) does not handle cases
-            # where the model's layers are modified, in our case the embedding layer
-            # is modified, so we resize the backbone model's embedding layer with our own
-            # utility before passing it along to load the PEFT model.
-            tokenizer_data_utils.tokenizer_and_embedding_resize(
-                {}, tokenizer=tokenizer, model=base_model
-            )
-            model = PeftModel.from_pretrained(
-                base_model,
-                checkpoint_dir,
-                attn_implementation="flash_attention_2" if use_flash_attn else None,
-                torch_dtype=bfloat16 if use_flash_attn else None,
-            )
-        else:
-            model = AutoModelForCausalLM.from_pretrained(
-                checkpoint_dir,
-                attn_implementation="flash_attention_2" if use_flash_attn else None,
-                torch_dtype=bfloat16 if use_flash_attn else None,
-            )
-
-        model_arch = model.config.model_type
-        # check that it is a granite model with llama architecture with tied weights
-        # ie. lm_head is duplicate of embeddings
-
-        # a fine tuned model will have params_dict.get("model.embed_tokens.weight")
-        # a prompt adapter has params_dict.get("base_model.model.embed_tokens.weight")
-        # a lora adapter has params_dict.get("base_model.model.model.embed_tokens.weight")
-        if model_arch == "llama" and hasattr(model, "lm_head"):
-            if (
-                # lora tuned model has an addt model layer
-                (
-                    hasattr(model.model, "model")
-                    and model.lm_head.weight.untyped_storage().data_ptr()
-                    == model.model.model.embed_tokens.weight.untyped_storage().data_ptr()
-                )
-                # prompt tuned model or fine tuned model
-                or (
-                    hasattr(model.model, "embed_tokens")
-                    and model.lm_head.weight.untyped_storage().data_ptr()
-                    == model.model.embed_tokens.weight.untyped_storage().data_ptr()
-                )
-            ):
-
-                logging.info("Removing lm_head from checkpoint")
-                del model.lm_head.weight
-
-                if hasattr(model, "lm_head.weight"):
-                    logging.warning("Failed to delete lm_head.weight from model")
-
-                logging.info("Saving checkpoint to %s", output_dir)
-                model.save_pretrained(checkpoint_dir)
-                # save tokenizer with model
-                tokenizer.save_pretrained(checkpoint_dir)
-
-    except Exception as e:  # pylint: disable=broad-except
-        logging.error(traceback.format_exc())
-        write_termination_log(f"Exception encountered removing lm_head from model: {e}")
         sys.exit(INTERNAL_ERROR_EXIT_CODE)
 
     # The .complete file will signal to users that we are finished copying

--- a/build/utils.py
+++ b/build/utils.py
@@ -40,29 +40,6 @@ def copy_checkpoint(source, destination):
             shutil.copy2(source_file, destination_file)
 
 
-def get_highest_checkpoint(dir_path):
-    """Given path to directory, returns name of highest checkpoint directory.
-    Expects checkpoint directories to be formatted 'checkpoint-<number>'
-
-    Args:
-        dir_path: str
-    Returns:
-        str
-    """
-    checkpoint_dir = ""
-    for curr_dir in os.listdir(dir_path):
-        if curr_dir.startswith("checkpoint"):
-            if checkpoint_dir:
-                curr_dir_num = int(checkpoint_dir.rsplit("-", maxsplit=1)[-1])
-                new_dir_num = int(curr_dir.split("-")[-1])
-                if new_dir_num > curr_dir_num:
-                    checkpoint_dir = curr_dir
-            else:
-                checkpoint_dir = curr_dir
-
-    return checkpoint_dir
-
-
 def serialize_args(args_json):
     """Given dict, converts to base64 byte representation.
 

--- a/tests/build/test_launch_script.py
+++ b/tests/build/test_launch_script.py
@@ -25,13 +25,14 @@ import pytest
 
 # First Party
 from build.accelerate_launch import main
-from build.utils import serialize_args, get_highest_checkpoint
+from build.utils import serialize_args
 from tests.data import TWITTER_COMPLAINTS_DATA
 from tuning.utils.error_logging import (
     USER_ERROR_EXIT_CODE,
     INTERNAL_ERROR_EXIT_CODE,
 )
 from tuning.config.tracker_configs import FileLoggingTrackerConfig
+from tuning.utils.postprocessting_utils import get_highest_checkpoint
 
 SCRIPT = "tuning/sft_trainer.py"
 MODEL_NAME = "Maykeye/TinyLLama-v0"

--- a/tuning/utils/postprocessting_utils.py
+++ b/tuning/utils/postprocessting_utils.py
@@ -1,0 +1,38 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Standard
+import os
+
+
+def get_highest_checkpoint(dir_path):
+    """Given full path to directory, returns name of highest checkpoint directory.
+    Expects checkpoint directories to be formatted 'checkpoint-<number>'
+
+    Args:
+        dir_path: str
+    Returns:
+        str
+    """
+    checkpoint_dir = ""
+    for curr_dir in os.listdir(dir_path):
+        if curr_dir.startswith("checkpoint"):
+            if checkpoint_dir:
+                curr_dir_num = int(checkpoint_dir.rsplit("-", maxsplit=1)[-1])
+                new_dir_num = int(curr_dir.split("-")[-1])
+                if new_dir_num > curr_dir_num:
+                    checkpoint_dir = curr_dir
+            else:
+                checkpoint_dir = curr_dir
+
+    return os.path.join(dir_path, checkpoint_dir)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

- Utilize the removal of duplicated lm_head weight in granite models with llama arch in sft_trainer instead of just in accelerate_launch script. Removal of lm_head weight still occurs in the save_model_dir OR the last checkpoint.
- Now on call to `sft_trainer.save()` the lm_head weight will automatically be removed
- No longer need to reload the checkpoint to remove lm_head

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

Currently testing

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass