### PR TITLE
fix: Addition of default pad token in tokenizer when EOS and PAD token are equal

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -262,6 +262,9 @@ def train(
         if tokenizer.unk_token is None:
             logger.warning("UNK token set to default, missing in tokenizer")
             special_tokens_dict["unk_token"] = configs.DEFAULT_UNK_TOKEN
+        if tokenizer.pad_token == tokenizer.eos_token:
+            logger.warning("PAD token set to default, different from eos token")
+            special_tokens_dict["pad_token"] = configs.DEFAULT_PAD_TOKEN
 
     # TODO: lower priority but understand if resizing impacts inference quality and why its needed.
     # It makes sense if we manipulate tokenizer that we also save it and provide it to inference.

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -263,8 +263,13 @@ def train(
             logger.warning("UNK token set to default, missing in tokenizer")
             special_tokens_dict["unk_token"] = configs.DEFAULT_UNK_TOKEN
         if tokenizer.pad_token == tokenizer.eos_token:
-            logger.warning("PAD token set to default, different from eos token")
-            special_tokens_dict["pad_token"] = configs.DEFAULT_PAD_TOKEN
+            logger.warning(
+                "PAD token set to default, to make it different from eos token"
+            )
+            if tokenizer.eos_token != configs.DEFAULT_PAD_TOKEN:
+                tokenizer.pad_token = configs.DEFAULT_PAD_TOKEN
+            else:
+                tokenizer.eos_token = configs.DEFAULT_EOS_TOKEN
 
     # TODO: lower priority but understand if resizing impacts inference quality and why its needed.
     # It makes sense if we manipulate tokenizer that we also save it and provide it to inference.


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

For any model when tokenizer has PAD token equal to EOS token, then the `DataCollatorForCompletionOnlyLM` masks the EOS token from `labels` of dataset batch which leads to repetitive `predicted_target` during inference time thus decreasing f1-micro for models like `granite-34b-gptq` 

### Related issue number

[#1309 ](https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1309)

### How to verify the PR

Running HF inference after QLoRA tuning of `granite-34b-gptq` model. 

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass