### PR TITLE
build(deps): Upgrade accelerate requirement to allow version 1.0.0

### DIFF
--- a/fixtures/accelerate_fsdp_defaults.yaml
+++ b/fixtures/accelerate_fsdp_defaults.yaml
@@ -14,7 +14,7 @@ fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
 
   # this controls the FSDP pipelining
-  fsdp_backward_prefetch_policy: BACKWARD_PRE # set to BACKWARD_PRE for the most time-efficient pipeline
+  fsdp_backward_prefetch: BACKWARD_PRE # set to BACKWARD_PRE for the most time-efficient pipeline
                                               # but requires the most memory. BACKWARD_POST is the less
                                               # memory intensive option
 

--- a/fixtures/accelerate_fsdp_defaults.yaml
+++ b/fixtures/accelerate_fsdp_defaults.yaml
@@ -17,6 +17,7 @@ fsdp_config:
   fsdp_backward_prefetch: BACKWARD_PRE # set to BACKWARD_PRE for the most time-efficient pipeline
                                               # but requires the most memory. BACKWARD_POST is the less
                                               # memory intensive option
+  fsdp_backward_prefetch_policy: BACKWARD_PRE # for backwards compatibility
 
   # setting this to true will increase forward memory by prefetching the next FSDP all-gather, while performing
   # the current forward pass. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers=[
 ]
 dependencies = [
 "numpy>=1.26.4,<2.0",
-"accelerate>=0.20.3,<0.35,!=0.34",
+"accelerate>=0.20.3,!=0.34,<1.1",
 "transformers>4.41,<4.50",
 "torch>=2.2.0,<3.0",
 "sentencepiece>=0.1.99,<0.3",

--- a/tests/build/dummy_job_config.json
+++ b/tests/build/dummy_job_config.json
@@ -5,7 +5,7 @@
       "dynamo_use_dynamic": true,
       "num_machines": 1,
       "main_process_port": 1234,
-      "fsdp_backward_prefetch_policy": "TRANSFORMER_BASED_WRAP",
+      "fsdp_backward_prefetch": "TRANSFORMER_BASED_WRAP",
       "fsdp_sharding_strategy": 1,
       "fsdp_state_dict_type": "FULL_STATE_DICT",
       "fsdp_cpu_ram_efficient_loading": true,

--- a/tests/build/test_utils.py
+++ b/tests/build/test_utils.py
@@ -44,7 +44,7 @@ def test_process_accelerate_launch_args(job_config):
     args = process_accelerate_launch_args(job_config)
     # json config values used
     assert args.use_fsdp is True
-    assert args.fsdp_backward_prefetch_policy == "TRANSFORMER_BASED_WRAP"
+    assert args.fsdp_backward_prefetch == "TRANSFORMER_BASED_WRAP"
     assert args.env == ["env1", "env2"]
     assert args.training_script == "tuning.sft_trainer"
     assert args.config_file == "fixtures/accelerate_fsdp_defaults.yaml"


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Updates the requirements on [accelerate](https://github.com/huggingface/accelerate) to permit the latest version.
Accelerate version 1.0.0 [release notes](https://github.com/huggingface/accelerate/releases/tag/v1.0.0)

Variable `--fsdp_backward_prefetch_policy` became outdated, replaced with new variable `--fsdp_backward_prefetch` to fix unit tests.

### Related issue number

closes #372 
<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass