### PR TITLE
fix: unable to find output_dir in multi-GPU during resume_from_checkpoint check

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -98,7 +98,7 @@ def main():
     #
     ##########
     output_dir = job_config.get("output_dir")
-    if not os.path.exists(output_dir): 
+    if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     try:
         # checkpoints outputted to tempdir, only final checkpoint copied to output dir

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -98,6 +98,8 @@ def main():
     #
     ##########
     output_dir = job_config.get("output_dir")
+    if not os.path.exists(output_dir): 
+        os.makedirs(output_dir)
     try:
         # checkpoints outputted to tempdir, only final checkpoint copied to output dir
         launch_command(args)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Addition of code to create `output_dir` in `accelerate_launch.py` if it doesn't exist.

### Related issue number

[#1352](https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1352)

### How to verify the PR

Run full fine tuning or LoRA tuning with multiple GPUs and check if issue exists.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass