### PR TITLE
feat: Added outputs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ venv/
 
 # Auto-generated file
 /tuning/_version.py
+
+# Outputs folder
+/outputs


### PR DESCRIPTION
### Description of the change

After running tuning locally, the results are saved in a folder /outputs. This folder is always listed as a change when I want to make commits. To solve this I have added /outputs to the .gitignore file. If it is intended to be able to commit the /outputs folder for certain reasons, please let me know and I will delete this PR.

### Related issue number

No related issue.

### How to verify the PR

Run tuning locally using: 
python3 tuning/sft_trainer.py \
--model_name_or_path Maykeye/TinyLLama-v0 \
--training_data_path tests/data/twitter_complaints_small.jsonl \
--output_dir outputs/lora-tuning \
--num_train_epochs 5 \
--per_device_train_batch_size 4 \
--gradient_accumulation_steps 4 \
--learning_rate 1e-5 \
--response_template "\n### Label:" \
--dataset_text_field "output" \
--use_flash_attn false \
--torch_dtype "float32" \
--peft_method "lora" \
--r 8 \
--lora_dropout 0.05 \
--lora_alpha 16  \
--log_level "error"

Then, verify that your output folder isn't shown when running git status or when trying to commit using GitHub Desktop.

### Was the PR tested

I ran tuning locally and checked git status, output folder was not listed as something to commit.
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass
I ran tox -e py and had 187 passed, no failed.