### PR TITLE
feat: Add timing tracker to fms-hf-tuning

### DIFF
--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -25,6 +25,7 @@ import sys
 import traceback
 import json
 from pathlib import Path
+from datetime import datetime
 
 # Third Party
 from accelerate.commands.launch import launch_command
@@ -49,6 +50,8 @@ ERROR_LOG = "/dev/termination-log"
 def main():
     if not os.getenv("TERMINATION_LOG_FILE"):
         os.environ["TERMINATION_LOG_FILE"] = ERROR_LOG
+
+    start_time = datetime.now()
 
     ##########
     #
@@ -174,6 +177,23 @@ def main():
     # files over
     if os.path.exists(output_dir):
         Path(os.path.join(output_dir, ".complete")).touch()
+
+    # Record the end time and total duration
+    end_time = datetime.now()
+    total_duration = (end_time - start_time).total_seconds()
+
+    timing_log = {
+        "name": "total_runtime",
+        "data": {
+            "start_time": start_time.isoformat(),
+            "end_time": end_time.isoformat(),
+            "total_duration_seconds": total_duration,
+        }
+    }
+
+    timing_log_path = os.path.join(output_dir, "timing_logs.jsonl")
+    with open(timing_log_path, "a", encoding="utf-8") as f:
+        json.dump(timing_log, f, sort_keys=True)
 
     return 0
 

--- a/build/accelerate_launch.py
+++ b/build/accelerate_launch.py
@@ -43,6 +43,7 @@ from tuning.utils.error_logging import (
     USER_ERROR_EXIT_CODE,
     INTERNAL_ERROR_EXIT_CODE,
 )
+from tuning.config.tracker_configs import TimingTrackerConfig
 
 ERROR_LOG = "/dev/termination-log"
 
@@ -188,10 +189,12 @@ def main():
             "start_time": start_time.isoformat(),
             "end_time": end_time.isoformat(),
             "total_duration_seconds": total_duration,
-        }
+        },
     }
 
-    timing_log_path = os.path.join(output_dir, "timing_logs.jsonl")
+    timing_log_path = os.path.join(
+        output_dir, TimingTrackerConfig().timing_logs_filename
+    )
     with open(timing_log_path, "a", encoding="utf-8") as f:
         json.dump(timing_log, f, sort_keys=True)
 

--- a/docs/experiment-tracking.md
+++ b/docs/experiment-tracking.md
@@ -10,7 +10,7 @@ from tuning import sft_trainer
 
 training_args = TrainingArguments(
     ...,
-    trackers = ["aim", "file_logger"]
+    trackers = ["aim", "file_logger", "timer"]
 )
 
 sft_trainer.train(train_args=training_args,...)
@@ -52,7 +52,7 @@ tracker_configs = TrackerConfigFactory(
 sft_trainer.train(train_args=training_args, tracker_configs=tracker_configs, ...)
 ```
 
-Currently File Logging tacker supports only one argument and this file will be placed inside the `train_args.output` folder.
+Currently File Logging tracker supports only one argument and this file will be placed inside the `train_args.output` folder.
 
 ## Aimstack Tracker
 
@@ -115,6 +115,37 @@ sft_trainer.train(train_args=training_args, tracker_configs=tracker_configs,....
 The code expects either the `local` or `remote` repo to be specified and will result in a `ValueError` otherwise.
 See [AimConfig](https://github.com/foundation-model-stack/fms-hf-tuning/blob/a9b8ec8d1d50211873e63fa4641054f704be8712/tuning/config/tracker_configs.py#L25) for more details.
 
+## Timing Tracker
+
+[Timer](../tuning/trackers/timing_tracker.py) is an inbuilt tracker which can be used to track training time of a model per process and total runtime if training is initialized in `accelerate_launch.py`.
+
+Currently the `Timer` is enabled by default and will output timing after training is complete, then total time will be appended after accelerate launch finishes running to a default file path specified [tracker configs](../tuning/config/tracker_configs.py).
+
+To override the location of file logger please pass an instance of the [TimingTrackerConfig](../tuning/config/tracker_configs.py) to `tracker_configs` argument.  
+
+```
+from tuning import sft_trainer
+from tuning.config.tracker_configs import TimingTrackerConfig, TrackerConfigFactory
+
+training_args = TrainingArguments(
+    ...,
+    trackers = ["timer"]
+)
+
+
+logs_file = "new_timing_logs.jsonl"
+
+tracker_configs = TrackerConfigFactory(
+    time_config=TimingTrackerConfig(
+        training_logs_filename=logs_file
+        )
+    )
+
+sft_trainer.train(train_args=training_args, tracker_configs=tracker_configs, ...)
+```
+
+Currently Timer tracker supports only one argument and this file will be placed inside the `train_args.output` folder.
+
 
 ## Running the code via command line `tuning/sft_trainer::main` function
 
@@ -123,7 +154,7 @@ If running the code via main function of [sft_trainer.py](../tuning/sft_trainer.
 To enable tracking please pass
 
 ```
---tracker <aim/file_logger>
+--tracker <aim/file_logger/timer>
 ```
 
 To further customise tracking you can specify additional arguments needed by the tracker like

--- a/docs/experiment-tracking.md
+++ b/docs/experiment-tracking.md
@@ -137,7 +137,7 @@ logs_file = "new_timing_logs.jsonl"
 
 tracker_configs = TrackerConfigFactory(
     time_config=TimingTrackerConfig(
-        training_logs_filename=logs_file
+        timing_logs_filename=logs_file
         )
     )
 

--- a/tests/trackers/test_timing_tracker.py
+++ b/tests/trackers/test_timing_tracker.py
@@ -1,0 +1,77 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+# https://spdx.dev/learn/handling-license-info/
+
+
+# Standard
+import copy
+import tempfile
+import os
+
+# First Party
+from tests.test_sft_trainer import (
+    DATA_ARGS,
+    MODEL_ARGS,
+    TRAIN_ARGS,
+    _get_checkpoint_path,
+    _test_run_causallm_ft,
+    _test_run_inference,
+    _validate_training,
+)
+
+# Local
+from tuning import sft_trainer
+from tuning.config.tracker_configs import TimingTrackerConfig, TrackerConfigFactory
+
+## Timing tracker tests
+
+
+def test_run_with_timing_tracker():
+    """Ensure that training succeeds with the timing tracker enabled."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args.trackers = ["timer"]
+
+        _test_run_causallm_ft(TRAIN_ARGS, MODEL_ARGS, DATA_ARGS, tempdir)
+        _test_run_inference(_get_checkpoint_path(tempdir))
+
+
+def test_sample_run_with_timing_tracker_updated_filename():
+    """Ensure that the timing tracker filename can be updated."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args.output_dir = tempdir
+
+        train_args.trackers = ["timer"]
+
+        logs_file = "custom_timing_logs.jsonl"
+
+        tracker_configs = TrackerConfigFactory(
+            timer_config=TimingTrackerConfig(timing_logs_filename=logs_file)
+        )
+
+        sft_trainer.train(
+            MODEL_ARGS, DATA_ARGS, train_args, tracker_configs=tracker_configs
+        )
+
+        # Validate that the timing logs file was created with the correct name
+        train_logs_file_path = "{}/{}".format(tempdir, logs_file)
+        train_log_contents = ""
+        with open(train_logs_file_path, encoding="utf-8") as f:
+            train_log_contents = f.read()
+        assert os.path.exists(train_logs_file_path) is True
+        assert os.path.getsize(train_logs_file_path) > 0
+        assert "train_runtime" in train_log_contents

--- a/tests/trackers/test_timing_tracker.py
+++ b/tests/trackers/test_timing_tracker.py
@@ -18,8 +18,8 @@
 
 # Standard
 import copy
-import tempfile
 import os
+import tempfile
 
 # First Party
 from tests.test_sft_trainer import (
@@ -29,7 +29,6 @@ from tests.test_sft_trainer import (
     _get_checkpoint_path,
     _test_run_causallm_ft,
     _test_run_inference,
-    _validate_training,
 )
 
 # Local

--- a/tuning/config/tracker_configs.py
+++ b/tuning/config/tracker_configs.py
@@ -64,6 +64,12 @@ class AimConfig:
 
 
 @dataclass
+class TimingTrackerConfig:
+    timing_logs_filename: str = "timing_logs.jsonl"
+
+
+@dataclass
 class TrackerConfigFactory:
     file_logger_config: FileLoggingTrackerConfig = None
     aim_config: AimConfig = None
+    timer_config: TimingTrackerConfig = None

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -51,9 +51,14 @@ from tuning.config.acceleration_configs import (
 from tuning.config.tracker_configs import (
     AimConfig,
     FileLoggingTrackerConfig,
+    TimingTrackerConfig,
     TrackerConfigFactory,
 )
-from tuning.trackers.tracker_factory import FILE_LOGGING_TRACKER, get_tracker
+from tuning.trackers.tracker_factory import (
+    FILE_LOGGING_TRACKER,
+    TIMING_TRACKER,
+    get_tracker,
+)
 from tuning.trainercontroller import TrainerControllerCallback
 from tuning.utils.config_utils import get_hf_peft_config, get_json_config
 from tuning.utils.data_type_utils import get_torch_dtype
@@ -81,7 +86,8 @@ def train(
     ] = None,
     trainer_controller_args: configs.TrainerControllerArguments = None,
     tracker_configs: Optional[TrackerConfigFactory] = TrackerConfigFactory(
-        file_logger_config=FileLoggingTrackerConfig()
+        file_logger_config=FileLoggingTrackerConfig(),
+        timer_config=TimingTrackerConfig(),
     ),
     additional_callbacks: Optional[List[TrainerCallback]] = None,
     exp_metadata: Optional[Dict] = None,
@@ -172,6 +178,9 @@ def train(
     # Ensure file logging is present
     if FILE_LOGGING_TRACKER not in requested_trackers:
         requested_trackers.add(FILE_LOGGING_TRACKER)
+
+    if TIMING_TRACKER not in requested_trackers:
+        requested_trackers.add(TIMING_TRACKER)
 
     if not isinstance(tracker_configs, TrackerConfigFactory):
         raise ValueError(

--- a/tuning/trackers/timing_tracker.py
+++ b/tuning/trackers/timing_tracker.py
@@ -43,7 +43,7 @@ class TimingCallback(TrainerCallback):
         total_duration = (end_time - self.start_time).total_seconds()
 
         log_obj = {
-            "name": "training_timing",
+            "name": "train_runtime",
             "data": {
                 "start_time": self.start_time.isoformat(),
                 "end_time": end_time.isoformat(),
@@ -53,7 +53,6 @@ class TimingCallback(TrainerCallback):
             },
         }
 
-        # Write the log to a JSONL file
         log_file_path = os.path.join(args.output_dir, self.logs_filename)
         with open(log_file_path, "a", encoding="utf-8") as f:
             f.write(f"{json.dumps(log_obj, sort_keys=True)}\n")

--- a/tuning/trackers/timing_tracker.py
+++ b/tuning/trackers/timing_tracker.py
@@ -1,3 +1,17 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Standard
 from datetime import datetime
 import json

--- a/tuning/trackers/timing_tracker.py
+++ b/tuning/trackers/timing_tracker.py
@@ -1,0 +1,58 @@
+# Standard
+from datetime import datetime
+import json
+import logging
+import os
+
+# Third Party
+from transformers import TrainerCallback
+
+# Local
+from .tracker import Tracker
+from tuning.config.tracker_configs import TimingTrackerConfig
+
+
+class TimingCallback(TrainerCallback):
+    """Logs the start time, end time, and runtime of the training to a file."""
+
+    def __init__(self, logs_filename="timing_logs.jsonl"):
+        self.logs_filename = logs_filename
+        self.start_time = None
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        """Record the start time when training begins."""
+        self.start_time = datetime.now()
+
+    def on_train_end(self, args, state, control, **kwargs):
+        """Record the end time and calculate total training time when training ends."""
+        end_time = datetime.now()
+        total_duration = (end_time - self.start_time).total_seconds()
+
+        log_obj = {
+            "name": "training_timing",
+            "data": {
+                "start_time": self.start_time.isoformat(),
+                "end_time": end_time.isoformat(),
+                "total_duration_seconds": total_duration,
+                "train_runtime": state.log_history[-1].get("train_runtime", "N/A"),
+                "timestamp": datetime.now().isoformat(),
+            },
+        }
+
+        # Write the log to a JSONL file
+        log_file_path = os.path.join(args.output_dir, self.logs_filename)
+        with open(log_file_path, "a", encoding="utf-8") as f:
+            f.write(f"{json.dumps(log_obj, sort_keys=True)}\n")
+
+
+class TimingTracker(Tracker):
+    def __init__(self, tracker_config: TimingTrackerConfig):
+        """Tracker to log training start and end times along with train_runtime."""
+        super().__init__(name="timing", tracker_config=tracker_config)
+        self.logger = logging.getLogger()
+
+    def get_hf_callback(self):
+        """Returns the TimingCallback object for this tracker."""
+        file = self.config.timing_logs_filename
+        self.hf_callback = TimingCallback(logs_filename=file)
+        return self.hf_callback

--- a/tuning/trackers/tracker_factory.py
+++ b/tuning/trackers/tracker_factory.py
@@ -21,13 +21,19 @@ from transformers.utils.import_utils import _is_package_available
 
 # Local
 from .filelogging_tracker import FileLoggingTracker
-from tuning.config.tracker_configs import FileLoggingTrackerConfig, TrackerConfigFactory
+from .timing_tracker import TimingTracker
+from tuning.config.tracker_configs import (
+    FileLoggingTrackerConfig,
+    TimingTrackerConfig,
+    TrackerConfigFactory,
+)
 
 # Information about all registered trackers
 AIMSTACK_TRACKER = "aim"
 FILE_LOGGING_TRACKER = "file_logger"
+TIMING_TRACKER = "timing"
 
-AVAILABLE_TRACKERS = [AIMSTACK_TRACKER, FILE_LOGGING_TRACKER]
+AVAILABLE_TRACKERS = [AIMSTACK_TRACKER, FILE_LOGGING_TRACKER, TIMING_TRACKER]
 
 
 # Trackers which can be used
@@ -72,15 +78,24 @@ def _register_file_logging_tracker():
     logging.info("Registered file logging tracker")
 
 
+def _register_timing_tracker():
+    TimeTracker = _get_tracker_class(TimingTracker, TimingTrackerConfig)
+    REGISTERED_TRACKERS[TIMING_TRACKER] = TimeTracker
+    logging.info("Registered timing tracker")
+
+
 # List of Available Trackers
 # file_logger - Logs loss to a file
 # aim - Aimstack Tracker
+# timer - Logs timing to a file
 def _register_trackers():
     logging.info("Registering trackers")
     if AIMSTACK_TRACKER not in REGISTERED_TRACKERS:
         _register_aim_tracker()
     if FILE_LOGGING_TRACKER not in REGISTERED_TRACKERS:
         _register_file_logging_tracker()
+    if TIMING_TRACKER not in REGISTERED_TRACKERS:
+        _register_timing_tracker()
 
 
 def _get_tracker_config_by_name(name: str, tracker_configs: TrackerConfigFactory):

--- a/tuning/trackers/tracker_factory.py
+++ b/tuning/trackers/tracker_factory.py
@@ -31,7 +31,7 @@ from tuning.config.tracker_configs import (
 # Information about all registered trackers
 AIMSTACK_TRACKER = "aim"
 FILE_LOGGING_TRACKER = "file_logger"
-TIMING_TRACKER = "timing"
+TIMING_TRACKER = "timer"
 
 AVAILABLE_TRACKERS = [AIMSTACK_TRACKER, FILE_LOGGING_TRACKER, TIMING_TRACKER]
 

--- a/tuning/trackers/tracker_factory.py
+++ b/tuning/trackers/tracker_factory.py
@@ -125,7 +125,8 @@ def get_tracker(name: str, tracker_configs: TrackerConfigFactory):
         tuning.trackers.tracker.Tracker: A subclass of tuning.trackers.tracker.Tracker
             Valid classes available are,
             tuning.trackers.tracker.aimstack_tracker.AimStackTracker,
-            tuning.trackers.tracker.filelogging_tracker.FileLoggingTracker
+            tuning.trackers.tracker.filelogging_tracker.FileLoggingTracker,
+            tuning.trackers.tracker.timing_tracker.TimingTracker
 
     Examples:
         file_logging_tracker = get_tracker("file_logger", TrackerConfigFactory(
@@ -139,6 +140,11 @@ def get_tracker(name: str, tracker_configs: TrackerConfigFactory):
                                 aim_repo=tempdir + "/"
                             )
                     ))
+        timing_tracker = get_tracker("timer", TrackerConfigFactory(
+                                    timing_config=TimingTrackerConfig(
+                                        timing_logs_filename=logs_file
+                                    )
+                                ))
     """
     if not REGISTERED_TRACKERS:
         # a one time step.


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
This change will add another tracker to `fms-hf-tuning` which will, per process, log the training time. Additionally, if tuning is run using `accelerate_launch.py`, it will log the entire run time from beginning to end (including pre and post processing).

Here is an example log of a run with two processes:
```
{"data": {"end_time": "2024-10-21T19:32:36.657076", "start_time": "2024-10-21T19:31:21.727124", "timestamp": "2024-10-21T19:32:36.657152", "total_duration_seconds": 74.929952, "train_runtime": 73.5228}, "name": "training_timing"}
{"data": {"end_time": "2024-10-21T19:32:36.674714", "start_time": "2024-10-21T19:31:21.724035", "timestamp": "2024-10-21T19:32:36.674749", "total_duration_seconds": 74.950679, "train_runtime": 74.8826}, "name": "training_timing"}
{"data": {"end_time": "2024-10-21T19:33:23.181481", "start_time": "2024-10-21T19:23:54.401312", "total_duration_seconds": 568.780169}, "name": "total_runtime"}
```

Questions:
- Is it helpful to have timer be per process or should there just be one train_runtime?
- Is there a better way to use the tracker for total runtime without passing it in the launch command?

### Related issue number

### How to verify the PR
Run these changes in a dev branch on any model and view the output directory once training is complete.

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass