### PR TITLE
fix:Remove use_cache and update ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,12 +916,12 @@ For information on supported dataset formats and how to tune a vision-language m
 
   ? May be supported, but not tested
 
-Model Name & Size  | Model Architecture | Full Finetuning |
--------------------- | ---------------- | --------------- |
-Llama 3.2-11B Vision  | MllamaForConditionalGeneration | ✅* |
-Llava 1.5-7B  | LlavaForConditionalGeneration | ✅* |
-Granite 3.1-2B Vision  | LlavaNextForConditionalGeneration | ✅* |
-Llava Mistral 1.6-7B  | LlavaNextForConditionalGeneration | ✅* |
+Model Name & Size  | Model Architecture | LoRA Tuning | Full Finetuning |
+-------------------- | ---------------- | --------------- | --------------- |
+Llama 3.2-11B Vision  | MllamaForConditionalGeneration | ✅* | ✅* | 
+Llava 1.5-7B  | LlavaForConditionalGeneration | ✅* | 🚫 | 
+Granite 3.1-2B Vision  | LlavaNextForConditionalGeneration | ✅* | 🚫 |
+Llava Mistral 1.6-7B  | LlavaNextForConditionalGeneration | ✅* | 🚫 |
 
 (*) - Supported with `fms-hf-tuning` v2.8.0 or later.
 

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -238,6 +238,15 @@ def train(
             if model_args.use_flash_attn
             else None,
         )
+        try:
+            if "use_cache" in model.language_model.config:
+                # avoid warning that use_cache is incompatible with gradient checkpointing
+                model.language_model.config.use_cache = (
+                    not train_args.gradient_checkpointing
+                )
+        except AttributeError as e:
+            # When the model doesn't have the use_cache attribute
+            logger.warning("Couldn't update use_cache for vision model: %s", e)
 
         processor = AutoProcessor.from_pretrained(model_args.model_name_or_path)
         tokenizer = processor.tokenizer

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -237,8 +237,6 @@ def train(
             attn_implementation="flash_attention_2"
             if model_args.use_flash_attn
             else None,
-            # avoid warning that use_cache is incompatible with gradient checkpointing
-            use_cache=(not train_args.gradient_checkpointing),
         )
 
         processor = AutoProcessor.from_pretrained(model_args.model_name_or_path)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Fix for supporting vision model tuning.

Changes:
- Removal of `use_cache` from `AutoModelForVision2Seq.from_pretrained` as vision model of type (`MllamaForConditionalGeneration`, `LlavaForConditionalGeneration` and `LlavaNextForConditionalGeneration`) doesn't support it.
- ReadMe update to include LoRA tuning support of vision models.

### Related issue number

Issue: https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1610

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass