### PR TITLE
fix: Update flash-attn version constraint to <2.8 for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["wheel>=0.42.0,<1.0", "packaging>=23.2,<25", "ninja>=1.11.1.1,<2.0", "scikit-learn>=1.0, <2.0", "boto3>=1.34, <2.0"]
-flash-attn = ["flash-attn>=2.5.3,<3.0"]
+flash-attn = ["flash-attn>=2.5.3,<2.8"]
 aim = ["aim>=3.19.0,<4.0"]
 mlflow = ["mlflow"]
 fms-accel = ["fms-acceleration>=0.6"]


### PR DESCRIPTION
### Description of the change


This PR resolves training failures caused by an incompatibility with the newly released `flash-attn` version `2.8.0.post2`.

#### Details

- The update to `flash-attn==2.8.0.post2` introduces breaking changes incompatible with our current training setup.

- To address this, the version constraint for flash-attn has been updated to exclude versions >=2.8.

<img width="1389" alt="Screenshot 2025-06-24 at 1 48 17 PM" src="https://github.com/user-attachments/assets/bc5bdc27-8e90-470c-9e56-f1e2fba6f6d1" />

#### Related Issue
https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1842