### PR TITLE
feat: new interface for fast_moe (non breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ The list of configurations for various `fms_acceleration` plugins:
   - `--padding_free`: technique to process multiple examples in single batch without adding padding tokens that waste compute.
   - `--multipack`: technique for *multi-gpu training* to balance out number of tokens processed in each device, to minimize waiting time.
 - [fast_moe_config](./tuning/config/acceleration_configs/fast_moe.py) (experimental):
-  - `--fast_moe`: trains MoE models in parallel with scatter MoE kernels, increasing throughput and decreasing memory usage.
+  - `--fast_moe`: trains MoE models in parallel with [Scatter MoE kernels](https://github.com/foundation-model-stack/fms-acceleration/tree/main/plugins/accelerated-moe#fms-acceleration-for-mixture-of-experts), increasing throughput and decreasing memory usage.
 
 Notes: 
  * `quantized_lora_config` requires that it be used along with LoRA tuning technique. See [LoRA tuning section](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main?tab=readme-ov-file#lora-tuning-example) on the LoRA parameters to pass.
@@ -821,10 +821,10 @@ Notes:
     - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
  * Notes on Fast MoE
     - `--fast_moe` takes either an integer or boolean value.
-      - When an integer `n` is passed, it enables expert parallel sharding with the expert parallel degree as `n` along with scatter MoE kernels enabled.
+      - When an integer `n` is passed, it enables expert parallel sharding with the expert parallel degree as `n` along with Scatter MoE kernels enabled.
       - When a boolean is passed, the expert parallel degree defaults to 1 and further the behaviour would be as follows:
-          - if True, it is scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
-          - if False, scatter MoE Kernels with complete replication of experts across ranks.
+          - if True, it is Scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
+          - if False, Scatter MoE Kernels with complete replication of experts across ranks.
     - `world_size` must be divisible by the `ep_degree`
     - `number of experts` in the MoE module must be divisible by the `ep_degree`
     - Running fast moe modifies the state dict of the model, and must be post-processed which happens automatically and the converted checkpoint can be found at `hf_converted_checkpoint` folder within every saved checkpoint directory. Alternatively, we can perform similar option manually through [checkpoint utils](https://github.com/foundation-model-stack/fms-acceleration/blob/main/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py) script.

--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ Notes:
       - When its an integer it enables expert parallel sharding with the given expert parallel degree along with Scatter MoE kernels.
       - When its boolean False, it is Scatter MoE Kernels with complete replication of experts across ranks.
       - When its boolean True, it is Scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
+      - When a boolean is passed, the expert parallel degree defaults to 1. When an integer is passed, Scatter MoE defaults to replicating experts across ranks.
     - `world_size` must be divisible by the `ep_degree`
     - Running fast moe modifies the state dict of the model, and must be post-processed which happens automatically and the converted checkpoint can be found at `hf_converted_checkpoint` folder within every saved checkpoint directory. Alternatively, we can perform similar option manually through [checkpoint utils](https://github.com/foundation-model-stack/fms-acceleration/blob/main/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py) script.
       - The typical usecase for this script is to run:

--- a/README.md
+++ b/README.md
@@ -820,7 +820,10 @@ Notes:
     - works only for *multi-gpu*.
     - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
  * Notes on Fast MoE
-    - `--fast_moe` is an integer value that configures the amount of expert parallel sharding (ep_degree).
+    - `--fast_moe` takes either an integer or boolean value.
+      - When its an integer it enables expert parallel sharding with the given expert parallel degree along with Scatter MoE kernels.
+      - When its boolean False, it is Scatter MoE Kernels with complete replication of experts across ranks.
+      - When its boolean True, it is Scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
     - `world_size` must be divisible by the `ep_degree`
     - Running fast moe modifies the state dict of the model, and must be post-processed which happens automatically and the converted checkpoint can be found at `hf_converted_checkpoint` folder within every saved checkpoint directory. Alternatively, we can perform similar option manually through [checkpoint utils](https://github.com/foundation-model-stack/fms-acceleration/blob/main/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py) script.
       - The typical usecase for this script is to run:

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ The list of configurations for various `fms_acceleration` plugins:
   - `--padding_free`: technique to process multiple examples in single batch without adding padding tokens that waste compute.
   - `--multipack`: technique for *multi-gpu training* to balance out number of tokens processed in each device, to minimize waiting time.
 - [fast_moe_config](./tuning/config/acceleration_configs/fast_moe.py) (experimental):
-  - `--fast_moe`: trains MoE models in parallel, increasing throughput and decreasing memory usage.
+  - `--fast_moe`: trains MoE models in parallel with scatter MoE kernels, increasing throughput and decreasing memory usage.
 
 Notes: 
  * `quantized_lora_config` requires that it be used along with LoRA tuning technique. See [LoRA tuning section](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main?tab=readme-ov-file#lora-tuning-example) on the LoRA parameters to pass.
@@ -821,11 +821,12 @@ Notes:
     - currently only includes the version of *multipack* optimized for linear attention implementations like *flash-attn*.
  * Notes on Fast MoE
     - `--fast_moe` takes either an integer or boolean value.
-      - When its an integer it enables expert parallel sharding with the given expert parallel degree along with Scatter MoE kernels.
-      - When its boolean False, it is Scatter MoE Kernels with complete replication of experts across ranks.
-      - When its boolean True, it is Scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
-      - When a boolean is passed, the expert parallel degree defaults to 1. When an integer is passed, Scatter MoE defaults to replicating experts across ranks.
+      - When an integer `n` is passed, it enables expert parallel sharding with the expert parallel degree as `n` along with scatter MoE kernels enabled.
+      - When a boolean is passed, the expert parallel degree defaults to 1 and further the behaviour would be as follows:
+          - if True, it is scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).
+          - if False, scatter MoE Kernels with complete replication of experts across ranks.
     - `world_size` must be divisible by the `ep_degree`
+    - `number of experts` in the MoE module must be divisible by the `ep_degree`
     - Running fast moe modifies the state dict of the model, and must be post-processed which happens automatically and the converted checkpoint can be found at `hf_converted_checkpoint` folder within every saved checkpoint directory. Alternatively, we can perform similar option manually through [checkpoint utils](https://github.com/foundation-model-stack/fms-acceleration/blob/main/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py) script.
       - The typical usecase for this script is to run:
         ```

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1387,6 +1387,66 @@ def test_run_moe_ft_and_inference(dataset_path):
         TWITTER_COMPLAINTS_DATA_JSONL,
     ],
 )
+def test_run_moe_ft_and_inference_kernels_only(dataset_path):
+    """Check if we can finetune a moe model with moe kernels only"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        data_args = copy.deepcopy(DATA_ARGS)
+        data_args.training_data_path = dataset_path
+        model_args = copy.deepcopy(MODEL_ARGS)
+        model_args.model_name_or_path = "Isotonic/TinyMixtral-4x248M-MoE"
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args.output_dir = tempdir
+        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=True))
+        sft_trainer.train(
+            model_args, data_args, train_args, fast_moe_config=fast_moe_config
+        )
+        _test_run_inference(
+            checkpoint_path=os.path.join(
+                _get_checkpoint_path(tempdir), "hf_converted_checkpoint"
+            )
+        )
+
+
+@pytest.mark.skipif(
+    not is_fms_accelerate_available(plugins="moe"),
+    reason="Only runs if fms-accelerate is installed along with accelerated-moe plugin",
+)
+@pytest.mark.parametrize(
+    "dataset_path",
+    [
+        TWITTER_COMPLAINTS_DATA_JSONL,
+    ],
+)
+def test_run_moe_ft_and_inference_ep1_kernels(dataset_path):
+    """Check if we can finetune a moe model with moe kernels and ep_degree=1"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        data_args = copy.deepcopy(DATA_ARGS)
+        data_args.training_data_path = dataset_path
+        model_args = copy.deepcopy(MODEL_ARGS)
+        model_args.model_name_or_path = "Isotonic/TinyMixtral-4x248M-MoE"
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        train_args.output_dir = tempdir
+        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=False))
+        sft_trainer.train(
+            model_args, data_args, train_args, fast_moe_config=fast_moe_config
+        )
+        _test_run_inference(
+            checkpoint_path=os.path.join(
+                _get_checkpoint_path(tempdir), "hf_converted_checkpoint"
+            )
+        )
+
+
+@pytest.mark.skipif(
+    not is_fms_accelerate_available(plugins="moe"),
+    reason="Only runs if fms-accelerate is installed along with accelerated-moe plugin",
+)
+@pytest.mark.parametrize(
+    "dataset_path",
+    [
+        TWITTER_COMPLAINTS_DATA_JSONL,
+    ],
+)
 def test_run_moe_ft_with_save_model_dir(dataset_path):
     """Check if we can finetune a moe model and check if hf checkpoint is created"""
     with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1352,72 +1352,14 @@ def test_run_e2e_with_hf_dataset_id(data_args):
     reason="Only runs if fms-accelerate is installed along with accelerated-moe plugin",
 )
 @pytest.mark.parametrize(
-    "dataset_path",
+    "dataset_path, ep_degree",
     [
-        TWITTER_COMPLAINTS_DATA_JSONL,
+        (TWITTER_COMPLAINTS_DATA_JSONL, 1),
+        (TWITTER_COMPLAINTS_DATA_JSONL, True),
+        (TWITTER_COMPLAINTS_DATA_JSONL, False),
     ],
 )
-def test_run_moe_ft_and_inference(dataset_path):
-    """Check if we can finetune a moe model and check if hf checkpoint is created"""
-    with tempfile.TemporaryDirectory() as tempdir:
-        data_args = copy.deepcopy(DATA_ARGS)
-        data_args.training_data_path = dataset_path
-        model_args = copy.deepcopy(MODEL_ARGS)
-        model_args.model_name_or_path = "Isotonic/TinyMixtral-4x248M-MoE"
-        train_args = copy.deepcopy(TRAIN_ARGS)
-        train_args.output_dir = tempdir
-        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=1))
-        sft_trainer.train(
-            model_args, data_args, train_args, fast_moe_config=fast_moe_config
-        )
-        _test_run_inference(
-            checkpoint_path=os.path.join(
-                _get_checkpoint_path(tempdir), "hf_converted_checkpoint"
-            )
-        )
-
-
-@pytest.mark.skipif(
-    not is_fms_accelerate_available(plugins="moe"),
-    reason="Only runs if fms-accelerate is installed along with accelerated-moe plugin",
-)
-@pytest.mark.parametrize(
-    "dataset_path",
-    [
-        TWITTER_COMPLAINTS_DATA_JSONL,
-    ],
-)
-def test_run_moe_ft_and_inference_kernels_only(dataset_path):
-    """Check if we can finetune a moe model with moe kernels only"""
-    with tempfile.TemporaryDirectory() as tempdir:
-        data_args = copy.deepcopy(DATA_ARGS)
-        data_args.training_data_path = dataset_path
-        model_args = copy.deepcopy(MODEL_ARGS)
-        model_args.model_name_or_path = "Isotonic/TinyMixtral-4x248M-MoE"
-        train_args = copy.deepcopy(TRAIN_ARGS)
-        train_args.output_dir = tempdir
-        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=True))
-        sft_trainer.train(
-            model_args, data_args, train_args, fast_moe_config=fast_moe_config
-        )
-        _test_run_inference(
-            checkpoint_path=os.path.join(
-                _get_checkpoint_path(tempdir), "hf_converted_checkpoint"
-            )
-        )
-
-
-@pytest.mark.skipif(
-    not is_fms_accelerate_available(plugins="moe"),
-    reason="Only runs if fms-accelerate is installed along with accelerated-moe plugin",
-)
-@pytest.mark.parametrize(
-    "dataset_path",
-    [
-        TWITTER_COMPLAINTS_DATA_JSONL,
-    ],
-)
-def test_run_moe_ft_and_inference_ep1_kernels(dataset_path):
+def test_run_moe_ft_and_inference_ep1_kernels(dataset_path, ep_degree):
     """Check if we can finetune a moe model with moe kernels and ep_degree=1"""
     with tempfile.TemporaryDirectory() as tempdir:
         data_args = copy.deepcopy(DATA_ARGS)
@@ -1426,7 +1368,7 @@ def test_run_moe_ft_and_inference_ep1_kernels(dataset_path):
         model_args.model_name_or_path = "Isotonic/TinyMixtral-4x248M-MoE"
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.output_dir = tempdir
-        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=False))
+        fast_moe_config = FastMoeConfig(fast_moe=FastMoe(ep_degree=ep_degree))
         sft_trainer.train(
             model_args, data_args, train_args, fast_moe_config=fast_moe_config
         )

--- a/tuning/config/acceleration_configs/fast_moe.py
+++ b/tuning/config/acceleration_configs/fast_moe.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 # Standard
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Union
+import argparse
 import os
 
 # Third Party
@@ -42,8 +44,15 @@ except ImportError:
 @parsable_dataclass
 @dataclass
 class FastMoe:
+    ep_degree: Union[int, bool] = 1
+    disable_distributed: bool = field(
+        default=False, metadata={"help": argparse.SUPPRESS}
+    )
 
-    ep_degree: int = 1
+    def __post_init__(self):
+        if isinstance(self.ep_degree, bool):
+            self.disable_distributed = self.ep_degree
+            self.ep_degree = 1
 
 
 @dataclass


### PR DESCRIPTION
### Description of the change

New interface for `--fast_moe` to support kernels only mode.

- `--fast_moe` takes either an integer or boolean value.
    - When its an integer it enables expert parallel sharding with the given expert parallel degree along with Scatter MoE kernels.
     - When its boolean False, it is Scatter MoE Kernels with complete replication of experts across ranks.
     - When its boolean True, it is Scatter MoE Kernels with experts sharded based on the top level sharding protocol (e.g. FSDP).



### How to verify the PR

You can check the unit tests.

### Was the PR tested

Tested with unit tests.

![image](https://github.com/user-attachments/assets/5cb4e5d6-7472-465c-a4f8-06eb28a1b661)

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass