### PR TITLE
fix: function name from `requires_agumentation` to `requires_augmentation`

### DIFF
--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -57,7 +57,7 @@ from tuning.utils.import_utils import is_fms_accelerate_available
 # for some reason the CI will raise an import error if we try to import
 # these from tests.artifacts.testdata
 TWITTER_COMPLAINTS_JSON_FORMAT = os.path.join(
-    os.path.dirname(__file__), "../artifacts/testdata/json/twitter_complaints_json.json"
+    os.path.dirname(__file__), "../artifacts/testdata/json/twitter_complaints_small.json"
 )
 TWITTER_COMPLAINTS_TOKENIZED = os.path.join(
     os.path.dirname(__file__),

--- a/tests/acceleration/test_acceleration_framework.py
+++ b/tests/acceleration/test_acceleration_framework.py
@@ -57,7 +57,8 @@ from tuning.utils.import_utils import is_fms_accelerate_available
 # for some reason the CI will raise an import error if we try to import
 # these from tests.artifacts.testdata
 TWITTER_COMPLAINTS_JSON_FORMAT = os.path.join(
-    os.path.dirname(__file__), "../artifacts/testdata/json/twitter_complaints_small.json"
+    os.path.dirname(__file__),
+    "../artifacts/testdata/json/twitter_complaints_small.json",
 )
 TWITTER_COMPLAINTS_TOKENIZED = os.path.join(
     os.path.dirname(__file__),

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -315,7 +315,7 @@ def train(
         time.time() - data_preprocessing_time
     )
 
-    if framework is not None and framework.requires_agumentation:
+    if framework is not None and framework.requires_augmentation:
         model, (peft_config,) = framework.augmentation(
             model, train_args, modifiable_args=(peft_config,)
         )


### PR DESCRIPTION
Nit fix for function in fms-acceleration which needs to be changed in fms-hf-tuning as well.
[PR #118](https://github.com/foundation-model-stack/fms-acceleration/pull/118) in fms-acceleration should be merged at the same time.