### PR TITLE
feat: Add ALoRA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ Activated LoRA (aLoRA) is a new low rank adapter architecture that allows for re
 
 [Github](https://github.com/IBM/activated-lora)
 
-*Usage* Usage is very similar to standard LoRA, with the key difference that an invocation_string must be specified so that the model knows when to turn on i.e "activate" the adapter weights. The model will scan any input strings (during training or at test time) for this invocation_string, and activate the adapter weights 1 token after the start of the sequence. If there are multiple instances of the invocation_string in the same input, it will activate at the last such instance.
+**Usage** Usage is very similar to standard LoRA, with the key difference that an invocation_string must be specified so that the model knows when to turn on i.e "activate" the adapter weights. The model will scan any input strings (during training or at test time) for this invocation_string, and activate the adapter weights 1 token after the start of the sequence. If there are multiple instances of the invocation_string in the same input, it will activate at the last such instance.
 
 **Note** Often (not always) aLoRA requires higher rank (r) than LoRA. r=32 can be a good starting point for challenging tasks.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   - [Tips on Parameters to Set](#tips-on-parameters-to-set)
 - [Tuning Techniques](#tuning-techniques)
   - [LoRA Tuning Example](#lora-tuning-example)
-  - [Activated LoRA Tuning Example](#alora-tuning-example)
+  - [Activated LoRA Tuning Example](#activated-lora-tuning-example)
   - [GPTQ-LoRA with AutoGPTQ Tuning Example](#gptq-lora-with-autogptq-tuning-example)
   - [Fine Tuning](#fine-tuning)
   - [FMS Acceleration](#fms-acceleration)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [Tips on Parameters to Set](#tips-on-parameters-to-set)
 - [Tuning Techniques](#tuning-techniques)
   - [LoRA Tuning Example](#lora-tuning-example)
+  - [Activated LoRA Tuning Example](#alora-tuning-example)
   - [GPTQ-LoRA with AutoGPTQ Tuning Example](#gptq-lora-with-autogptq-tuning-example)
   - [Fine Tuning](#fine-tuning)
   - [FMS Acceleration](#fms-acceleration)

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ To summarize you can pick either python for single-GPU jobs or use accelerate la
 
 ### Tips on Parameters to Set
 
-#### Saving checkpoints while training
+#### Saving checkpoints while training (does not apply to Activated LoRA)
 
 By default, [`save_strategy`](tuning/config/configs.py) is set to `"epoch"` in the TrainingArguments. This means that checkpoints will be saved on each epoch. This can also be set to `"steps"` to save on every `"save_steps"` or `"no"` to not save any checkpoints.
 
@@ -689,6 +689,167 @@ post_process_vLLM_adapters_new_tokens(
 </details>
 
 _________________________
+
+### Activated LoRA Tuning Example
+
+
+Activated LoRA (aLoRA) is a new low rank adapter architecture that allows for reusing existing base model KV cache for more efficient inference. This approach is best suited for inference pipelines which rely on the base model for most tasks/generations, but use aLoRA adapter(s) to perform specialized task(s) within the chain. For example, checking or rewriting generated outputs of the base model.
+
+[Paper](https://arxiv.org/abs/2504.12397)
+
+[IBM Research Blogpost](https://research.ibm.com/blog/inference-friendly-aloras)
+
+[Github](https://github.com/IBM/activated-lora)
+
+*Usage* Usage is very similar to standard LoRA, with the key difference that an invocation_string must be specified so that the model knows when to turn on i.e "activate" the adapter weights. The model will scan any input strings (during training or at test time) for this invocation_string, and activate the adapter weights 1 token after the start of the sequence. If there are multiple instances of the invocation_string in the same input, it will activate at the last such instance.
+
+**Note** Often (not always) aLoRA requires higher rank (r) than LoRA. r=32 can be a good starting point for challenging tasks.
+
+
+
+
+**Installation** The Activated LoRA requirements are an optional install in pyproject.toml (activated-lora)
+
+
+
+Set `peft_method` to `"alora"`. 
+
+
+You *must* pass in an invocation_string argument. This invocation_string *must be present* in both training data inputs and the input at test time. A good solution is to set invocation_string = response_template, this will ensure that every training input will have the invocation_string present. We keep these separate arguments for flexibility. It is most robust if the invocation_string begins and ends with special tokens.
+
+
+
+You can additionally pass any arguments from [aLoraConfig](https://github.com/IBM/activated-lora/blob/fms-hf-tuning/alora/config.py#L35), see the LoRA section for examples.
+
+Example command to run, here using the ([Granite Instruct response template](https://huggingface.co/ibm-granite/granite-3.0-8b-instruct/blob/main/tokenizer_config.json#L188)) as the invocation sequence:
+
+```bash
+python tuning/sft_trainer.py \
+--model_name_or_path $MODEL_PATH \
+--tokenizer_name_or_path $MODEL_PATH \ # This field is optional and if not specified, tokenizer from model_name_or_path will be used
+--training_data_path $TRAIN_DATA_PATH \
+--output_dir $OUTPUT_PATH \
+--num_train_epochs 40 \
+--per_device_train_batch_size 4 \
+---learning_rate 1e-4 \
+--response_template "<|start_of_role|>assistant<|end_of_role|>" \ #this example uses special tokens in the Granite tokenizer, adjust for other models
+--invocation_string "<|start_of_role|>assistant<|end_of_role|>" \
+--dataset_text_field "output" \
+--peft_method "alora" \
+--r 32 \
+--lora_dropout 0.05 \
+--lora_alpha 16 \
+--target_modules q_proj k_proj v_proj
+```
+
+Equally you can pass in a JSON configuration for running tuning. See [build doc](./build/README.md) for more details. The above can also be passed in as JSON:
+```json
+{
+    "model_name_or_path": $MODEL_PATH,
+    "training_data_path": $TRAIN_DATA_PATH,
+    "output_dir": $OUTPUT_PATH,
+    "num_train_epochs": 40.0,
+    "per_device_train_batch_size": 4,
+    "learning_rate": 1e-4,
+    "response_template": "<|start_of_role|>assistant<|end_of_role|>",
+    "invocation_string": "<|start_of_role|>assistant<|end_of_role|>",
+    "dataset_text_field": "output",
+    "peft_method": "alora",
+    "r": 32,
+    "lora_dropout": 0.05,
+    "lora_alpha": 16,
+    "target_modules": ["q_proj", "k_proj", "v_proj"]
+}
+```
+
+Notice the `target_modules` are the names of the modules to apply the adapter to.
+- If this is specified, only the modules with the specified names will be replaced. When passing a list of strings, either an exact match will be performed or it is checked if the name of the module ends with any of the passed strings. If this is specified as `all-linear`, then all linear/Conv1D modules are chosen, excluding the output layer. 
+- If this is not specified, modules will be chosen according to the model architecture. If the architecture is not known, an error will be raised — in this case, you should specify the target modules manually. See [HuggingFace docs](https://huggingface.co/docs/peft/en/package_reference/lora#peft.LoraConfig) for more details.
+
+#### How to get list of aLoRA target_modules of a model
+For each model, the `target_modules` will depend on the type of model architecture. You can specify linear or attention layers to `target_modules`. To obtain list of `target_modules` for a model:
+
+```py
+from transformers import AutoModelForCausalLM
+# load the model
+model = AutoModelForCausalLM.from_pretrained(MODEL_PATH)
+# see the module list
+model.modules
+
+# to get just linear layers
+import re
+model_modules = str(model.modules)
+pattern = r'\((\w+)\): Linear'
+linear_layer_names = re.findall(pattern, model_modules)
+
+names = []
+for name in linear_layer_names:
+    names.append(name)
+target_modules = list(set(names))
+```
+
+For example for LLaMA model the modules look like:
+```
+<bound method Module.modules of LlamaForCausalLM(
+  (model): LlamaModel(
+    (embed_tokens): Embedding(32000, 4096, padding_idx=0)
+    (layers): ModuleList(
+      (0-31): 32 x LlamaDecoderLayer(
+        (self_attn): LlamaSdpaAttention(
+          (q_proj): Linear(in_features=4096, out_features=4096, bias=False)
+          (k_proj): Linear(in_features=4096, out_features=4096, bias=False)
+          (v_proj): Linear(in_features=4096, out_features=4096, bias=False)
+          (o_proj): Linear(in_features=4096, out_features=4096, bias=False)
+          (rotary_emb): LlamaRotaryEmbedding()
+        )
+        (mlp): LlamaMLP(
+          (gate_proj): Linear(in_features=4096, out_features=11008, bias=False)
+          (up_proj): Linear(in_features=4096, out_features=11008, bias=False)
+          (down_proj): Linear(in_features=11008, out_features=4096, bias=False)
+          (act_fn): SiLU()
+        )
+        (input_layernorm): LlamaRMSNorm()
+        (post_attention_layernorm): LlamaRMSNorm()
+      )
+    )
+    (norm): LlamaRMSNorm()
+  )
+  (lm_head): Linear(in_features=4096, out_features=32000, bias=False)
+)>
+```
+
+You can specify attention or linear layers. With the CLI, you can specify layers with `--target_modules "q_proj" "v_proj" "k_proj" "o_proj"` or `--target_modules "all-linear"`.
+
+#### Recommended target modules per model architecture 
+As per [aLoRA paper](https://arxiv.org/abs/2504.12397), by using the key, query and value projection matrices, we can achieve good quality with efficient GPU utilization. Hence, while thinking about what aLoRA adapters to specify, we recommend starting with key, query and value matrices. 
+
+#### Checkpoint saving
+For now, `save_strategy` is not supported (it is always reset to `none`). You can either save the model once training is complete, or pass in a custom callback in `additional_callbacks` directly to `tuning.sft_trainer.train` to perform saving. For example the following (from [alora github](https://github.com/IBM/activated-lora/blob/fms-hf-tuning/train_scripts/finetune_example_callback.py)) saves and updates the best performing model so far, checking whenever eval is called according to `eval_strategy`:
+```py
+class SaveBestModelCallback(TrainerCallback):
+    def __init__(self):
+        self.best_eval_loss = float("inf")  # Track best loss
+
+    def on_evaluate(self, args, state, control, **kwargs):
+        """Save the best model manually during evaluation."""
+
+        model = kwargs["model"]
+        metrics = kwargs["metrics"]
+        
+        eval_loss = metrics.get("eval_loss")
+        if eval_loss is not None and eval_loss < self.best_eval_loss:
+            self.best_eval_loss = eval_loss  # Update best loss
+
+            # Manually save best model
+            model.save_pretrained(args.output_dir)
+```
+
+#### Running aLoRA models on VLLM
+
+Coming soon! For now, there is inference support in this package, or see [aLoRA github](https://github.com/IBM/activated-lora/experiments/inference_example.py) for example code demonstrating KV cache reuse from prior base model calls.
+
+__________
+
 
 
 ### GPTQ-LoRA with AutoGPTQ Tuning Example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ fms-accel = ["fms-acceleration>=0.6"]
 gptq-dev = ["auto_gptq>0.4.2", "optimum>=1.15.0"]
 mamba = ["mamba_ssm[causal-conv1d]>=2.0.0,<3.0.0"]
 scanner-dev = ["HFResourceScanner>=0.1.0"]
-activated-lora = ["alora @ git+ssh://git@github.com/IBM/activated-lora.git@fms-hf-tuning"]
+activated-lora = ["git+ssh://git@github.com/IBM/activated-lora.git@fms-hf-tuning"]
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ fms-accel = ["fms-acceleration>=0.6"]
 gptq-dev = ["auto_gptq>0.4.2", "optimum>=1.15.0"]
 mamba = ["mamba_ssm[causal-conv1d]>=2.0.0,<3.0.0"]
 scanner-dev = ["HFResourceScanner>=0.1.0"]
-activated-lora = ["git+ssh://git@github.com/IBM/activated-lora.git@fms-hf-tuning"]
+activated-lora = ["alora>=0.1.0"]
 
 
 [tool.setuptools.packages.find]

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -227,7 +227,7 @@ class TunedCausalLM:
                         # Third Party
                         try:
                             # Third Party
-                            from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+                            from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
 
                             model = aLoRAPeftModelForCausalLM.from_pretrained(
                                 base_model,

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -295,11 +295,11 @@ class TunedCausalLM:
                 
         tok_res = self.tokenizer(text, return_tensors="pt")
         input_ids = tok_res.input_ids.to(self.device)
-        if alora_offsets is None: #pass in alora_offsets needed for alora model
+        if alora_offsets is None: 
             peft_outputs = self.peft_model.generate(
                 input_ids=input_ids, max_new_tokens=max_new_tokens
             )
-        else:
+        else: #pass in alora_offsets needed for alora model
             peft_outputs = self.peft_model.generate(
                 input_ids=input_ids, max_new_tokens=max_new_tokens, alora_offsets = alora_offsets
             )

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -329,7 +329,7 @@ class TunedCausalLM:
             # Tokenize separately to enforce correct token boundary
             before_ids = self.tokenizer(before, return_tensors="pt").input_ids
             after_ids = self.tokenizer(invocation_string, return_tensors="pt").input_ids
-            alora_offsets = after_ids.shape[1] - 1
+            alora_offsets = [after_ids.shape[1] - 1]
             input_ids = torch.cat([before_ids, after_ids], dim=1).to(self.device)
 
             peft_outputs = self.peft_model.generate(

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -327,7 +327,7 @@ class TunedCausalLM:
                     f"aLoRA invocation string '{invocation_string}' not found in input '{text}'."
                 )
             # Tokenize separately to enforce correct token boundary
-            before_ids = [self.tokenizer(before, return_tensors="pt").input_ids]
+            before_ids = self.tokenizer(before, return_tensors="pt").input_ids
             after_ids = self.tokenizer(invocation_string, return_tensors="pt").input_ids
             alora_offsets = after_ids.shape[1] - 1
             input_ids = torch.cat([before_ids, after_ids], dim=1).to(self.device)

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -227,7 +227,9 @@ class TunedCausalLM:
                         # Third Party
                         try:
                             # Third Party
-                            from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
+                            from alora.peft_model_alora import (  # pylint: disable=import-error
+                                aLoRAPeftModelForCausalLM,
+                            )
 
                             model = aLoRAPeftModelForCausalLM.from_pretrained(
                                 base_model,

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -290,7 +290,7 @@ class TunedCausalLM:
         *,
         max_new_tokens: int,
         ret_gen_text_only: bool = False,
-        alora_offsets: str = None,  # alora_offsets for alora models
+        alora_offsets: list[int] = None,  # alora_offsets for alora models
     ) -> str:
         """Runs inference on an instance of this model.
 

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -227,7 +227,7 @@ class TunedCausalLM:
                         # Third Party
                         try:
                             # Third Party
-                            from alora.peft_model_alora import (  # pylint: disable=import-error
+                            from alora.peft_model_alora import (  # pylint: disable=import-outside-toplevel
                                 aLoRAPeftModelForCausalLM,
                             )
 
@@ -239,11 +239,11 @@ class TunedCausalLM:
                                 else None,
                                 torch_dtype=torch.bfloat16 if use_flash_attn else None,
                             )
-                        except ImportError:
+                        except ImportError as exc:
                             raise ImportError(
                                 "The alora package is required for this operation. "
                                 "Please install it with pip install alora."
-                            )
+                            ) from exc
                     else:
                         model = PeftModel.from_pretrained(
                             base_model,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -93,8 +93,7 @@ from tuning.data.data_config import (
     load_and_validate_data_config,
 )
 from tuning.data.data_handlers import DataHandler, DataHandlerType
-from tuning.utils.import_utils import is_fms_accelerate_available, is_alora_available
-
+from tuning.utils.import_utils import is_alora_available, is_fms_accelerate_available
 
 MODEL_ARGS = configs.ModelArguments(
     model_name_or_path=MODEL_NAME, use_flash_attn=False, torch_dtype="float32"
@@ -133,7 +132,7 @@ TRAIN_ALORA_ARGS = configs.TrainingArguments(
     include_tokens_per_second=True,
     packing=False,
     max_seq_length=4096,
-    save_strategy="no", 
+    save_strategy="no",
     output_dir="tmp",
 )
 PEFT_PT_ARGS = peft_config.PromptTuningConfig(
@@ -143,12 +142,17 @@ PEFT_PT_ARGS = peft_config.PromptTuningConfig(
 )
 
 PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
-try: #Optional package
-    from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+try:  # Optional package
+    # Third Party
     from alora.config import aLoraConfig
-    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = "Label:")
+    from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+
+    PEFT_ALORA_ARGS = aLoraConfig(
+        r=8, lora_alpha=32, lora_dropout=0.05, invocation_string="Label:"
+    )
 except ImportError:
     pass
+
 
 @pytest.mark.parametrize(
     "enable_reduce_loss_sum",
@@ -717,10 +721,11 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that" in output_inference
 
-@pytest.mark.skipif( 
-     not is_alora_available(), 
-     reason="Only runs if alora is installed", 
- ) 
+
+@pytest.mark.skipif(
+    not is_alora_available(),
+    reason="Only runs if alora is installed",
+)
 @pytest.mark.parametrize(
     "target_modules,expected",
     target_modules_val_map,
@@ -736,8 +741,10 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 
-        trainer, metadata = sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
-        sft_trainer.save(train_args.output_dir + "/checkpoint-1",trainer)
+        trainer, metadata = sft_trainer.train(
+            MODEL_ARGS, DATA_ARGS, train_args, base_alora_args
+        )
+        sft_trainer.save(train_args.output_dir + "/checkpoint-1", trainer)
 
         # validate lora tuning configs
         _validate_training(tempdir)
@@ -750,11 +757,20 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME, use_alora=True)
-        invocation_string = loaded_model.peft_model.peft_config[loaded_model.peft_model.active_adapter].invocation_string
-        alora_offsets = [loaded_model.tokenizer(invocation_string, return_tensors="pt").input_ids.shape[1] - 1]
+        invocation_string = loaded_model.peft_model.peft_config[
+            loaded_model.peft_model.active_adapter
+        ].invocation_string
+        alora_offsets = [
+            loaded_model.tokenizer(
+                invocation_string, return_tensors="pt"
+            ).input_ids.shape[1]
+            - 1
+        ]
         # Run inference on the text
         output_inference = loaded_model.run(
-            "Simply put, the theory of relativity states that \n" + invocation_string, max_new_tokens=50, alora_offsets = alora_offsets
+            "Simply put, the theory of relativity states that \n" + invocation_string,
+            max_new_tokens=50,
+            alora_offsets=alora_offsets,
         )
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that \n" in output_inference

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -731,7 +731,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         alora_offsets = loaded_model.tokenizer(invocation_string, return_tensors="pt").input_ids.shape[1] - 1
         # Run inference on the text
         output_inference = loaded_model.run(
-            "Simply put, the theory of relativity states that \n" + invocation_string, max_new_tokens=50, alora_offsets = 
+            "Simply put, the theory of relativity states that \n" + invocation_string, max_new_tokens=50, alora_offsets = alora_offsets
         )
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that \n" in output_inference

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -711,6 +711,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
         base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
+        print(base_alora_args)
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -130,7 +130,7 @@ PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
 try: #Optional package
     from alora.peft_model_alora import aLoRAPeftModelForCausalLM
     from alora.config import aLoraConfig
-    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = "### Label:")
+    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = " Label:")
 except ImportError:
     pass
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -711,7 +711,6 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
         base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
-        print(base_alora_args)
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -732,8 +732,8 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 
-        sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
-        sft_trainer.save(train_args.output_dir + "/checkpoint-final")
+        trainer, metadata = sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
+        sft_trainer.save(train_args.output_dir + "/checkpoint-final",trainer)
 
         # validate lora tuning configs
         _validate_training(tempdir)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -733,7 +733,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
             base_alora_args.target_modules = target_modules
 
         trainer, metadata = sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
-        sft_trainer.save(train_args.output_dir + "/checkpoint-final",trainer)
+        sft_trainer.save(train_args.output_dir + "/checkpoint-1",trainer)
 
         # validate lora tuning configs
         _validate_training(tempdir)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -145,8 +145,7 @@ PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
 try:  # Optional package
     # Third Party
     from alora.config import aLoraConfig
-    from alora.peft_model_alora import aLoRAPeftModelForCausalLM
-
+    
     PEFT_ALORA_ARGS = aLoraConfig(
         r=8, lora_alpha=32, lora_dropout=0.05, invocation_string="Label:"
     )
@@ -741,7 +740,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 
-        trainer, metadata = sft_trainer.train(
+        trainer, _ = sft_trainer.train(
             MODEL_ARGS, DATA_ARGS, train_args, base_alora_args
         )
         sft_trainer.save(train_args.output_dir + "/checkpoint-1", trainer)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -710,7 +710,14 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
     with tempfile.TemporaryDirectory() as tempdir:
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
-        base_alora_args = PEFT_ALORA_ARGS
+        base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
+
+        # Convert nested dict back into the right config object if needed
+        if isinstance(base_alora_args.runtime_config, dict):
+            base_alora_args.runtime_config = LoraRuntimeConfig(**base_alora_args.runtime_config)
+
+
+        from peft.utils.config import LoraRuntimeConfig
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -130,7 +130,7 @@ PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
 try: #Optional package
     from alora.peft_model_alora import aLoRAPeftModelForCausalLM
     from alora.config import aLoraConfig
-    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = DATA_ARGS.response_template)
+    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = "### Label:")
 except ImportError:
     pass
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -94,6 +94,7 @@ from tuning.data.data_config import (
 )
 from tuning.data.data_handlers import DataHandler, DataHandlerType
 from tuning.utils.import_utils import is_fms_accelerate_available
+from peft import LoraConfig
 
 MODEL_ARGS = configs.ModelArguments(
     model_name_or_path=MODEL_NAME, use_flash_attn=False, torch_dtype="float32"
@@ -717,7 +718,8 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
             base_alora_args.runtime_config = LoraRuntimeConfig(**base_alora_args.runtime_config)
 
 
-        from peft.utils.config import LoraRuntimeConfig
+        from peft.tuners.lora import LoraRuntimeConfig
+
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -93,7 +93,7 @@ from tuning.data.data_config import (
     load_and_validate_data_config,
 )
 from tuning.data.data_handlers import DataHandler, DataHandlerType
-from tuning.utils.import_utils import is_fms_accelerate_available
+from tuning.utils.import_utils import is_fms_accelerate_available, is_alora_available
 
 
 MODEL_ARGS = configs.ModelArguments(

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -130,7 +130,7 @@ PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
 try: #Optional package
     from alora.peft_model_alora import aLoRAPeftModelForCausalLM
     from alora.config import aLoraConfig
-    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = " Label:")
+    PEFT_ALORA_ARGS = aLoraConfig(r=8, lora_alpha=32, lora_dropout=0.05,invocation_string = "Label:")
 except ImportError:
     pass
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -759,17 +759,10 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         invocation_string = loaded_model.peft_model.peft_config[
             loaded_model.peft_model.active_adapter
         ].invocation_string
-        alora_offsets = [
-            loaded_model.tokenizer(
-                invocation_string, return_tensors="pt"
-            ).input_ids.shape[1]
-            - 1
-        ]
         # Run inference on the text
         output_inference = loaded_model.run(
             "Simply put, the theory of relativity states that \n" + invocation_string,
             max_new_tokens=50,
-            alora_offsets=alora_offsets,
         )
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that \n" in output_inference

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -120,6 +120,22 @@ TRAIN_ARGS = configs.TrainingArguments(
     save_strategy="epoch",
     output_dir="tmp",
 )
+TRAIN_ALORA_ARGS = configs.TrainingArguments(
+    num_train_epochs=5,
+    per_device_train_batch_size=4,
+    per_device_eval_batch_size=4,
+    gradient_accumulation_steps=1,
+    learning_rate=0.00001,
+    weight_decay=0,
+    warmup_ratio=0.03,
+    lr_scheduler_type="cosine",
+    logging_steps=1,
+    include_tokens_per_second=True,
+    packing=False,
+    max_seq_length=4096,
+    save_strategy="no", 
+    output_dir="tmp",
+)
 PEFT_PT_ARGS = peft_config.PromptTuningConfig(
     prompt_tuning_init="RANDOM",
     num_virtual_tokens=0,
@@ -709,7 +725,7 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
 def test_run_causallm_alora_and_inference(request, target_modules, expected):
     """Check if we can bootstrap and alora tune causallm models"""
     with tempfile.TemporaryDirectory() as tempdir:
-        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args = copy.deepcopy(TRAIN_ALORA_ARGS)
         train_args.output_dir = tempdir
         base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -747,7 +747,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME, use_alora=True)
         invocation_string = loaded_model.peft_model.peft_config[loaded_model.peft_model.active_adapter].invocation_string
-        alora_offsets = loaded_model.tokenizer(invocation_string, return_tensors="pt").input_ids.shape[1] - 1
+        alora_offsets = [loaded_model.tokenizer(invocation_string, return_tensors="pt").input_ids.shape[1] - 1]
         # Run inference on the text
         output_inference = loaded_model.run(
             "Simply put, the theory of relativity states that \n" + invocation_string, max_new_tokens=50, alora_offsets = alora_offsets

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -145,7 +145,7 @@ PEFT_LORA_ARGS = peft_config.LoraConfig(r=8, lora_alpha=32, lora_dropout=0.05)
 try:  # Optional package
     # Third Party
     from alora.config import aLoraConfig
-    
+
     PEFT_ALORA_ARGS = aLoraConfig(
         r=8, lora_alpha=32, lora_dropout=0.05, invocation_string="Label:"
     )

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -746,7 +746,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
 
         # Load the model
         loaded_model = TunedCausalLM.load(checkpoint_path, MODEL_NAME, use_alora=True)
-        invocation_string = loaded_model.peft_config[model_UQ.active_adapter].invocation_string
+        invocation_string = loaded_model.peft_model.peft_config[loaded_model.peft_model.active_adapter].invocation_string
         alora_offsets = loaded_model.tokenizer(invocation_string, return_tensors="pt").input_ids.shape[1] - 1
         # Run inference on the text
         output_inference = loaded_model.run(

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -733,6 +733,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
             base_alora_args.target_modules = target_modules
 
         sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
+        sft_trainer.save(train_args.output_dir + "/checkpoint-final")
 
         # validate lora tuning configs
         _validate_training(tempdir)

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -717,6 +717,10 @@ def test_run_causallm_lora_and_inference(request, target_modules, expected):
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that" in output_inference
 
+@pytest.mark.skipif( 
+     not is_alora_available(), 
+     reason="Only runs if alora is installed", 
+ ) 
 @pytest.mark.parametrize(
     "target_modules,expected",
     target_modules_val_map,

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -94,7 +94,7 @@ from tuning.data.data_config import (
 )
 from tuning.data.data_handlers import DataHandler, DataHandlerType
 from tuning.utils.import_utils import is_fms_accelerate_available
-from peft import LoraConfig
+
 
 MODEL_ARGS = configs.ModelArguments(
     model_name_or_path=MODEL_NAME, use_flash_attn=False, torch_dtype="float32"
@@ -712,13 +712,6 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
         base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
-
-        # Convert nested dict back into the right config object if needed
-        if isinstance(base_alora_args.runtime_config, dict):
-            base_alora_args.runtime_config = LoraRuntimeConfig(**base_alora_args.runtime_config)
-
-
-        from peft.tuners.lora import LoraRuntimeConfig
 
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -710,7 +710,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
     with tempfile.TemporaryDirectory() as tempdir:
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
-        base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
+        base_alora_args = PEFT_ALORA_ARGS
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 

--- a/tuning/config/peft_config.py
+++ b/tuning/config/peft_config.py
@@ -59,7 +59,6 @@ class LoraConfig:
     lora_dropout: float = 0.05
 
 
-
 @dataclass
 class PromptTuningConfig:
     """

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -336,7 +336,7 @@ def _process_raw_data_args(
     tokenizer_kwargs["max_length"] = max_seq_length
     tokenizer_kwargs["truncation"] = True
     # Lets not pad in tokenizer...we can handle that in the collator
-    tokenizer_kwargs["padding"] = False
+    tokenizer_kwargs["padding"] = True
 
     processor_kwargs = {}
     processor_kwargs["return_tensors"] = "pt"

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -339,7 +339,7 @@ def _process_raw_data_args(
     if tokenizer.pad_token is not None:
         tokenizer_kwargs["padding"] = True
     else:
-        tokenizer_kwargs["padding"] = False #can be handled by collator
+        tokenizer_kwargs["padding"] = False  # can be handled by collator
 
     processor_kwargs = {}
     processor_kwargs["return_tensors"] = "pt"

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -335,8 +335,11 @@ def _process_raw_data_args(
     tokenizer_kwargs = {}
     tokenizer_kwargs["max_length"] = max_seq_length
     tokenizer_kwargs["truncation"] = True
-    # As of peft=0.14, this must be True
-    tokenizer_kwargs["padding"] = True
+    # As of peft=0.14, this must be True in batched settings
+    if tokenizer.pad_token is not None:
+        tokenizer_kwargs["padding"] = True
+    else:
+        tokenizer_kwargs["padding"] = False #can be handled by collator
 
     processor_kwargs = {}
     processor_kwargs["return_tensors"] = "pt"

--- a/tuning/data/setup_dataprocessor.py
+++ b/tuning/data/setup_dataprocessor.py
@@ -335,7 +335,7 @@ def _process_raw_data_args(
     tokenizer_kwargs = {}
     tokenizer_kwargs["max_length"] = max_seq_length
     tokenizer_kwargs["truncation"] = True
-    # Lets not pad in tokenizer...we can handle that in the collator
+    # As of peft=0.14, this must be True
     tokenizer_kwargs["padding"] = True
 
     processor_kwargs = {}

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -495,7 +495,20 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
         os.makedirs(path, exist_ok=True)
 
     logger.info("Saving tuned model to path: %s", path)
-    trainer.save_model(path)
+    USE_ALORA = False
+    try:
+        from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+        if isinstance(trainer.model, aLoRAPeftModelForCausalLM):
+            USE_ALORA = True
+    except ImportError:
+        pass
+        
+    if USE_ALORA: # Save adapter weights and tokenizer only. aLoRA requires weights to not be merged.
+        trainer.model.save_pretrained(path)
+        trainer.tokenizer.save_pretrained(path)
+    else: #Save full model
+        trainer.save_model(path)
+        
 
 
 def get_parser():

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -133,6 +133,12 @@ def train(
         from alora.config import aLoraConfig
         if isinstance(peft_config, aLoraConfig):
             USE_ALORA = True
+            if train_args.save_strategy!="no": 
+                logger.warning("Setting train_args.save_strategy to 'no' for aLoRA. Model will be saved at end of training.")
+                ALORA_SAVE_END = True
+                train_args.save_strategy = "no"
+            else:
+                ALORA_SAVE_END = False
     except ImportError:
         pass
 
@@ -470,6 +476,10 @@ def train(
     trainer.train(resume_from_checkpoint)
     additional_metadata = {}
     additional_metadata["added_tokens_info"] = added_tokens_dict
+
+    if USE_ALORA and ALORA_SAVE_END: #saving was requested, saving at end
+        trainer.model.save_pretrained(training_args.output_dir)
+    
     return trainer, additional_metadata
 
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -77,7 +77,7 @@ def train(
     data_args: configs.DataArguments,
     train_args: configs.TrainingArguments,
     peft_config: Optional[  # pylint: disable=redefined-outer-name
-        Union[peft_config.LoraConfig, aLoraConfig, peft_config.PromptTuningConfig]
+        Union[peft_config.LoraConfig, peft_config.PromptTuningConfig]
     ] = None,
     trainer_controller_args: configs.TrainerControllerArguments = None,
     tracker_configs: Optional[TrackerConfigFactory] = TrackerConfigFactory(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -37,7 +37,7 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import is_accelerate_available
 from trl import SFTConfig, SFTTrainer, DataCollatorForCompletionOnlyLM
 import transformers
-
+from peft import LoraConfig
 
 # Local
 from tuning.config import configs, peft_config
@@ -77,7 +77,7 @@ def train(
     data_args: configs.DataArguments,
     train_args: configs.TrainingArguments,
     peft_config: Optional[  # pylint: disable=redefined-outer-name
-        Union[peft_config.LoraConfig, peft_config.PromptTuningConfig]
+        Union[peft_config.LoraConfig,LoraConfig, peft_config.PromptTuningConfig]
     ] = None,
     trainer_controller_args: configs.TrainerControllerArguments = None,
     tracker_configs: Optional[TrackerConfigFactory] = TrackerConfigFactory(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -603,14 +603,7 @@ def parse_arguments(parser, json_config=None):
         dict[str, str]
             Extra tracker metadata.
     """
-    if peft_method == "alora": 
-        try:
-            from alora.config import aLoraConfig
-        except ImportError:
-            raise ImportError(
-                "The alora package is required for this operation. "
-                "Please install it from https://github.com/IBM/activated-lora."
-            )
+    
     if json_config:
         (
             model_args,
@@ -660,7 +653,15 @@ def parse_arguments(parser, json_config=None):
         invocation_string = additional.invocation_string
         if peft_method == "alora":  
             if invocation_string is None:
-                error("invocation_string needed for aLoRA")
+                ValueError("invocation_string is not passed required for aLoRA usage")
+    if peft_method == "alora": 
+        try:
+            from alora.config import aLoraConfig
+        except ImportError:
+            raise ImportError(
+                "The alora package is required for this operation. "
+                "Please install it from https://github.com/IBM/activated-lora."
+            )
     if peft_method == "lora":
         tune_config = lora_config
     elif peft_method == "alora": 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -78,7 +78,7 @@ def train(
     train_args: configs.TrainingArguments,
     peft_config: Optional[  # pylint: disable=redefined-outer-name
         Union[peft_config.LoraConfig, LoraConfig, peft_config.PromptTuningConfig]
-    ] = None,  # LoRA should use peft_config.LoraConfig, here LoraConfig is for Activated LoRA.
+    ] = None,
     trainer_controller_args: configs.TrainerControllerArguments = None,
     tracker_configs: Optional[TrackerConfigFactory] = TrackerConfigFactory(
         file_logger_config=FileLoggingTrackerConfig()
@@ -100,6 +100,7 @@ def train(
         data_args: tuning.config.configs.DataArguments
         train_args: tuning.config.configs.TrainingArguments
         peft_config: peft_config.LoraConfig for Lora tuning | \
+        LoraConfig (peft.LoraConfig): for activated Lora (aLoRA) tuning | \
         peft_config.PromptTuningConfig for prompt tuning | \
         None for fine tuning
             The peft configuration to pass to trainer

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -478,7 +478,7 @@ def train(
     additional_metadata["added_tokens_info"] = added_tokens_dict
 
     if USE_ALORA and ALORA_SAVE_END: #saving was requested, saving at end
-        trainer.model.save_pretrained(training_args.output_dir)
+        trainer.model.save_pretrained(training_args.output_dir + "/checkpoint-final")
     
     return trainer, additional_metadata
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -138,7 +138,8 @@ def train(
             USE_ALORA = True
             if train_args.save_strategy != "no":
                 logger.warning(
-                    "Setting train_args.save_strategy to 'no' for aLoRA. Model will be saved at end of training."
+                    "Setting train_args.save_strategy to 'no' for aLoRA."
+                    "Model will be saved at end of training."
                 )
                 ALORA_SAVE_END = True
                 train_args.save_strategy = "no"
@@ -573,7 +574,8 @@ def get_parser():
         "--invocation_string",
         type=str,
         default=None,
-        help="Pass a invocation string that will be used to activate the aLoRA. This needs to be present in each training data row.",
+        help="Pass a invocation string that will be used to activate the aLoRA.\
+            This needs to be present in each training data row.",
     )
     return parser
 
@@ -669,7 +671,7 @@ def parse_arguments(parser, json_config=None):
         invocation_string = additional.invocation_string
         if peft_method == "alora":
             if invocation_string is None:
-                ValueError("invocation_string is not passed required for aLoRA usage")
+                raise ValueError("invocation_string is not passed required for aLoRA usage")
     if peft_method == "alora":
         try:
             # Third Party

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -132,7 +132,9 @@ def train(
     try:
         # Third Party
         from alora.config import aLoraConfig  # pylint: disable=import-error
-        from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
+        from alora.peft_model_alora import (  # pylint: disable=import-error
+            aLoRAPeftModelForCausalLM,
+        )
 
         if isinstance(peft_config, aLoraConfig):
             USE_ALORA = True
@@ -520,7 +522,9 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
     USE_ALORA = False
     try:
         # Third Party
-        from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
+        from alora.peft_model_alora import (  # pylint: disable=import-error
+            aLoRAPeftModelForCausalLM,
+        )
 
         if isinstance(trainer.model, aLoRAPeftModelForCausalLM):
             USE_ALORA = True
@@ -671,9 +675,12 @@ def parse_arguments(parser, json_config=None):
         invocation_string = additional.invocation_string
         if peft_method == "alora":
             if invocation_string is None:
-                raise ValueError("invocation_string is not passed required for aLoRA usage")
+                raise ValueError(
+                    "invocation_string is not passed required for aLoRA usage"
+                )
     if peft_method == "alora":
         try:
+            # Third Party
             from alora.config import aLoraConfig  # pylint: disable=import-error
         except ImportError:
             raise ImportError(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -660,7 +660,7 @@ def parse_arguments(parser, json_config=None):
         except ImportError:
             raise ImportError(
                 "The alora package is required for this operation. "
-                "Please install it from https://github.com/IBM/activated-lora."
+                "Please install it with pip install alora."
             )
     if peft_method == "lora":
         tune_config = lora_config

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -478,7 +478,7 @@ def train(
     additional_metadata["added_tokens_info"] = added_tokens_dict
 
     if USE_ALORA and ALORA_SAVE_END: #saving was requested, saving at end
-        trainer.model.save_pretrained(training_args.output_dir + "/checkpoint-final")
+        trainer.model.save_pretrained(training_args.output_dir + "/checkpoint-1")
     
     return trainer, additional_metadata
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -131,8 +131,8 @@ def train(
     train_args, logger = set_log_level(train_args, "sft_trainer_train")
     try:
         # Third Party
-        from alora.config import aLoraConfig
-        from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+        from alora.config import aLoraConfig  # pylint: disable=import-error
+        from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
 
         if isinstance(peft_config, aLoraConfig):
             USE_ALORA = True
@@ -520,7 +520,7 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
     USE_ALORA = False
     try:
         # Third Party
-        from alora.peft_model_alora import aLoRAPeftModelForCausalLM
+        from alora.peft_model_alora import aLoRAPeftModelForCausalLM  # pylint: disable=import-error
 
         if isinstance(trainer.model, aLoRAPeftModelForCausalLM):
             USE_ALORA = True
@@ -674,8 +674,7 @@ def parse_arguments(parser, json_config=None):
                 raise ValueError("invocation_string is not passed required for aLoRA usage")
     if peft_method == "alora":
         try:
-            # Third Party
-            from alora.config import aLoraConfig
+            from alora.config import aLoraConfig  # pylint: disable=import-error
         except ImportError:
             raise ImportError(
                 "The alora package is required for this operation. "

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -133,6 +133,8 @@ def train(
         from alora.config import aLoraConfig
         if isinstance(peft_config, aLoraConfig):
             USE_ALORA = True
+    except ImportError:
+        pass
 
     train_args, logger = set_log_level(train_args, "sft_trainer_train")
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -131,8 +131,8 @@ def train(
     train_args, logger = set_log_level(train_args, "sft_trainer_train")
     try:
         # Third Party
-        from alora.config import aLoraConfig  # pylint: disable=import-error
-        from alora.peft_model_alora import (  # pylint: disable=import-error
+        from alora.config import aLoraConfig  # pylint: disable=import-outside-toplevel
+        from alora.peft_model_alora import (  # pylint: disable=import-outside-toplevel
             aLoRAPeftModelForCausalLM,
         )
 
@@ -522,7 +522,7 @@ def save(path: str, trainer: SFTTrainer, log_level="WARNING"):
     USE_ALORA = False
     try:
         # Third Party
-        from alora.peft_model_alora import (  # pylint: disable=import-error
+        from alora.peft_model_alora import (  # pylint: disable=import-outside-toplevel
             aLoRAPeftModelForCausalLM,
         )
 
@@ -681,12 +681,14 @@ def parse_arguments(parser, json_config=None):
     if peft_method == "alora":
         try:
             # Third Party
-            from alora.config import aLoraConfig  # pylint: disable=import-error
-        except ImportError:
+            from alora.config import (  # pylint: disable=import-outside-toplevel
+                aLoraConfig,
+            )
+        except ImportError as exc:
             raise ImportError(
                 "The alora package is required for this operation. "
                 "Please install it with pip install alora."
-            )
+            ) from exc
     if peft_method == "lora":
         tune_config = lora_config
     elif peft_method == "alora":

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -101,7 +101,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         #if alora_config["target_modules"] == ["all-linear"]:
         #    alora_config["target_modules"] = "all-linear"
         #hf_peft_config = aLoraConfig(**alora_config)
-        #alora_config = tuning_config
+        alora_config = tuning_config
         alora_config.target_modules = "all-linear"
     elif isinstance(tuning_config, peft_config.LoraConfig):
         lora_config = asdict(tuning_config)

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -100,7 +100,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         alora_config = asdict(tuning_config)
         if alora_config["target_modules"] == ["all-linear"]:
             alora_config["target_modules"] = "all-linear"
-        hf_peft_config = aLoraConfig(task_type=task_type, **alora_config)
+        hf_peft_config = aLoraConfig(**alora_config)
     elif isinstance(tuning_config, peft_config.LoraConfig):
         lora_config = asdict(tuning_config)
         if lora_config["target_modules"] == ["all-linear"]:

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -94,6 +94,8 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         from alora.config import aLoraConfig
         if isinstance(tuning_config, aLoraConfig):
             USE_ALORA = True
+    except ImportError:
+        pass
     if USE_ALORA:
         alora_config = asdict(tuning_config)
         if alora_config["target_modules"] == ["all-linear"]:

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -97,10 +97,12 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     except ImportError:
         pass
     if USE_ALORA:
-        alora_config = asdict(tuning_config)
-        if alora_config["target_modules"] == ["all-linear"]:
-            alora_config["target_modules"] = "all-linear"
-        hf_peft_config = aLoraConfig(**alora_config)
+        #alora_config = asdict(tuning_config)
+        #if alora_config["target_modules"] == ["all-linear"]:
+        #    alora_config["target_modules"] = "all-linear"
+        #hf_peft_config = aLoraConfig(**alora_config)
+        #alora_config = tuning_config
+        alora_config.target_modules = "all-linear"
     elif isinstance(tuning_config, peft_config.LoraConfig):
         lora_config = asdict(tuning_config)
         if lora_config["target_modules"] == ["all-linear"]:

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -103,6 +103,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         #hf_peft_config = aLoraConfig(**alora_config)
         alora_config = tuning_config
         alora_config.target_modules = "all-linear"
+        hf_peft_config = alora_config
     elif isinstance(tuning_config, peft_config.LoraConfig):
         lora_config = asdict(tuning_config)
         if lora_config["target_modules"] == ["all-linear"]:

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -64,7 +64,9 @@ def create_tuning_config(peft_method, **kwargs):
     if peft_method == "alora":
         try:
             # Third Party
-            from alora.config import aLoraConfig  # pylint: disable=import-error
+            from alora.config import (  # pylint: disable=import-outside-toplevel
+                aLoraConfig,
+            )
 
             tune_config = aLoraConfig()
             update_config(tune_config, **kwargs)
@@ -96,7 +98,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     USE_ALORA = False
     try:
         # Third Party
-        from alora.config import aLoraConfig  # pylint: disable=import-error
+        from alora.config import aLoraConfig  # pylint: disable=import-outside-toplevel
 
         if isinstance(tuning_config, aLoraConfig):
             USE_ALORA = True

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -64,7 +64,7 @@ def create_tuning_config(peft_method, **kwargs):
     if peft_method == "alora":
         try:
             # Third Party
-            from alora.config import aLoraConfig
+            from alora.config import aLoraConfig  # pylint: disable=import-error
 
             tune_config = aLoraConfig()
             update_config(tune_config, **kwargs)
@@ -96,7 +96,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     USE_ALORA = False
     try:
         # Third Party
-        from alora.config import aLoraConfig
+        from alora.config import aLoraConfig  # pylint: disable=import-error
 
         if isinstance(tuning_config, aLoraConfig):
             USE_ALORA = True

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -98,9 +98,8 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         pass
     if USE_ALORA:
         alora_config = tuning_config
-        if alora_config["target_modules"] == ["all-linear"]:
-            alora_config["target_modules"] = "all-linear"
-        alora_config.target_modules = "all-linear"
+        if alora_config.target_modules == ["all-linear"]:
+            alora_config.target_modules = "all-linear"
         alora_config.task_type = task_type
         hf_peft_config = alora_config
     elif isinstance(tuning_config, peft_config.LoraConfig):

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -65,8 +65,9 @@ def create_tuning_config(peft_method, **kwargs):
         try:
             # Third Party
             from alora.config import aLoraConfig
+
             tune_config = aLoraConfig()
-            update_config(tune_config,**kwargs)
+            update_config(tune_config, **kwargs)
         except ImportError:
             raise ImportError(
                 "alora package is required for this operation. "

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -68,11 +68,11 @@ def create_tuning_config(peft_method, **kwargs):
 
             tune_config = aLoraConfig()
             update_config(tune_config, **kwargs)
-        except ImportError:
+        except ImportError as exc:
             raise ImportError(
                 "alora package is required for this operation. "
-                "Please install it from https://github.com/IBM/activated-lora."
-            )
+                "Please install it with pip install alora."
+            ) from exc
 
     elif peft_method == "lora":
         tune_config = peft_config.LoraConfig()

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -103,6 +103,7 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
         #hf_peft_config = aLoraConfig(**alora_config)
         alora_config = tuning_config
         alora_config.target_modules = "all-linear"
+        alora_config.task_type = task_type
         hf_peft_config = alora_config
     elif isinstance(tuning_config, peft_config.LoraConfig):
         lora_config = asdict(tuning_config)

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -97,11 +97,9 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     except ImportError:
         pass
     if USE_ALORA:
-        #alora_config = asdict(tuning_config)
-        #if alora_config["target_modules"] == ["all-linear"]:
-        #    alora_config["target_modules"] = "all-linear"
-        #hf_peft_config = aLoraConfig(**alora_config)
         alora_config = tuning_config
+        if alora_config["target_modules"] == ["all-linear"]:
+            alora_config["target_modules"] = "all-linear"
         alora_config.target_modules = "all-linear"
         alora_config.task_type = task_type
         hf_peft_config = alora_config

--- a/tuning/utils/config_utils.py
+++ b/tuning/utils/config_utils.py
@@ -63,13 +63,16 @@ def create_tuning_config(peft_method, **kwargs):
     ], f"peft config {peft_method} not defined in peft.py"
     if peft_method == "alora":
         try:
+            # Third Party
             from alora.config import aLoraConfig
+            tune_config = aLoraConfig()
+            update_config(tune_config,**kwargs)
         except ImportError:
             raise ImportError(
                 "alora package is required for this operation. "
                 "Please install it from https://github.com/IBM/activated-lora."
             )
-            
+
     elif peft_method == "lora":
         tune_config = peft_config.LoraConfig()
         update_config(tune_config, **kwargs)
@@ -90,8 +93,10 @@ def get_hf_peft_config(task_type, tuning_config, tokenizer_name_or_path):
     Return: HF PEFT config or None
     """
     USE_ALORA = False
-    try: 
+    try:
+        # Third Party
         from alora.config import aLoraConfig
+
         if isinstance(tuning_config, aLoraConfig):
             USE_ALORA = True
     except ImportError:

--- a/tuning/utils/import_utils.py
+++ b/tuning/utils/import_utils.py
@@ -32,3 +32,18 @@ def is_fms_accelerate_available(
         if not _is_package_available(n):
             return False
     return True
+
+def is_alora_available(
+    plugins: Union[str, List[str]] = None, package_name: str = "alora"
+):
+    names = [package_name]
+    if plugins is not None:
+        if isinstance(plugins, str):
+            plugins = [plugins]
+        names.extend([package_name + "_" + x for x in plugins])
+
+    for n in names:
+        if not _is_package_available(n):
+            return False
+    return True
+

--- a/tuning/utils/import_utils.py
+++ b/tuning/utils/import_utils.py
@@ -34,15 +34,8 @@ def is_fms_accelerate_available(
     return True
 
 
-def is_alora_available(
-    plugins: Union[str, List[str]] = None, package_name: str = "alora"
-):
+def is_alora_available(package_name: str = "alora"):
     names = [package_name]
-    if plugins is not None:
-        if isinstance(plugins, str):
-            plugins = [plugins]
-        names.extend([package_name + "_" + x for x in plugins])
-
     for n in names:
         if not _is_package_available(n):
             return False

--- a/tuning/utils/import_utils.py
+++ b/tuning/utils/import_utils.py
@@ -33,6 +33,7 @@ def is_fms_accelerate_available(
             return False
     return True
 
+
 def is_alora_available(
     plugins: Union[str, List[str]] = None, package_name: str = "alora"
 ):
@@ -46,4 +47,3 @@ def is_alora_available(
         if not _is_package_available(n):
             return False
     return True
-


### PR DESCRIPTION
### Description of the change

Support for activated lora. Right now points to alora code on a public repo https://github.com/IBM/activated-lora . Also uses a data collator by default due to the nature of alora, and adds a new argument for the invocation string. Also note that peft=0.14.0 seems to be necessary to avoid errors with the alora code.

### Related issue number

https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1629

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested
I tested it with the following command
python tuning/sft_trainer.py \
--model_name_or_path ibm-granite/granite-3.1-2b-base \
--training_data_path /proj/dmfexp/statllm/users/kgreenewald/Thermometer/TuningStack/fms-hf-tuning-alora/tests/artifacts/testdata/json/twitter_complaints_input_output.json \
--output_dir ./output \
--num_train_epochs 1 \
--per_device_train_batch_size 4 \
---learning_rate 1e-4 \
--response_template "\n### Label:" \
--dataset_text_field "output" \
--peft_method "alora" \
--save_strategy=no \
--r 8 \
--use_flash_attn false \
--lora_dropout 0.05 \
--lora_alpha 16 \
--invocation_string "\n### Label:" \
--target_modules q_proj k_proj v_proj

output:

{'loss': 0.0, 'grad_norm': 0.0, 'learning_rate': 0.0, 'epoch': 1.0}                                                         
{'train_runtime': 25.4343, 'train_samples_per_second': 1.966, 'train_steps_per_second': 0.511, 'train_loss': 0.0, 'epoch': 1.0}
