### PR TITLE
build(deps): set transformers below 4.46, waiting on fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers=[
 dependencies = [
 "numpy>=1.26.4,<2.0",
 "accelerate>=0.20.3,!=0.34,<1.1",
-"transformers>4.41,<4.50",
+"transformers>4.41,<4.46",
 "torch>=2.2.0,<2.5",
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->
The triton fast_kernels are broken in transformers v4.46 due to the changes and the way the patching is done in fms-acceleration described [here](https://github.com/foundation-model-stack/fms-acceleration/issues/98). In addition, the  gradient_accumulation is deteriorated in v4.46 which is fixed in [transformers PR](https://github.com/huggingface/transformers/pull/34373) which has been merged but not released yet.

In addition, upgrading transformers broke unit tests and is being resolved/discussion in #383.

Thus we will set transformers below v4.46 while we wait for these fixes to go in.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass