### PR TITLE
fix: Add pad_token to special_tokens_dict when pad_token == eos_token

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -290,8 +290,10 @@ def train(
             )
             if tokenizer.eos_token != configs.DEFAULT_PAD_TOKEN:
                 tokenizer.pad_token = configs.DEFAULT_PAD_TOKEN
+                special_tokens_dict["pad_token"] = configs.DEFAULT_PAD_TOKEN
             else:
                 tokenizer.eos_token = configs.DEFAULT_EOS_TOKEN
+                special_tokens_dict["eos_token"] = configs.DEFAULT_EOS_TOKEN
 
     # TODO: lower priority but understand if resizing impacts inference quality and why its needed.
     # It makes sense if we manipulate tokenizer that we also save it and provide it to inference.


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Add `pad_token` to special_tokens_dict when `pad_token == eos_token`

### Related issue number

Issue:https://github.com/foundation-model-stack/fms-hf-tuning/pull/343
Issue 343 modifies pad_token of tokenizer but in this PR adds it to `special_tokens_dict` for model resizing. 

Reason of this case of `pad_token == eos_token`: 
When tokenizer has PAD token equal to EOS token, then the DataCollatorForCompletionOnlyLM masks the EOS token from labels of dataset batch and hence its not used in loss calculation and hence it leads to repetitive `predicted_target` during inference time.

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass