### PR TITLE
fix: set use_cache=false while model loading to prevent graph break

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -224,6 +224,8 @@ def train(
         cache_dir=train_args.cache_dir,
         torch_dtype=get_torch_dtype(model_args.torch_dtype),
         attn_implementation="flash_attention_2" if model_args.use_flash_attn else None,
+        # avoid warning that use_cache is incompatible with gradient checkpointing
+        use_cache=(not train_args.gradient_checkpointing),
     )
 
     # TODO: Move these to a config as well


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Setting use_cache to false when gradient checkpointing is true. If not, then `modeling_granite`/`llama` has a check to set it to false anyway but after printing the following warning:

```
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
```
This is causing a graph break when doing torch.compile. To avoid this, we are manually setting this arg when loading model, [similar to how SFT is doing in their example scripts](https://github.com/huggingface/trl/blob/9f3702f6be24505c58aadbbf8651b24ef10363b6/trl/scripts/sft.py#L80C15-L80C16)

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->
Example tuning command to reproduce the error:
```
accelerate launch --num_processes=1  -m tuning.sft_trainer --output_dir ./train_output --max_steps 5 --learning_rate 2e-5 --training_data_path=/data/cg/ei_5.jsonl --save_steps=50 --torch_dtype bfloat16 --logging_strategy steps --logging_steps 1 --per_device_train_batch_size 8 --max_seq_length 1024 --include_tokens_per_second true --data_formatter_template "### Input: {input} \n\n### Response: {output}" --response_template "\n### Response:" --torch_compile True --model_name_or_path /data/models/granite3-8b --use_flash_attn True --gradient_checkpointing True --packing
```

This will print the warning log line:
```
The new embeddings will be initialized from a multivariate normal distribution that has old embeddings' mean and covariance. As described in this article: https://nlp.stanford.edu/~johnhew/vocab-expansion.html. To disable this, use `mean_resizing=False`
/workspace/auto_runner/.venv/lib/python3.12/site-packages/transformers/training_args.py:2105: FutureWarning: `--push_to_hub_token` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `--hub_token` instead.
  warnings.warn(
/workspace/auto_runner/.venv/lib/python3.12/site-packages/tuning/sft_trainer.py:364: FutureWarning: `tokenizer` is deprecated and removed starting from version 0.16.0 for `SFTTrainer.__init__`. Use `processing_class` instead.
  trainer = SFTTrainer(
/workspace/auto_runner/.venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:300: UserWarning: You passed a processing_class with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `processing_class.padding_side = 'right'` to your code.
  warnings.warn(
  0%|                                                                                                                                 | 0/5 [00:00<?, ?it/s]
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
...
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass