### PR TITLE
docs: add note to note that file extension is required in training data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ARROW       |   ✅
 
 As iterated above, we also support passing a HF dataset ID directly via `--training_data_path` argument.
 
-Because of the variety of data formats and file types supported, if `--training_data_path` is a file, it requires a file extension in the path name. If `--training_data_path` does not have a file extension, the data preprocessor will check if it is a valid folder. If `--training_data_path` is not a folder and does not have a file extension, it is considered an HF dataset ID.
+**NOTE**: Due to the variety of supported data formats and file types, when --training_data_path points to a file, it must include a file extension (e.g., .json, .csv). If the path does not include a file extension, it will be treated either as a folder or as an HF dataset ID.
 
 ## Use cases supported with `training_data_path` argument
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ ARROW       |   ✅
 
 As iterated above, we also support passing a HF dataset ID directly via `--training_data_path` argument.
 
-**NOTE**: Due to the variety of supported data formats and file types, when --training_data_path points to a file, it must include a file extension (e.g., .json, .csv). If the path does not include a file extension, it will be treated either as a folder or as an HF dataset ID.
+**NOTE**: Due to the variety of supported data formats and file types, `--training_data_path` is handled as follows:
+- If `--training_data_path` ends in a valid file extension (e.g., .json, .csv), it is treated as a file.
+- If `--training_data_path` points to a valid folder, it is treated as a folder.
+- If neither of these are true, the data preprocessor tries to load `--training_data_path` as a Hugging Face (HF) dataset ID.
 
 ## Use cases supported with `training_data_path` argument
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ ARROW       |   ✅
 
 As iterated above, we also support passing a HF dataset ID directly via `--training_data_path` argument.
 
+Because of the variety of data formats and file types supported, if `--training_data_path` is a file, it requires a file extension in the path name. If the input file does not have a file extension, the data preprocessor will check if it is a valid folder. If it is not a folder and does not have a file extension, it is considered an HF dataset ID.
+
 ## Use cases supported with `training_data_path` argument
 
 ### 1. Data formats with a single sequence and a specified response_template to use for masking on completion.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ARROW       |   ✅
 
 As iterated above, we also support passing a HF dataset ID directly via `--training_data_path` argument.
 
-Because of the variety of data formats and file types supported, if `--training_data_path` is a file, it requires a file extension in the path name. If the input file does not have a file extension, the data preprocessor will check if it is a valid folder. If it is not a folder and does not have a file extension, it is considered an HF dataset ID.
+Because of the variety of data formats and file types supported, if `--training_data_path` is a file, it requires a file extension in the path name. If `--training_data_path` does not have a file extension, the data preprocessor will check if it is a valid folder. If `--training_data_path` is not a folder and does not have a file extension, it is considered an HF dataset ID.
 
 ## Use cases supported with `training_data_path` argument
 


### PR DESCRIPTION
### Description of the change
With changes to data preprocessor, file extension is now required for data files because of the variety of datasets we support (as opposed to just supporting JSON, which made it so file extension wasn't required because it could be assumed).