### PR TITLE
refactor: set log level to separate out train args

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -62,7 +62,7 @@ from tuning.utils.error_logging import (
     USER_ERROR_EXIT_CODE,
     write_termination_log,
 )
-from tuning.utils.logging import set_log_level
+from tuning.utils.logging import set_log_level, set_python_log_level
 from tuning.utils.preprocessing_utils import (
     format_dataset,
     get_data_collator,
@@ -377,11 +377,7 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
             Optional threshold to set save save logger to, default warning.
     """
     logger = logging.getLogger("sft_trainer_save")
-    # default value from TrainingArguments
-    if log_level == "passive":
-        log_level = "WARNING"
-
-    logger.setLevel(log_level.upper())
+    set_python_log_level(log_level, logger)
 
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)

--- a/tuning/utils/logging.py
+++ b/tuning/utils/logging.py
@@ -53,12 +53,24 @@ def set_log_level(train_args, logger_name=None):
             else os.environ.get("TRANSFORMERS_VERBOSITY")
         )
 
-    logging.basicConfig(
-        format="%(levelname)s:%(filename)s:%(message)s", level=log_level.upper()
-    )
-
+    train_logger = logging.getLogger()
     if logger_name:
         train_logger = logging.getLogger(logger_name)
-    else:
-        train_logger = logging.getLogger()
+
+    set_python_log_level(log_level, train_logger)
+    set_python_log_level(log_level)
     return train_args, train_logger
+
+
+def set_python_log_level(log_level=None, logger=None):
+    # Configure Python native logger
+    # If CLI arg is passed, assign same log level to python native logger
+    if not log_level:
+        log_level = os.environ.get("LOG_LEVEL", "WARNING")
+
+    if logger:
+        logger.setLevel(log_level.upper())
+    else:
+        logging.basicConfig(
+            format="%(levelname)s:%(filename)s:%(message)s", level=log_level.upper()
+        )


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Separate out python logging and setting log level with setting log level using train_args and altering `train_args.log_level` to match python logging level. 

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass