### PR TITLE
ci: Install dnf-plugins-core in cuda-base stage

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -67,6 +67,8 @@ ENV CUDA_VERSION=12.1.0 \
     NV_CUDA_CUDART_VERSION=12.1.55-1 \
     NV_CUDA_COMPAT_VERSION=530.30.02-1
 
+RUN dnf install -y dnf-plugins-core && dnf clean all
+
 RUN dnf config-manager \
        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo \
     && dnf install -y \


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

We saw failure at this step:
```
> [cuda-base 1/1] RUN dnf config-manager        --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo     && dnf install -y         cuda-cudart-12-1-12.1.55-1         cuda-compat-12-1-530.30.02-1     && echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf     && echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf     && dnf clean all:

#0 0.219 No such command: config-manager. Please use /usr/bin/dnf --help

#0 0.219 It could be a DNF plugin command, try: "dnf install 'dnf-command(config-manager)'"
```

Unsure why this started failing when it was working before. But this PR will fix it by installing `dnf-plugins-core`

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass