### PR TITLE
fix: Revert changes from PR#326 with trl version change

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -67,7 +67,6 @@ from tuning.utils.logging import set_log_level
 from tuning.utils.preprocessing_utils import (
     format_dataset,
     get_data_collator,
-    is_pretokenized_dataset,
     validate_data_args,
 )
 
@@ -348,11 +347,6 @@ def train(
     }
     training_args = SFTConfig(**transformer_kwargs)
 
-    dataset_kwargs = {}
-    if is_pretokenized_dataset(
-        data_args.training_data_path or data_args.validation_data_path
-    ):
-        dataset_kwargs["skip_prepare_dataset"] = True
     trainer = SFTTrainer(
         model=model,
         tokenizer=tokenizer,
@@ -365,7 +359,6 @@ def train(
         max_seq_length=max_seq_length,
         callbacks=trainer_callbacks,
         peft_config=peft_config,
-        dataset_kwargs=dataset_kwargs,
     )
 
     # We track additional metrics and experiment metadata after trainer object creation


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Setting trl to version 0.9.6 causes the following error:
```
if not args.packing:
            # If we aren't skipping data preparation, then a dataset_text_field
            # or formatting_func must be provided.
            if (
                args.dataset_text_field is None
                and formatting_func is None
                and dataset_kwargs is not None
                and "skip_prepare_dataset" in dataset_kwargs
                and dataset_kwargs["skip_prepare_dataset"]
            ):
>               raise ValueError(
                    "You passed `packing=False` to the SFTTrainer/SFTConfig, but you didn't pass a `dataset_text_field` or `formatting_func` argument."
                )
E               ValueError: You passed `packing=False` to the SFTTrainer/SFTConfig, but you didn't pass a `dataset_text_field` or `formatting_func` argument.
```

This PR is to temporarily revert the changes in PR #326 until Fabian's qlora fix is in the latest version of trl

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass