### PR TITLE
build(deps): unset hardcoded trl version to get latest updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",
 "tqdm>=4.66.2,<5.0",
-"trl==0.9.6",
+"trl>=0.9.3,<1.0",
 "peft>=0.8.0,<0.13",
 "protobuf>=5.28.0,<6.0.0",
 "datasets>=2.15.0,<3.0",


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Previousl in PR #329 we had hardcoded release branch to be v0.9.6 of trl but we want to unset the hardcoded version to get updates since we fixed the error with pretokenized datasets on main branch.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass