### PR TITLE
fix: Remove the additional closing curly bracket

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -184,7 +184,7 @@ RUN if [[ "${ENABLE_MLFLOW}" == "true" ]]; then \
 RUN if [[ "${ENABLE_SCANNER}" == "true" ]]; then \
         python -m pip install --user "$(head bdist_name)[scanner-dev]"; \
     fi
-RUN if [[ "${ENABLE_CLEARML}}" == "true" ]]; then \
+RUN if [[ "${ENABLE_CLEARML}" == "true" ]]; then \
         python -m pip install --user "$(head bdist_name)[clearml]"; \
     fi
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Due to an additional `}` with `${ENABLE_CLEARML}`, the clearml package does not getting installed even if `ENABLE_CLEARML` is passed when building the image using the Dockerfile.

<img width="1563" alt="Screenshot 2025-06-25 at 12 29 56 PM" src="https://github.com/user-attachments/assets/98d2a413-b718-40ec-a0c2-3ba46c0b134f" />

This PR removes the additional closing curly bracket to fix this bug.