### PR TITLE
build: Set triton environment variables

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -169,6 +169,12 @@ RUN mkdir /app && \
     chown -R $USER:0 /app /tmp && \
     chmod -R g+rwX /app /tmp
 
+# Set Triton environment variables for qLoRA
+ENV TRITON_HOME="/tmp/triton_home"
+ENV TRITON_DUMP_DIR="/tmp/triton_dump_dir"
+ENV TRITON_CACHE_DIR="/tmp/triton_cache_dir"
+ENV TRITON_OVERRIDE_DIR="/tmp/triton_override_dir"
+
 # Need a better way to address these hacks
 RUN if [[ "${ENABLE_AIM}" == "true" ]] ; then \
         touch /.aim_profile && \


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Add triton environment variables for QLoRA tuning if random user in cluster.

### Related issue number

closes #367 

### How to verify the PR
Use image `docker-na-public.artifactory.swg-devops.com/wcp-ai-foundation-team-docker-virtual/sft-trainer:triton_env_vars_ubi9_py311.triton_env_vars` and run tuning as a random user without setting these variable manually.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass