### PR TITLE
fix: (data pre-process) un-escape templates and strings passed on cli correctly

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -131,6 +131,17 @@ class DataArguments:
         },
     )
 
+    def __post_init__(self):
+        def unescape(s):
+            if s is not None and isinstance(s, str):
+                return s.encode("utf-8").decode("unicode_escape")
+            return s
+
+        self.chat_template = unescape(self.chat_template)
+        self.data_formatter_template = unescape(self.data_formatter_template)
+        self.response_template = unescape(self.response_template)
+        self.instruction_template = unescape(self.instruction_template)
+
 
 @dataclass
 class TrainingArguments(transformers.TrainingArguments):


### PR DESCRIPTION
Fix for #492

<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

### Related issue number

#492 

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass