### PR TITLE
feat: Silence certain warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -281,7 +281,7 @@ ignored-parents=
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -145,6 +145,10 @@ class TrainingArguments(transformers.TrainingArguments):
             Other possible values are 'debug', 'info', 'warning', 'error' and 'critical'"
         },
     )
+    warnings: bool = field(
+        default=False,
+        metadata={"help": "Enable warnings during training. Default is False."},
+    )
 
 
 @dataclass

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -19,6 +19,7 @@ import json
 import sys
 import time
 import traceback
+import warnings
 
 # Third Party
 from huggingface_hub.utils._validators import HFValidationError
@@ -111,6 +112,9 @@ def train(
             Should be used in combination with quantized_lora_config. Also currently 
             fused_lora and fast_kernels must used together (may change in future). \
     """
+
+    if not train_args.warnings:
+        warnings.filterwarnings("ignore", category=FutureWarning)
 
     train_args, logger = set_log_level(train_args, "sft_trainer_train")
 


### PR DESCRIPTION
### Description of the change
This PR is to silence certain warnings, preliminarily silencing future warnings if the new Training Arguments flag `warnings` is set to False (which it is by default).
Imported warnings into sft_trainer.py
Changed the maximum number of class parameters to 8 from 7 in .pylintrc.

With this preliminary change (only silencing FutureWarnings) when running `tox -e py`:
Before:
``` 153 passed, 14 skipped, 249 warnings in 76.34s (0:01:16) ```
After:
```153 passed, 14 skipped, 207 warnings in 69.31s (0:01:09)```

### Questions for reviewers

- Should I use a pre-existing flag such as log_level to do this?
- Is where I put the silencing code where it should be?
- If we want to add this new flag:
   - Is it okay to change pylintrc max from 7 to 8 or do we want to maintain 7 as a maximum?
   - Should we allow direct control over the type of warnings that are silenced? If so, 

### How to verify the PR
In root of fms-hf-tuning
```
python3 tuning/sft_trainer.py \                                        
--model_name_or_path Maykeye/TinyLLama-v0 \
--training_data_path tests/data/twitter_complaints_small.jsonl \
--output_dir outputs/lora-tuning \
--num_train_epochs 5 \
--per_device_train_batch_size 4 \
--gradient_accumulation_steps 4 \
--learning_rate 1e-5 \
--response_template "\n### Label:" \
--dataset_text_field "output" \
--use_flash_attn false \
--torch_dtype "float32" \
--peft_method "lora" \
--r 8 \
--lora_dropout 0.05 \
--lora_alpha 16  \
--warnings True
```
OR
```
--warnings False
```

You can also run `tox -e py` before and after changes.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass