### PR TITLE
fix: saving logic for alora

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -762,6 +762,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
             "Simply put, the theory of relativity states that \n" + invocation_string,
             max_new_tokens=50,
         )
+        print(output_inference)
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that \n" in output_inference
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -762,7 +762,7 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
             "Simply put, the theory of relativity states that \n" + invocation_string,
             max_new_tokens=50,
         )
-        print(output_inference)
+
         assert len(output_inference) > 0
         assert "Simply put, the theory of relativity states that \n" in output_inference
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -735,15 +735,13 @@ def test_run_causallm_alora_and_inference(request, target_modules, expected):
     with tempfile.TemporaryDirectory() as tempdir:
         train_args = copy.deepcopy(TRAIN_ALORA_ARGS)
         train_args.output_dir = tempdir
+        train_args.save_strategy = "steps"
         base_alora_args = copy.deepcopy(PEFT_ALORA_ARGS)
 
         if "default" not in request._pyfuncitem.callspec.id:
             base_alora_args.target_modules = target_modules
 
-        trainer, _ = sft_trainer.train(
-            MODEL_ARGS, DATA_ARGS, train_args, base_alora_args
-        )
-        sft_trainer.save(train_args.output_dir + "/checkpoint-1", trainer)
+        sft_trainer.train(MODEL_ARGS, DATA_ARGS, train_args, base_alora_args)
 
         # validate lora tuning configs
         _validate_training(tempdir)

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -491,7 +491,7 @@ def train(
     additional_metadata = {}
     additional_metadata["added_tokens_info"] = added_tokens_dict
 
-    if USE_ALORA and ALORA_SAVE_END and train_args.save_model_dir is not None:
+    if USE_ALORA and ALORA_SAVE_END and train_args.save_model_dir is None:
         # saving was requested, saving at end (but don't save twice)
         save(
             os.path.join(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -491,7 +491,7 @@ def train(
     additional_metadata = {}
     additional_metadata["added_tokens_info"] = added_tokens_dict
 
-    if USE_ALORA and ALORA_SAVE_END and training_args.save_model_dir is not None:
+    if USE_ALORA and ALORA_SAVE_END and train_args.save_model_dir is not None:
         # saving was requested, saving at end (but don't save twice)
         save(
             os.path.join(

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -493,7 +493,12 @@ def train(
 
     if USE_ALORA and ALORA_SAVE_END and training_args.save_model_dir is not None:
         # saving was requested, saving at end (but don't save twice)
-        save(training_args.output_dir + "/checkpoint-1", trainer)
+        save(
+            os.path.join(
+                training_args.output_dir, f"checkpoint-{trainer.state.global_step}"
+            ),
+            trainer,
+        )
 
     return trainer, additional_metadata
 


### PR DESCRIPTION
Irrespective of the save_strategy, we only save once at the end of the training as per @kgreenewald. However, in such case we dont need save_model_dir to be defined and model is saved at the output_dir and global step checkpoint dir. In case save_model_dir is defined then the model is saved at the save_model_dir location. PR also removes hard coding of the checkpoint dir. 