### PR TITLE
fix: check for wte.weight along with embed_tokens.weight

### DIFF
--- a/tuning/utils/merge_model_utils.py
+++ b/tuning/utils/merge_model_utils.py
@@ -168,7 +168,7 @@ def post_process_vLLM_adapters_new_tokens(
                     # vLLM requires renaming to output_embeddings
                     new_embeddings["output_embeddings"] = new_output_embeddings
 
-                elif "embed_tokens.weight" in k:
+                elif "embed_tokens.weight" in k or "wte.weight" in k:
                     embed_tokens = f.get_tensor(k)
                     # pull out tensor values of new tokens
                     new_input_embeddings = embed_tokens[-num_added_tokens:]


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Some granite models use naming convention `wte.weight` instead of `embed_tokens.weight`. Accounting for the difference for v2.0.0 release until we can get something more generic.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass