### PR TITLE
fix: cap transformers at v4.44

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 dependencies = [
 "numpy>=1.26.4,<2.0",
 "accelerate>=0.20.3,<0.34",
-"transformers>4.41,<5.0",
+"transformers>4.41,<4.45",
 "torch>=2.2.0,<3.0",
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

Latest version of [transformers v4.45.0](https://github.com/huggingface/transformers/releases) was released two hours ago and is breaking unit tests ([see failures](https://github.com/foundation-model-stack/fms-hf-tuning/actions/runs/11040215549/job/30667675308?pr=338)) with error: `AttributeError: 'AdamW' object has no attribute 'train'` when running training. 

Capping version below v4.45.


### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass