### PR TITLE
feat: Support for add special tokens via cli args

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -981,7 +981,7 @@ def test_run_chat_style_ft(dataset_path):
 
 
 def test_run_chat_style_add_special_tokens_ft():
-    """Check if we can perform an e2e run with chat template and multi turn chat training."""
+    """Test to check an e2e multi turn chat training by adding special tokens via command line."""
     with tempfile.TemporaryDirectory() as tempdir:
 
         # sample hugging face dataset id

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -122,6 +122,14 @@ class DataArguments:
             Passed in conjunction with response_template"
         },
     )
+    add_special_tokens: List[str] = field(
+        default=None,
+        metadata={
+            "help": "List of special tokens to be added to the tokenizer's vocabulary. \
+            Used to add Special Tokens to Tokenizer's Vocabulary,\
+            Add special tokens as new tokens and increase vocabulary and model embedding size."
+        },
+    )
 
 
 @dataclass

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -297,6 +297,13 @@ def train(
                 tokenizer.eos_token = configs.DEFAULT_EOS_TOKEN
                 special_tokens_dict["eos_token"] = configs.DEFAULT_EOS_TOKEN
 
+    # adds user specified special tokens to vocab
+    if data_args.add_special_tokens:
+        logger.info(
+            "Adding user-defined special tokens: %s ", data_args.add_special_tokens
+        )
+        special_tokens_dict["additional_special_tokens"] = data_args.add_special_tokens
+
     # TODO: lower priority but understand if resizing impacts inference quality and why its needed.
     # It makes sense if we manipulate tokenizer that we also save it and provide it to inference.
     added_tokens_dict = tokenizer_and_embedding_resize(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Adds support for add_special_tokens to tokenizer's vocabulary via cli args
List of Special Tokens can be passed as follows:
<img width="523" alt="image" src="https://github.com/user-attachments/assets/459d2970-02f3-4921-a723-e948343791e2" />

<!-- Please summarize the changes -->

### Related issue number
Partially Solves #470 , Support for Reserved Special Tokens is not supported yet
<!-- For example: "Closes #1234" -->

### How to verify the PR
Run a small sample training job with `--add_special_tokens` flag 

```
python tuning/sft_trainer.py    --include_tokens_per_second="true" \
    --learning_rate="1e-05" \
    --logging_steps="1" \
    --logging_strategy="steps" \
    --max_steps="100" \
    --model_name_or_path="/your/model" \
    --output_dir="/output/directory" \
    --per_device_train_batch_size="1" \
    --save_steps="50" \
    --save_strategy="steps" \
    --add_special_tokens "<|assistant|>" "<|user|>" \
    --use_flash_attn=false \
    --training_data_path="/dataset"
```
once the training is completed load the trained model and check if the special token is tokenized properly as a single token/ or if it is part of the tokenizer's vocabulary


### Was the PR tested
Debugging was done to ensure the updated tokens are reflected in the Tokenizer Vocab.
![image](https://github.com/user-attachments/assets/ddfa96b6-e340-4f50-96d9-04f7729c1e20)

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass