### PR TITLE
fix: space missing from data_formatter_template causing mismatch with response_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Example: Train.json
   },
  ...
 ]`  
-data_formatter_template: `### Input: {{input}} \n\n##Label: {{output}}`  
+data_formatter_template: `### Input: {{input}} \n\n## Label: {{output}}`  
 
 Formatting will happen on the fly while tuning. The keys in template should match fields in the dataset file. The `response template` corresponding to the above template will need to be supplied. in this case, `response template` = `\n## Label:`.
 
@@ -299,7 +299,7 @@ python tuning/sft_trainer.py  \
 --gradient_accumulation_steps 4  \
 --learning_rate 1e-5  \
 --response_template "\n## Label:"  \
---data_formatter_template: "### Input: {{input}} \n\n##Label: {{output}}"
+--data_formatter_template: "### Input: {{input}} \n\n## Label: {{output}}"
 
 ```
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass