### PR TITLE
build(deps): install mamba_ssm from package instead of github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ aim = ["aim>=3.19.0,<4.0"]
 mlflow = ["mlflow"]
 fms-accel = ["fms-acceleration>=0.6"]
 gptq-dev = ["auto_gptq>0.4.2", "optimum>=1.15.0"]
-mamba = ["mamba_ssm[causal-conv1d] @ git+https://github.com/state-spaces/mamba.git"]
+mamba = ["mamba_ssm[causal-conv1d]>=2.0.0,<3.0.0"]
 scanner-dev = ["HFResourceScanner>=0.1.0"]
 
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Installing mamba_ssm from github blocks PyPi release due to error
```
[33mWARNING [0m Error during upload. Retry with the --verbose option for more details. 
2025-03-20T15:47:26.0222991Z [31mERROR   [0m HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
          Can't have direct dependency: mamba_ssm[causal-conv1d]@                
          git+https://github.com/state-spaces/mamba.git ; extra == "mamba". See  
          https://packaging.python.org/specifications/core-metadata for more     
          information.      
```

Thus we are installing from package instead of github.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass