### PR TITLE
feat: Add support for renaming and retaining columns in data preprocessor

### DIFF
--- a/docs/advanced-data-preprocessing.md
+++ b/docs/advanced-data-preprocessing.md
@@ -60,6 +60,10 @@ definitions:
         type: float
       builder:
         type: string
+      rename_columns:
+        type: object
+      retain_columns:
+        type: object
       data_paths:
         type: array
         items:
@@ -118,6 +122,8 @@ Users can create a data config file in any of YAML or JSON format they choose (w
   - `name` (optional, str): A unique identifier for the dataset.
     - `data_paths` (optional, list): A `list` of file paths or directories containing the dataset.
     - `builder` (optional, str): Specifies a [Hugging Face dataset builder](https://huggingface.co/docs/datasets/v3.2.0/en/package_reference/loading_methods#datasets.load_dataset.path), if applicable.
+    - `rename_columns` (optional, dict[str:str]): Specifies a dictionary of columns to rename like `{"old_name": "new_name"}` at dataset load time. *Applied before `retain_columns` if both are specified*.
+    - `retain_columns` (optional, list[str]): Specifies a list of columns to retain `["input_ids", "labels"]` every other column will be dropped at dataset load time. *Applied strictly after `rename_columns` if both are specified*.
     - `sampling` (optional, float): The sampling ratio (0.0 to 1.0) with which to sample a dataset in case of interleaving.
     - `data_handlers` (optional, list): A list of data handler configurations which preprocess the dataset.
 
@@ -149,6 +155,8 @@ Not Supported:
 Currently there's no support for sampling under multiple data paths which are defined inside a dataset definition.
 All dataset paths that will be specified inside one dataset will be [concatenated](https://huggingface.co/docs/datasets/v3.2.0/en/process#concatenate) after loading them, while across datasets users can specify [mixing via sampling datasets](#data-mixing)
 
+Additionally while loading, users can specify which columns to rename via `rename_columns` and which to retain via `retain_columns` arguments above.
+The order of application of these operations is *strictly rename followed by retain* so users should note that a column name which is renamed will not be available in retain and should be careful while applying these operations.
 
 ### How can users specify data handlers.
 

--- a/docs/advanced-data-preprocessing.md
+++ b/docs/advanced-data-preprocessing.md
@@ -155,8 +155,10 @@ Not Supported:
 Currently there's no support for sampling under multiple data paths which are defined inside a dataset definition.
 All dataset paths that will be specified inside one dataset will be [concatenated](https://huggingface.co/docs/datasets/v3.2.0/en/process#concatenate) after loading them, while across datasets users can specify [mixing via sampling datasets](#data-mixing)
 
-Additionally while loading, users can specify which columns to rename via `rename_columns` and which to retain via `retain_columns` arguments above.
-The order of application of these operations is *strictly rename followed by retain* so users should note that a column name which is renamed will not be available in retain and should be careful while applying these operations.
+Probably something like this:
+
+Additionally while loading the dataset, users can specify which columns to rename via `rename_columns` and which to retain via `retain_columns` arguments above.
+The order of application of these operations is *strictly rename followed by retain* so users should note that an old column name which is renamed will not be available in retain and hence should be careful while applying these operations. The code will throw a `ValueError` in case user specified a column requested to be renamed via rename argument in retain argument as well. 
 
 ### How can users specify data handlers.
 

--- a/docs/ept.md
+++ b/docs/ept.md
@@ -32,7 +32,7 @@ datasets:
     data_paths:
       - "<path-to-the-jsonl-dataset>"
         data_handlers:
-        - name: apply_custom_data_formatting
+        - name: add_tokenizer_eos_token
             arguments:
             remove_columns: all
             batched: false
@@ -109,4 +109,4 @@ The code again would add `EOS_TOKEN` to the non tokenized data before using it a
 
 ### Additional Information
 This feature is supported post [v2.3.1](https://github.com/foundation-model-stack/fms-hf-tuning/releases/tag/v2.3.1) of this library.
-Post Last Updated On: 10-02-2025
+Post Last Updated On: 12-02-2025

--- a/tests/artifacts/predefined_data_configs/__init__.py
+++ b/tests/artifacts/predefined_data_configs/__init__.py
@@ -37,3 +37,6 @@ DATA_CONFIG_MULTIPLE_DATASETS_SAMPLING_YAML = os.path.join(
 DATA_CONFIG_DUPLICATE_COLUMNS = os.path.join(
     PREDEFINED_DATA_CONFIGS, "duplicate_columns.yaml"
 )
+DATA_CONFIG_RENAME_RETAIN_COLUMNS = os.path.join(
+    PREDEFINED_DATA_CONFIGS, "rename_retain_columns.yaml"
+)

--- a/tests/artifacts/predefined_data_configs/rename_retain_columns.yaml
+++ b/tests/artifacts/predefined_data_configs/rename_retain_columns.yaml
@@ -1,0 +1,20 @@
+dataprocessor:
+    type: default
+datasets:
+  - name: text_dataset_input_output_masking
+    rename_columns:
+      "input"  : "instruction"
+      "output" : "response"
+    retain_columns:
+      - "instruction"
+      - "response"
+    data_paths:
+      - "FILE_PATH"
+    data_handlers:
+      - name: tokenize_and_apply_input_masking
+        arguments:
+          remove_columns: all
+          batched: false
+          fn_kwargs:
+            input_field_name: instruction
+            output_field_name: response

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -38,6 +38,7 @@ from scripts.run_inference import TunedCausalLM
 from tests.artifacts.predefined_data_configs import (
     DATA_CONFIG_DUPLICATE_COLUMNS,
     DATA_CONFIG_MULTIPLE_DATASETS_SAMPLING_YAML,
+    DATA_CONFIG_RENAME_RETAIN_COLUMNS,
     DATA_CONFIG_TOKENIZE_AND_APPLY_INPUT_MASKING_YAML,
 )
 from tests.artifacts.testdata import (
@@ -836,6 +837,10 @@ def test_run_causallm_ft_pretokenized(dataset_path):
                 TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_PARQUET,
             ],
             DATA_CONFIG_MULTIPLE_DATASETS_SAMPLING_YAML,
+        ),
+        (
+            [TWITTER_COMPLAINTS_DATA_INPUT_OUTPUT_JSON],
+            DATA_CONFIG_RENAME_RETAIN_COLUMNS,
         ),
     ],
 )

--- a/tuning/data/data_config.py
+++ b/tuning/data/data_config.py
@@ -36,6 +36,8 @@ class DataSetConfig:
     data_paths: List[str]
     builder: Optional[str] = None  # Referring to Hugging Face dataset builder
     sampling: Optional[float] = None
+    rename_columns: Optional[Dict] = None
+    retain_columns: Optional[List] = None
     data_handlers: Optional[List[DataHandlerConfig]] = None
 
 
@@ -100,6 +102,18 @@ def _validate_dataset_config(dataset_config) -> DataSetConfig:
             0 <= ratio <= 1.0
         ), f"sampling ratio: {ratio} should be float and in range [0.0,1.0]"
         c.sampling = ratio
+    if "rename_columns" in kwargs and kwargs["rename_columns"] is not None:
+        rename = kwargs["rename_columns"]
+        assert isinstance(
+            rename, dict
+        ), "rename_columns should be a dict with current_name:new_name"
+        c.rename_columns = rename
+    if "retain_columns" in kwargs and kwargs["retain_columns"] is not None:
+        retain = kwargs["retain_columns"]
+        assert isinstance(
+            retain, list
+        ), "retain_columns should be a list[str] with names of columns to retain"
+        c.retain_columns = retain
     if "data_handlers" in kwargs:
         c.data_handlers = []
         for handler in kwargs["data_handlers"]:

--- a/tuning/data/data_processors.py
+++ b/tuning/data/data_processors.py
@@ -243,6 +243,24 @@ class DataPreProcessor:
 
             logger.info("Loaded raw dataset : %s", str(raw_dataset))
 
+            # Check if both are conflicting options before proceeding.
+            if d.rename_columns and d.retain_columns:
+                commmon = set(d.rename_columns.keys()) & set(d.retain_columns)
+                if commmon:
+                    raise ValueError(
+                        f"You are trying to retain {str(commmon)} columns"
+                        " which will be renamed via rename operation."
+                    )
+
+            if d.rename_columns:
+                logger.info("Renaming %s columns", str(d.rename_columns))
+                raw_dataset = raw_dataset.rename_columns(column_mapping=d.rename_columns)
+                logger.info("Done")
+            if d.retain_columns:
+                logger.info("Retaining %s columns", str(d.retain_columns))
+                raw_dataset = raw_dataset.select_columns(column_names=d.retain_columns)
+                logger.info("Done")
+
             raw_datasets = DatasetDict()
 
             # Assume all is train split

--- a/tuning/data/data_processors.py
+++ b/tuning/data/data_processors.py
@@ -254,7 +254,9 @@ class DataPreProcessor:
 
             if d.rename_columns:
                 logger.info("Renaming %s columns", str(d.rename_columns))
-                raw_dataset = raw_dataset.rename_columns(column_mapping=d.rename_columns)
+                raw_dataset = raw_dataset.rename_columns(
+                    column_mapping=d.rename_columns
+                )
                 logger.info("Done")
             if d.retain_columns:
                 logger.info("Retaining %s columns", str(d.retain_columns))


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Add two flags to the `data_config` under `dataset` definition. 
1. `rename_columns` which allows users to rename columns by passing a dict
2. `retain_columns` which allows users to specify which columns to retain and drop others.

This is different and outside the `remove_columns` argument to `data handlers` because people might want to use this functionality even without invoking data handlers.

This is especially needed in the case of interleaving multiple datasets with different features.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass