### PR TITLE
fix: crash when output directory doesn't exist

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -637,6 +637,9 @@ def main():
     combined_tracker_configs.file_logger_config = file_logger_config
     combined_tracker_configs.aim_config = aim_config
 
+    if training_args.output_dir:
+        os.makedirs(training_args.output_dir, exist_ok=True)
+        logger.info("using the output directory at %s", training_args.output_dir)
     try:
         trainer, additional_train_info = train(
             model_args=model_args,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Fixes crash in https://github.com/foundation-model-stack/fms-hf-tuning/issues/359

### Related issue number

https://github.com/foundation-model-stack/fms-hf-tuning/issues/359

### How to verify the PR

Run a multi GPU training with a non-existent output dir.

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass