### PR TITLE
fix: bug in aim tracker where the server based tracking was not picked

### DIFF
--- a/tuning/trackers/aimstack_tracker.py
+++ b/tuning/trackers/aimstack_tracker.py
@@ -121,7 +121,7 @@ class AimStackTracker(Tracker):
 
         if url is not None:
             aim_callback = RunIDExporterAimCallback(repo=url, experiment=exp)
-        if repo:
+        elif repo:
             aim_callback = RunIDExporterAimCallback(repo=repo, experiment=exp)
         else:
             self.logger.error(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Fix bug in conditional check where aimstack server tracking was not picked up correctly.

Tested by running a KFTO job with aimstack tracker server url and port.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass