### PR TITLE
fix: additional special tokens being replaced

### DIFF
--- a/scripts/offline_data_processing.py
+++ b/scripts/offline_data_processing.py
@@ -132,7 +132,10 @@ def get_processed_dataset(
 
     if special_tokens_dict:
         logger.info("Adding special tokens: %s", special_tokens_dict)
-        tokenizer.add_special_tokens(special_tokens_dict)
+        tokenizer.add_special_tokens(
+            special_tokens_dict=special_tokens_dict,
+            replace_additional_special_tokens=False,
+        )
 
     # Process data using the provided arguments and tokenizer
     logger.info("Calling process_dataargs to format datasets.")

--- a/tests/utils/test_embedding_resize.py
+++ b/tests/utils/test_embedding_resize.py
@@ -19,6 +19,9 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
 
+# First Party
+from tests.artifacts.testdata import CUSTOM_TOKENIZER_TINYLLAMA
+
 # Local
 from tuning.utils.tokenizer_data_utils import tokenizer_and_embedding_resize
 
@@ -99,6 +102,62 @@ def test_resize_with_special_tokens():
 
     assert output_tokenizer_len == input_tokenizer_len + 2
     assert resize_result["num_new_tokens"] == output_tokenizer_len - input_tokenizer_len
+
+    output = _inference(
+        tokenizer=tokenizer, model=model, input_text=input_text, max_new_tokens=20
+    )
+    assert output is not None
+
+
+def test_special_tokens_before_and_after():
+    """Test if additional special tokens added do not replace existing tokens"""
+    input_text = INPUT_TEXT
+    tokenizer = AutoTokenizer.from_pretrained(CUSTOM_TOKENIZER_TINYLLAMA)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+    input_tokenizer_len = len(tokenizer.get_vocab())
+    addn_spl_tokens_before = tokenizer.special_tokens_map.get(
+        "additional_special_tokens"
+    )
+    assert (
+        len(addn_spl_tokens_before) > 0
+    ), "this test needs tokenizer special tokens to not be empty before testing"
+
+    special_tokens_dict = {"sep_token": "<SEP>", "pad_token": "<PAD>"}
+    addn_spl_tokens_added = ["<NotSeenTokenA>", "<NotSeenTokenB>", "<NotSeenTokenC>"]
+    special_tokens_dict["additional_special_tokens"] = addn_spl_tokens_added
+
+    resize_result = tokenizer_and_embedding_resize(
+        special_tokens_dict=special_tokens_dict,
+        tokenizer=tokenizer,
+        model=model,
+        multiple_of=1,
+    )
+
+    output_tokenizer_len = len(tokenizer.get_vocab())
+    addn_spl_tokens_before.extend(addn_spl_tokens_added)
+    expected_addn_special_tokens = addn_spl_tokens_before
+    expected_embedding_size = (
+        input_tokenizer_len + len(addn_spl_tokens_added) + 2
+    )
+    addn_spl_tokens_after = tokenizer.special_tokens_map.get(
+        "additional_special_tokens"
+    )
+
+    assert "<SEP>" in tokenizer.get_vocab()
+    assert "<PAD>" in tokenizer.get_vocab()
+    assert output_tokenizer_len == expected_embedding_size
+    assert resize_result["num_new_tokens"] == output_tokenizer_len - input_tokenizer_len
+    assert resize_result["new_embedding_size"] == expected_embedding_size
+
+    assert len(addn_spl_tokens_after) == len(
+        expected_addn_special_tokens
+    ), "length of the additional special tokens after must equal length before plus added tokens"
+
+    for tok in expected_addn_special_tokens:
+        assert (
+            tok in addn_spl_tokens_after
+        ), "additional special tokens added are not in tokenizer"
 
     output = _inference(
         tokenizer=tokenizer, model=model, input_text=input_text, max_new_tokens=20

--- a/tests/utils/test_embedding_resize.py
+++ b/tests/utils/test_embedding_resize.py
@@ -137,9 +137,7 @@ def test_special_tokens_before_and_after():
     output_tokenizer_len = len(tokenizer.get_vocab())
     addn_spl_tokens_before.extend(addn_spl_tokens_added)
     expected_addn_special_tokens = addn_spl_tokens_before
-    expected_embedding_size = (
-        input_tokenizer_len + len(addn_spl_tokens_added) + 2
-    )
+    expected_embedding_size = input_tokenizer_len + len(addn_spl_tokens_added) + 2
     addn_spl_tokens_after = tokenizer.special_tokens_map.get(
         "additional_special_tokens"
     )

--- a/tuning/utils/tokenizer_data_utils.py
+++ b/tuning/utils/tokenizer_data_utils.py
@@ -35,7 +35,9 @@ def tokenizer_and_embedding_resize(
     Return:
         dict: Metadata on number of added tokens
     """
-    num_new_tokens = tokenizer.add_special_tokens(special_tokens_dict)
+    num_new_tokens = tokenizer.add_special_tokens(
+        special_tokens_dict=special_tokens_dict, replace_additional_special_tokens=False
+    )
     embedding_size = int(multiple_of * math.ceil(len(tokenizer) / multiple_of))
     num_new_tokens = num_new_tokens + embedding_size - len(tokenizer)
     model.resize_token_embeddings(embedding_size)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

While adding additional special tokens it was noticed that the existing special tokens were being replaced and not present this was due to the fact that when calling [add_special_tokens](https://huggingface.co/docs/transformers/en/main_classes/tokenizer#transformers.PreTrainedTokenizerFast.add_special_tokens) the argument [replace_additional_special_tokens](https://huggingface.co/docs/transformers/en/main_classes/tokenizer#transformers.PreTrainedTokenizerFast.add_special_tokens.replace_additional_special_tokens) was being set to `True` by default and was causing the issue. 

*Note* the HF [documentation](https://github.com/huggingface/transformers/blob/0b057e66b52556da3a1cbc29e2a98c0784ea9c33/src/transformers/tokenization_utils_base.py#L932) of this function states 
```
   If `True`, the existing list of additional special tokens will be replaced by the list provided in
                `special_tokens_dict`. Otherwise, `self._special_tokens_map["additional_special_tokens"]` is just extended. In the former
                case, the tokens will NOT be removed from the tokenizer's full vocabulary - they are only being flagged
                as non-special tokens. Remember, this only affects which tokens are skipped during decoding, not the
                `added_tokens_encoder` and `added_tokens_decoder`. This means that the previous
                `additional_special_tokens` are still added tokens, and will not be split by the model.
```

Which means model accuracy and performance before this fix was not going to be affected but to fix the desired behavior this change sets `replace_additional_special_tokens=False`

Also adds a test case to check this internally.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass