### PR TITLE
set unique UNK token

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -292,6 +292,14 @@ def train(
                 tokenizer.pad_token = configs.DEFAULT_PAD_TOKEN
             else:
                 tokenizer.eos_token = configs.DEFAULT_EOS_TOKEN
+        if tokenizer.unk_token == tokenizer.eos_token:
+            logger.warning(
+                "UNK token set to default, to make it different from eos token"
+            )
+            if tokenizer.eos_token != configs.DEFAULT_UNK_TOKEN:
+                tokenizer.unk_token = configs.DEFAULT_UNK_TOKEN
+            else:
+                tokenizer.eos_token = configs.DEFAULT_EOS_TOKEN
 
     # TODO: lower priority but understand if resizing impacts inference quality and why its needed.
     # It makes sense if we manipulate tokenizer that we also save it and provide it to inference.


### PR DESCRIPTION


### Description of the change

Granite models have UNK = EOS , this is resulting in poor quality when tuning for some datasets. When it is set to unique, the quality improves.

### Related issue number

https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1435

### How to verify the PR

Tested with tone dataset 
`
/home/tuning/.local/bin/accelerate launch --num_processes=2 --config_file /app/accelerate_fsdp_defaults.yaml -m tuning.sft_trainer --model_name_or_path $MODEL_PATH --training_data_path $TRAIN_DATA_PATH --torch_dtype bfloat16 --output_dir $OUTPUT_PATH --num_train_epochs 5 --per_device_train_batch_size 4 --gradient_accumulation_steps 4 --learning_rate 1e-5 --response_template "\n### Response:" --dataset_text_field "output"`

export MODEL_PATH="ibm-granite/granite-3.0-8b-base"
export TRAIN_DATA_PATH="/testing/tuning/input/cc_tone_sft_format_1000_train.json"

at inference we get repeated output without the change , and proper output after change

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass