### PR TITLE
fix: Use main process first instead of local_main_process_first

### DIFF
--- a/tuning/data/data_processors.py
+++ b/tuning/data/data_processors.py
@@ -434,9 +434,10 @@ class DataPreProcessor:
         # https://github.com/huggingface/trl/blob/e3244d/trl/trainer/sft_trainer.py#L367
         state = PartialState()
 
-        # The local_main_process_first context ensures that the main process runs first per node
+        # The main_process_first context ensures that the main process runs first
         # as we want to reuse HF cache and not redo computation on all nodes
-        with state.local_main_process_first():
+        # For rationale see https://github.com/huggingface/trl/pull/3106
+        with state.main_process_first():
             train_dataset = self._process_dataset_configs(dataset_configs, **kwargs)
 
         return train_dataset


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

TRL made a [change in the code](https://github.com/huggingface/trl/pull/3106) where they shifted to using `main_process_first` instead of `local_main_process_first` as the later can cause race conditions among nodes and lead to cache `FileNotFoundErrors` these were also reported internally by few users [here](https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1666). 

Might be worthwile to be conservative for now and follow the same pattern.

<!-- Please summarize the changes -->

### Related issue number

Closes  [#1666](https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1666)

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass