### PR TITLE
fix: Using Sandboxed Environment in handler rendering Jinja template

### DIFF
--- a/tests/data/test_data_handlers.py
+++ b/tests/data/test_data_handlers.py
@@ -103,15 +103,23 @@ def test_apply_custom_formatting_template_gives_error_with_wrong_keys():
         )
 
 
-def test_apply_custom_formatting_jinja_template_gives_error_with_wrong_keys():
+@pytest.mark.parametrize(
+    "template",
+    [
+        "### Input: {{ not found }} \n\n ### Response: {{ text_label }}",
+        "### Input: }} Tweet text {{ \n\n ### Response: {{ text_label }}",
+        "### Input: {{ Tweet text }} \n\n ### Response: {{ ''.__class__ }}",
+        "### Input: {{ Tweet text }} \n\n ### Response: {{ undefined_variable.split() }}",
+    ],
+)
+def test_apply_custom_formatting_jinja_template_gives_error_with_wrong_keys(template):
     """Tests that the jinja formatting function will throw error if wrong keys are passed to template"""
     json_dataset = datasets.load_dataset(
         "json", data_files=TWITTER_COMPLAINTS_DATA_JSONL
     )
-    template = "### Input: {{not found}} \n\n ### Response: {{text_label}}"
     formatted_dataset_field = "formatted_data_field"
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
-    with pytest.raises(KeyError):
+    with pytest.raises((KeyError, ValueError)):
         json_dataset.map(
             apply_custom_data_formatting_jinja_template,
             fn_kwargs={


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Modification as a part of this PR: https://github.com/foundation-model-stack/fms-hf-tuning/pull/438
Includes usage of `Sandboxed Environment` instead of normal `Environment` in rendering Jinja template which is more safer to use as it evaluates untrusted templates and restricts access to unsafe attributes/methods inside the template. 

### Related issue number

Issue: https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1470

### How to verify the PR

Check relevant test case.

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass