### PR TITLE
fix: Resolve some warnings

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -311,14 +311,16 @@ def train(
     # this validation, we just drop the things that aren't part of the SFT Config and build one
     # from our object directly. In the future, we should consider renaming this class and / or
     # not adding things that are not directly used by the trainer instance to it.
-    
+
     transformer_train_arg_fields = [x.name for x in dataclasses.fields(SFTConfig)]
     transformer_kwargs = {
-        'hub_token' if k == 'push_to_hub_token' else k: v
+        "hub_token" if k == "push_to_hub_token" else k: v
         for k, v in train_args.to_dict().items()
         if k in transformer_train_arg_fields
     }
-    training_args = SFTConfig(**transformer_kwargs, dataset_text_field=dataset_text_field)
+    training_args = SFTConfig(
+        **transformer_kwargs, dataset_text_field=dataset_text_field
+    )
 
     trainer = SFTTrainer(
         model=model,

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -200,6 +200,7 @@ def train(
         ),
         cache_dir=train_args.cache_dir,
         use_fast=True,
+        legacy=False,
     )
 
     # Calculate and save additional metrics to track later.

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -201,6 +201,7 @@ def train(
         cache_dir=train_args.cache_dir,
         use_fast=True,
         legacy=False,
+        padding_side="right",
     )
 
     # Calculate and save additional metrics to track later.

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -313,7 +313,7 @@ def train(
     # not adding things that are not directly used by the trainer instance to it.
     transformer_train_arg_fields = [x.name for x in dataclasses.fields(SFTConfig)]
     transformer_kwargs = {
-        k: v
+        'hub_token' if k == 'push_to_hub_token' else k: v
         for k, v in train_args.to_dict().items()
         if k in transformer_train_arg_fields
     }

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -327,6 +327,9 @@ def train(
     training_args.dataset_text_field = (
         dataset_text_field  # Inject the dataset text field into the training args
     )
+    training_args.packing = (
+        packing  # Inject packing into the training args
+    )
 
     trainer = SFTTrainer(
         model=model,

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -327,9 +327,7 @@ def train(
     training_args.dataset_text_field = (
         dataset_text_field  # Inject the dataset text field into the training args
     )
-    training_args.packing = (
-        packing  # Inject packing into the training args
-    )
+    training_args.packing = packing  # Inject packing into the training args
 
     trainer = SFTTrainer(
         model=model,

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -311,13 +311,14 @@ def train(
     # this validation, we just drop the things that aren't part of the SFT Config and build one
     # from our object directly. In the future, we should consider renaming this class and / or
     # not adding things that are not directly used by the trainer instance to it.
+    
     transformer_train_arg_fields = [x.name for x in dataclasses.fields(SFTConfig)]
     transformer_kwargs = {
         'hub_token' if k == 'push_to_hub_token' else k: v
         for k, v in train_args.to_dict().items()
         if k in transformer_train_arg_fields
     }
-    training_args = SFTConfig(**transformer_kwargs)
+    training_args = SFTConfig(**transformer_kwargs, dataset_text_field=dataset_text_field)
 
     trainer = SFTTrainer(
         model=model,
@@ -326,9 +327,7 @@ def train(
         eval_dataset=formatted_validation_dataset,
         packing=packing,
         data_collator=data_collator,
-        dataset_text_field=dataset_text_field,
         args=training_args,
-        max_seq_length=max_seq_length,
         callbacks=trainer_callbacks,
         peft_config=peft_config,
     )


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
This change resolves three warnings:
```
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
fms-hf-tuning/.venv/lib/python3.12/site-packages/transformers/training_args.py:2007: FutureWarning: `--push_to_hub_token` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `--hub_token` instead.
  warnings.warn(
fms-hf-tuning/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_deprecation.py:100: FutureWarning: Deprecated argument(s) used in '__init__': dataset_text_field, max_seq_length. Will not be supported from version '1.0.0'.
fms-hf-tuning/.venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:408: UserWarning: You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code.
  warnings.warn(
```
To resolve these warnings, legacy was set to False (as the warning recommends), we use hub_token instead of push_to_hub_token in 

### How to verify the PR
In tox -e py:
Legacy fix: 357 -> 357 warnings (since it's not explicitly a warning)
push_to_hub_token fix: 357 -> 330 warnings
dataset_text_field and max_seq_length fix: 330 -> 252 warnings
tokenizer.padding_size: 252 -> 225 warnings
Warnings decrease of 37.0%


```
% python3 tuning/sft_trainer.py \
--model_name_or_path Maykeye/TinyLLama-v0 \
--training_data_path tests/data/twitter_complaints_small.jsonl \
--output_dir outputs/lora-tuning \
--num_train_epochs 5 \
--per_device_train_batch_size 4 \
--gradient_accumulation_steps 4 \
--learning_rate 1e-5 \
--response_template "\n### Label:" \
--dataset_text_field "output" \
--use_flash_attn false \
--torch_dtype "float32" \
--peft_method "lora" \
--r 8 \
--lora_dropout 0.05 \
--lora_alpha 16  \
--log_level "error"
```

What training logs used to look like:
```
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/transformers/training_args.py:2007: FutureWarning: `--push_to_hub_token` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `--hub_token` instead.
  warnings.warn(
/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_deprecation.py:100: FutureWarning: Deprecated argument(s) used in '__init__': dataset_text_field, max_seq_length. Will not be supported from version '1.0.0'.

Deprecated positional argument(s) used in SFTTrainer, please use the SFTConfig to set these arguments instead.
  warnings.warn(message, FutureWarning)
/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:280: UserWarning: You passed a `max_seq_length` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.
  warnings.warn(
/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:318: UserWarning: You passed a `dataset_text_field` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.
  warnings.warn(
/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:408: UserWarning: You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code.
  warnings.warn(
{'loss': 7.9407, 'grad_norm': 3.3928208351135254, 'learning_rate': 8.000000000000001e-06, 'epoch': 1.0}                                              
 20%|██████████████████████▊                                                                                           | 1/5 [00:00<00:02,  1.70it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'loss': 3.9542, 'grad_norm': 2.5375678539276123, 'learning_rate': 4.000000000000001e-06, 'epoch': 2.0}                                              
 60%|████████████████████████████████████████████████████████████████████▍                                             | 3/5 [00:01<00:00,  2.89it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
 80%|███████████████████████████████████████████████████████████████████████████████████████████▏                      | 4/5 [00:01<00:00,  2.93it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'loss': 3.8708, 'grad_norm': 1.4121605157852173, 'learning_rate': 0.0, 'epoch': 3.0}                                                                
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  2.93it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'train_runtime': 1.8424, 'train_samples_per_second': 27.138, 'train_steps_per_second': 2.714, 'train_loss': 4.718147087097168, 'epoch': 3.0}        
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  2.71it/s]
```

What they look like now:
```
WARNING:sft_trainer.py:max_seq_length 4096 exceeds tokenizer.model_max_length             2048, using tokenizer.model_max_length 2048
{'loss': 7.9407, 'grad_norm': 3.680093765258789, 'learning_rate': 8.000000000000001e-06, 'epoch': 1.0}                                                         
 20%|████████████████████████▊                                                                                                   | 1/5 [00:00<00:01,  2.40it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'loss': 3.9542, 'grad_norm': 2.5959932804107666, 'learning_rate': 4.000000000000001e-06, 'epoch': 2.0}                                                        
 60%|██████████████████████████████████████████████████████████████████████████▍                                                 | 3/5 [00:00<00:00,  4.07it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
 80%|███████████████████████████████████████████████████████████████████████████████████████████████████▏                        | 4/5 [00:01<00:00,  3.78it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'loss': 3.8707, 'grad_norm': 1.501767873764038, 'learning_rate': 0.0, 'epoch': 3.0}                                                                           
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  3.78it/s]/Users/mwj/Code/IBM/fms-hf-tuning/.venv/lib/python3.12/site-packages/peft/utils/save_and_load.py:232: UserWarning: Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning.
  warnings.warn(
{'train_runtime': 1.3916, 'train_samples_per_second': 35.93, 'train_steps_per_second': 3.593, 'train_loss': 4.718081665039063, 'epoch': 3.0}                   
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  3.59it/s]
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass