### PR TITLE
ci: run unit tests, fmt, image build on release branch

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,9 +16,9 @@ name: Format
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
 
 jobs:
   lint:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,9 +1,9 @@
 name: Image
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,9 @@
 name: Test
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release" ]
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

We want to run CI automation on PRs that go directly to release branch. This includes any patch fixes (currently) and the release time PRs. By not running unit tests, we miss differences between main and release branch as well as dependencies may be new and updated that should be tested. This vets the PR at release time. 

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass