### PR TITLE
feat: add support for chat template from data config

### DIFF
--- a/docs/advanced-data-preprocessing.md
+++ b/docs/advanced-data-preprocessing.md
@@ -47,6 +47,8 @@ definitions:
         type: string
       seed:
         type: integer
+      chat_template:
+        type: string
     required:
       - type
     title: Dataprocessor
@@ -118,6 +120,7 @@ Users can create a data config file in any of YAML or JSON format they choose (w
  - `streaming` (optional, bool): Stream datasets using [IterableDatasets](https://huggingface.co/docs/datasets/v3.2.0/en/package_reference/main_classes#datasets.IterableDataset).
  - `sampling_stopping_strategy` (optional, str): Dataset interleave stopping strategy in case of choosing to mix multiple datasets by weight, supported values are [`all_exhausted` or `first_exhausted`](https://huggingface.co/docs/datasets/v3.2.0/en/package_reference/main_classes#datasets.interleave_datasets.stopping_strategy), defaults to `all_exhausted`.
  - `sampling_seed` (optional, int): [Sampling seed](https://huggingface.co/docs/datasets/v3.2.0/en/package_reference/main_classes#datasets.interleave_datasets.seed) to use for interleaving datasets, for reproducibility choose same value, defaults to 42.
+ - `chat_template` (optional, str): pass `chat_template` via data_config for multi-turn data, replaces existing default chat template.
 
 `datasets` (list):
   - `name` (optional, str): A unique identifier for the dataset.

--- a/tests/artifacts/predefined_data_configs/__init__.py
+++ b/tests/artifacts/predefined_data_configs/__init__.py
@@ -34,6 +34,9 @@ DATA_CONFIG_TOKENIZE_AND_APPLY_INPUT_MASKING_YAML = os.path.join(
 DATA_CONFIG_MULTIPLE_DATASETS_SAMPLING_YAML = os.path.join(
     PREDEFINED_DATA_CONFIGS, "multiple_datasets_with_sampling.yaml"
 )
+DATA_CONFIG_MULTITURN_DATA_YAML = os.path.join(
+    PREDEFINED_DATA_CONFIGS, "multi_turn_data_with_chat_template.yaml"
+)
 DATA_CONFIG_YAML_STREAMING_INPUT_OUTPUT = os.path.join(
     PREDEFINED_DATA_CONFIGS, "tokenize_and_apply_input_masking_streaming.yaml"
 )

--- a/tests/artifacts/predefined_data_configs/multi_turn_data_with_chat_template.yaml
+++ b/tests/artifacts/predefined_data_configs/multi_turn_data_with_chat_template.yaml
@@ -1,0 +1,20 @@
+dataprocessor:
+    type: default
+    chat_template: |
+      {% for message in messages['messages'] %}
+        {% if message['role'] == 'user' %}{{ '<|user|>\n' + message['content'] + eos_token }}
+        {% elif message['role'] == 'system' %}{{ '<|system|>\n' + message['content'] + eos_token }}
+        {% elif message['role'] == 'assistant' %}{{ '<|assistant|>\n'  + message['content'] + eos_token }}
+        {% endif %}
+        {% if loop.last and add_generation_prompt %}{{ '<|assistant|>' }}
+        {% endif %}
+      {% endfor %}
+datasets:
+  - name: dataset_1
+    data_paths:
+      - "FILE_PATH"
+    data_handlers:
+      - name: apply_tokenizer_chat_template
+        arguments:
+          fn_kwargs:
+            dataset_text_field: formatted_chat_data

--- a/tuning/data/data_config.py
+++ b/tuning/data/data_config.py
@@ -48,6 +48,7 @@ class DataPreProcessorConfig:
     # Default seed is not none to ensure reproducability
     sampling_seed: Optional[float] = 42
     streaming: Optional[bool] = False
+    chat_template: Optional[str] = None
 
 
 @dataclass
@@ -147,6 +148,10 @@ def _validate_dataprocessor_config(dataprocessor_config) -> DataPreProcessorConf
         streaming = kwargs["streaming"]
         assert isinstance(streaming, bool), f"streaming: {streaming} should be a bool"
         c.streaming = streaming
+    if "chat_template" in kwargs:
+        chat_template = kwargs["chat_template"]
+        assert isinstance(chat_template, str), "chat_template should be a string"
+        c.chat_template = chat_template
     return c
 
 

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -75,6 +75,16 @@ def _process_dataconfig_file(
         tokenizer=tokenizer,
         additional_data_handlers=additional_data_handlers,
     )
+
+    if processor.processor_config.chat_template is not None:
+        if tokenizer.chat_template:
+            logger.warning(
+                "replacing existing chat_template %s with data config's chat_template %s",
+                tokenizer.chat_template,
+                processor.processor_config.chat_template,
+            )
+        tokenizer.chat_template = processor.processor_config.chat_template
+
     if processor.processor_config.streaming:
         if train_args.max_steps < 1:
             logging.error(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -250,6 +250,10 @@ def train(
     )
 
     if data_args.chat_template:
+        # TODO: passing "/n" through cli causes parsing issues,
+        # hence providing a temporary fix
+        data_args.chat_template = data_args.chat_template.replace(r"\n", "\n")
+
         logger.info("adding chat_template to the tokenizer")
         if tokenizer.chat_template:
             logger.warning(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Adds support for `chat_template`/`chat_template_b64` from data config.
adds fix for "/n" parsing issue for passing chat_template via cli args

Updates test case for chat_template through data config
<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass