### PR TITLE
fix: avoid docker push timeout by splitting the single big layer into 2 smaller layers

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -150,6 +150,18 @@ RUN python -m pip uninstall wheel build -y && \
     # Cleanup the bdist whl file
     rm $(head bdist_name) /tmp/bdist_name
 
+## Builder image without nvidia ###############################
+FROM python-installations AS builderwithoutnvidia
+ARG USER
+ARG PYTHON_VERSION
+RUN rm -rf /home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages/nvidia
+
+## Builder image with only nvidia ###############################
+FROM scratch AS builderwithnvidia
+ARG USER
+ARG PYTHON_VERSION
+COPY --from=python-installations /home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages/nvidia /home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages/nvidia
+
 ## Final image ################################################
 FROM release-base AS release
 ARG USER
@@ -180,7 +192,8 @@ ENV SET_NUM_PROCESSES_TO_NUM_GPUS="True"
 
 WORKDIR /app
 USER ${USER}
-COPY --from=python-installations /home/${USER}/.local /home/${USER}/.local
+COPY --from=builderwithoutnvidia /home/${USER}/.local /home/${USER}/.local
+COPY --from=builderwithnvidia /home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages/nvidia /home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages/nvidia
 ENV PYTHONPATH="/home/${USER}/.local/lib/python${PYTHON_VERSION}/site-packages"
 
 CMD [ "python", "/app/accelerate_launch.py" ]


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Split the 6GB layer into a two around 3GB layers

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass