### PR TITLE
fix:Avoid passing dataset_text_field in data arguments when already passed in data_config yaml

### DIFF
--- a/tests/data/test_data_preprocessing.py
+++ b/tests/data/test_data_preprocessing.py
@@ -757,7 +757,9 @@ def test_process_dataconfig_file_with_streaming(data_config_path, data_path):
     ) as temp_yaml_file:
         yaml.dump(yaml_content, temp_yaml_file)
         temp_yaml_file_path = temp_yaml_file.name
-        data_args = configs.DataArguments(data_config_path=temp_yaml_file_path)
+        data_args = configs.DataArguments(
+            data_config_path=temp_yaml_file_path, dataset_text_field=None
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 
@@ -816,7 +818,9 @@ def test_process_dataconfig_file_with_streaming_no_max_steps_errors(
     ) as temp_yaml_file:
         yaml.dump(yaml_content, temp_yaml_file)
         temp_yaml_file_path = temp_yaml_file.name
-        data_args = configs.DataArguments(data_config_path=temp_yaml_file_path)
+        data_args = configs.DataArguments(
+            data_config_path=temp_yaml_file_path, dataset_text_field=None
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 
@@ -892,7 +896,9 @@ def test_process_dataconfig_file(data_config_path, data_path):
     ) as temp_yaml_file:
         yaml.dump(yaml_content, temp_yaml_file)
         temp_yaml_file_path = temp_yaml_file.name
-        data_args = configs.DataArguments(data_config_path=temp_yaml_file_path)
+        data_args = configs.DataArguments(
+            data_config_path=temp_yaml_file_path, dataset_text_field=None
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 
@@ -982,7 +988,9 @@ def test_process_datahandler_eos_token(data_config_path, data_path, add_eos_toke
     ) as temp_yaml_file:
         yaml.dump(yaml_content, temp_yaml_file)
         temp_yaml_file_path = temp_yaml_file.name
-        data_args = configs.DataArguments(data_config_path=temp_yaml_file_path)
+        data_args = configs.DataArguments(
+            data_config_path=temp_yaml_file_path, dataset_text_field=None
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
     tokenizer.add_special_tokens({"eos_token": "</s>"})
@@ -1128,7 +1136,9 @@ def test_process_dataconfig_multiple_files(data_config_path, data_path_list):
     ) as temp_yaml_file:
         yaml.dump(yaml_content, temp_yaml_file)
         temp_yaml_file_path = temp_yaml_file.name
-        data_args = configs.DataArguments(data_config_path=temp_yaml_file_path)
+        data_args = configs.DataArguments(
+            data_config_path=temp_yaml_file_path, dataset_text_field=None
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
 

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -33,6 +33,7 @@ from tuning.data.data_config import (
 from tuning.data.data_handlers import DataHandler
 from tuning.data.data_preprocessing_utils import get_data_collator
 from tuning.data.data_processors import get_datapreprocessor
+from tuning.utils.utils import get_dataset_text_field_config
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,13 @@ def _process_dataconfig_file(
             )
     train_dataset = processor.process_dataset_configs(data_config.datasets)
 
-    return (train_dataset, None, data_args.dataset_text_field)
+    dataset_text_field = data_args.dataset_text_field
+    if dataset_text_field is None:
+        try:
+            dataset_text_field = get_dataset_text_field_config(data_config)
+        except KeyError:
+            logger.warning("dataset_text_field not found in data_config arguments")
+    return (train_dataset, None, dataset_text_field)
 
 
 # Data Format 1: Pretokenized Data


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Currently when we use `data_config` YAML file to apply `Data Handlers` which needs `fn_kwargs` as `dataset_text_field`, we also needed to pass the same `dataset_text_field` via command line arguments. 

Now with the change in this PR, if `dataset_text_field` passed via arguments is None, then it picks up the `dataset_text_field` passed in `data_config` YAML.

Other checks: If user passes multiple datasets in `data_config` YAML and each datasets have different `dataset_text_field` then it will give warning and pick up `dataset_text_field` of the first dataset.

Related Slack Discussion: https://ibm-research.slack.com/archives/C0698T0FW3S/p1740598883877809

### Related issue number

Issue: https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1657

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass