### PR TITLE
fix: fastmoe lora `all-linear` excluding `router`

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -188,7 +188,11 @@ def train(
                 "modules when using `--fast_moe` with LoRA."
             )
         # If other common non-linear modules, raise warning
-        if peft_config is not None and hasattr(peft_config, "target_modules") and fast_moe_config.fast_moe is not None:
+        if (
+            peft_config is not None
+            and hasattr(peft_config, "target_modules")
+            and fast_moe_config.fast_moe is not None
+        ):
             logger.warning(
                 "You are running lora with the ScatterMoE plugin, please note that "
                 "passing target modules that are part of the moe module can cause unexpected "

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -181,7 +181,7 @@ def train(
                 "passing target modules that are part of the moe module can cause unexpected "
                 "behaviors and unsuccessful tuning while LoRA tuning with ScatterMoE. "
                 "For safe tuning, only pass linear modules such as those in the attn layer "
-                "(i.e. ['q_proj', 'v_proj', 'o_proj', 'k_proj'])"
+                "(i.e. ['q_proj', 'v_proj', 'o_proj', 'k_proj']) or pass 'all-linear'"
             )
 
     task_type = "CAUSAL_LM"

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -171,17 +171,19 @@ def train(
         fast_moe_config = None
     if fast_moe_config is not None:
         # If LoRA with ScatterMoE detected, raise warning
+        accepted_layers = ["all-linear"]
         if (
             peft_config is not None
             and hasattr(peft_config, "target_modules")
             and fast_moe_config.fast_moe is not None
+            and peft_config.target_modules != accepted_layers
         ):
             logger.warning(
                 "You are running lora with the ScatterMoE plugin, please note that "
                 "passing target modules that are part of the moe module can cause unexpected "
                 "behaviors and unsuccessful tuning while LoRA tuning with ScatterMoE. "
                 "For safe tuning, only pass linear modules such as those in the attn layer "
-                "(i.e. ['q_proj', 'v_proj', 'o_proj', 'k_proj']) or pass 'all-linear'"
+                "(i.e. ['q_proj', 'v_proj', 'o_proj', 'k_proj'])"
             )
 
     task_type = "CAUSAL_LM"

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -180,6 +180,7 @@ def train(
                 module in (peft_config.target_modules or [])
                 for module in restricted_modules
             )
+            and fast_moe_config.fast_moe is not None
         ):
             raise ValueError(
                 "`--fast_moe` with LoRA does not currently support `all-linear`, as "
@@ -187,7 +188,7 @@ def train(
                 "modules when using `--fast_moe` with LoRA."
             )
         # If other common non-linear modules, raise warning
-        if peft_config is not None and hasattr(peft_config, "target_modules"):
+        if peft_config is not None and hasattr(peft_config, "target_modules") and fast_moe_config.fast_moe is not None:
             logger.warning(
                 "You are running lora with the ScatterMoE plugin, please note that "
                 "passing target modules that are part of the moe module can cause unexpected "

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -170,29 +170,14 @@ def train(
     if fast_moe_config is not None and fast_moe_config.fast_moe is None:
         fast_moe_config = None
     if fast_moe_config is not None:
-        # Checking for unsupported modules with Scatter MoE for LoRA
-        # Only raise an error for `all-linear`
-        restricted_modules = ["all-linear"]
-        if (
-            peft_config is not None
-            and hasattr(peft_config, "target_modules")
-            and any(
-                module in (peft_config.target_modules or [])
-                for module in restricted_modules
-            )
-            and fast_moe_config.fast_moe is not None
-        ):
-            raise ValueError(
-                "`--fast_moe` with LoRA does not currently support `all-linear`, as "
-                "target modules at this time. Please explicitly specify target "
-                "modules when using `--fast_moe` with LoRA."
-            )
-        # If other common non-linear modules, raise warning
+        # If LoRA with ScatterMoE detected, raise warning
+        # and exclude router module
         if (
             peft_config is not None
             and hasattr(peft_config, "target_modules")
             and fast_moe_config.fast_moe is not None
         ):
+            peft_config.exclude_modules = "router"
             logger.warning(
                 "You are running lora with the ScatterMoE plugin, please note that "
                 "passing target modules that are part of the moe module can cause unexpected "

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -171,13 +171,11 @@ def train(
         fast_moe_config = None
     if fast_moe_config is not None:
         # If LoRA with ScatterMoE detected, raise warning
-        # and exclude router module
         if (
             peft_config is not None
             and hasattr(peft_config, "target_modules")
             and fast_moe_config.fast_moe is not None
         ):
-            peft_config.exclude_modules = "router"
             logger.warning(
                 "You are running lora with the ScatterMoE plugin, please note that "
                 "passing target modules that are part of the moe module can cause unexpected "


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Goes with [#142](https://github.com/foundation-model-stack/fms-acceleration/pull/142) to allow `all-linear` for ScatterMoE. Without the fms-acceleration PR to filter it out, router was included since it is a linear layer, but will not be able to run vLLM inference if it is included. With the fms-acceleration PR, `all-linear` can be passed because `router` will always be filtered out
<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass