### PR TITLE
test: get highest checkpoint instead of hard coded path

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -59,12 +59,12 @@ TRAIN_ARGS = configs.TrainingArguments(
     num_train_epochs=5,
     per_device_train_batch_size=4,
     per_device_eval_batch_size=4,
-    gradient_accumulation_steps=4,
+    gradient_accumulation_steps=1,
     learning_rate=0.00001,
     weight_decay=0,
     warmup_ratio=0.03,
     lr_scheduler_type="cosine",
-    logging_steps=1,
+    logging_strategy="epoch",
     include_tokens_per_second=True,
     packing=False,
     max_seq_length=4096,
@@ -242,6 +242,26 @@ def _get_latest_checkpoint_trainer_state(dir_path: str, checkpoint_index: int = 
         last_checkpoint: The path to the checkpoint directory.
     """
     trainer_state = None
+    last_checkpoint = _get_checkpoint(dir_path, checkpoint_index)
+    trainer_state_file = os.path.join(last_checkpoint, "trainer_state.json")
+    with open(trainer_state_file, "r", encoding="utf-8") as f:
+        trainer_state = json.load(f)
+    return trainer_state, last_checkpoint
+
+
+def _get_checkpoint(dir_path: str, checkpoint_index: int = -1):
+    """
+    Get the latest or specified checkpoint directory.
+
+    Args:
+        dir_path (str): The directory path where checkpoint folders are located.
+        checkpoint_index (int, optional): The index of the checkpoint to retrieve,
+                                          based on the checkpoint number. The default
+                                          is -1, which returns the latest checkpoint.
+
+    Returns:
+        last_checkpoint: The path to the checkpoint directory.
+    """
     last_checkpoint = None
     checkpoints = [
         os.path.join(dir_path, d)
@@ -252,10 +272,7 @@ def _get_latest_checkpoint_trainer_state(dir_path: str, checkpoint_index: int = 
         last_checkpoint = sorted(checkpoints, key=lambda x: int(x.split("-")[-1]))[
             checkpoint_index
         ]
-        trainer_state_file = os.path.join(last_checkpoint, "trainer_state.json")
-        with open(trainer_state_file, "r", encoding="utf-8") as f:
-            trainer_state = json.load(f)
-    return trainer_state, last_checkpoint
+    return last_checkpoint
 
 
 def _get_training_logs_by_epoch(dir_path: str, epoch: int = None):
@@ -398,7 +415,7 @@ def test_run_causallm_pt_and_inference():
 
         # validate peft tuning configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
 
         _validate_adapter_config(
@@ -434,7 +451,7 @@ def test_run_causallm_pt_and_inference_with_formatting_data():
 
         # validate peft tuning configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
         _validate_adapter_config(
             adapter_config, "PROMPT_TUNING", MODEL_ARGS.model_name_or_path
@@ -467,7 +484,7 @@ def test_run_causallm_pt_and_inference_JSON_file_formatter():
 
         # validate peft tuning configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
         _validate_adapter_config(
             adapter_config, "PROMPT_TUNING", MODEL_ARGS.model_name_or_path
@@ -499,7 +516,7 @@ def test_run_causallm_pt_init_text():
 
         # validate peft tuning configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
         _validate_adapter_config(
             adapter_config, "PROMPT_TUNING", MODEL_ARGS.model_name_or_path
@@ -621,7 +638,7 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
 
         # validate lora tuning configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
         _validate_adapter_config(adapter_config, "LORA")
 
@@ -663,7 +680,7 @@ def test_successful_lora_target_modules_default_from_main():
         _validate_training(tempdir)
         # Calling LoRA tuning from the main results in 'added_tokens_info.json'
         assert "added_tokens_info.json" in os.listdir(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
         adapter_config = _get_adapter_config(checkpoint_path)
         _validate_adapter_config(adapter_config, "LORA")
 
@@ -692,7 +709,7 @@ def test_run_causallm_ft_and_inference(dataset_path):
         data_args.training_data_path = dataset_path
 
         _test_run_causallm_ft(TRAIN_ARGS, MODEL_ARGS, data_args, tempdir)
-        _test_run_inference(checkpoint_path=_get_checkpoint_path(tempdir))
+        _test_run_inference(checkpoint_path=_get_checkpoint(tempdir))
 
 
 def test_run_causallm_ft_save_with_save_model_dir_save_strategy_no():
@@ -741,7 +758,7 @@ def test_run_causallm_ft_pretokenized(dataset_path):
 
         # validate full ft configs
         _validate_training(tempdir)
-        checkpoint_path = _get_checkpoint_path(tempdir)
+        checkpoint_path = _get_checkpoint(tempdir)
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME)
@@ -795,10 +812,6 @@ def _validate_logfile(log_file_path, check_eval=False):
 
     if check_eval:
         assert "validation_loss" in train_log_contents
-
-
-def _get_checkpoint_path(dir_path):
-    return os.path.join(dir_path, "checkpoint-5")
 
 
 def _get_adapter_config(dir_path):

--- a/tests/trackers/test_aim_tracker.py
+++ b/tests/trackers/test_aim_tracker.py
@@ -30,7 +30,7 @@ from tests.test_sft_trainer import (
     DATA_ARGS,
     MODEL_ARGS,
     TRAIN_ARGS,
-    _get_checkpoint_path,
+    _get_checkpoint,
     _test_run_inference,
     _validate_training,
 )
@@ -99,7 +99,7 @@ def test_e2e_run_with_aim_tracker(aimrepo):
         _validate_training(tempdir)
 
         # validate inference
-        _test_run_inference(checkpoint_path=_get_checkpoint_path(tempdir))
+        _test_run_inference(checkpoint_path=_get_checkpoint(tempdir))
 
 
 @pytest.mark.skipif(aim_not_available, reason="Requires aimstack to be installed")

--- a/tests/trackers/test_file_logging_tracker.py
+++ b/tests/trackers/test_file_logging_tracker.py
@@ -25,7 +25,7 @@ from tests.test_sft_trainer import (
     DATA_ARGS,
     MODEL_ARGS,
     TRAIN_ARGS,
-    _get_checkpoint_path,
+    _get_checkpoint,
     _test_run_causallm_ft,
     _test_run_inference,
     _validate_training,
@@ -45,7 +45,7 @@ def test_run_with_file_logging_tracker():
         train_args.trackers = ["file_logger"]
 
         _test_run_causallm_ft(TRAIN_ARGS, MODEL_ARGS, DATA_ARGS, tempdir)
-        _test_run_inference(_get_checkpoint_path(tempdir))
+        _test_run_inference(checkpoint_path=_get_checkpoint(tempdir))
 
 
 def test_sample_run_with_file_logger_updated_filename():


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

[Unit tests were failing](https://github.com/foundation-model-stack/fms-hf-tuning/actions/runs/11579915780/job/32237578921?pr=382) on transformers v4.46 with errors:
- Resume training tests failing with `assert 9.666666666666666 == (3.6666666666666665 + 5)` where the epochs being logged didn't match
- Other tests failing because the checkpoint path that was being used was hardcoded to `checkpoint-5` but the checkpoints were only saving 3 checkpoints, not matching the number of epochs.

Because of this I updated our trainingArguments parameters to use `gradient_accumulation_steps=1` and `logging_strategy="epoch"` so that the loss logs would print per each full epoch. When setting gradient_accumulation_steps>1 the loss values would be fractions of epochs. I suspect that because the logging was set to partial epochs that the checkpoints being saved may have also been off.

This is more consistent with `save_strategy="epoch"` that we have set and I removed `logging_steps=1` since we are logging based on epochs.

The loss logging and then a print statement I added that for `os.listdir(output_dir)` showed:
```sh
{'loss': 20.4898, 'grad_norm': 23.858930587768555, 'learning_rate': 1e-05, 'epoch': 1.67}
{'loss': 20.9744, 'grad_norm': 23.15357780456543, 'learning_rate': 8.535533905932739e-06, 'epoch': 3.67}
{'train_runtime': 1.649, 'train_samples_per_second': 30.322, 'train_steps_per_second': 3.032, 'train_tokens_per_second': 1825.376, 'train_loss': 25.917576789855957, 'epoch': 3.67}
['checkpoint-1', 'training_logs.jsonl', 'checkpoint-0', 'checkpoint-2']
```
As you can see only 3 checkpoints are saved including one for checkpoint-0, likely because of the partial epochs being logged.

With these changes, the loss logging and `os.listdir(output_dir)` shows:
```sh
{'loss': 10.5682, 'grad_norm': 41.685245513916016, 'learning_rate': 9.504844339512096e-06, 'epoch': 1.0}
{'loss': 10.3005, 'grad_norm': 43.35952377319336, 'learning_rate': 7.169418695587791e-06, 'epoch': 2.0}
{'loss': 9.8799, 'grad_norm': 35.97984313964844, 'learning_rate': 3.887395330218429e-06, 'epoch': 3.0}
{'loss': 9.8383, 'grad_norm': 40.168182373046875, 'learning_rate': 1.0908425876598516e-06, 'epoch': 4.0}
{'loss': 9.8219, 'grad_norm': 35.47007751464844, 'learning_rate': 0.0, 'epoch': 5.0}
{'train_runtime': 3.0789, 'train_samples_per_second': 16.24, 'train_steps_per_second': 4.872, 'train_tokens_per_second': 977.63, 'train_loss': 10.081750996907552, 'epoch': 5.0}
['checkpoint-6', 'training_logs.jsonl', 'checkpoint-9', 'checkpoint-3', 'checkpoint-12', 'checkpoint-15']
```

I'm not sure how the number is determined for `checkpoint-<number>`, but it's better to not hardcode `checkpoint-5` so instead I refactored our existing code to get the highest checkpoint and return it.

I verified that this works with transformers v4.45 and v4.46.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass