### PR TITLE
fix: Decouple offline data processing from collators

### DIFF
--- a/tests/data/test_data_preprocessing.py
+++ b/tests/data/test_data_preprocessing.py
@@ -81,9 +81,9 @@ from tuning.data.data_config import (
 from tuning.data.data_preprocessing_utils import get_data_collator
 from tuning.data.data_processors import DataPreProcessor, get_datapreprocessor
 from tuning.data.setup_dataprocessor import (
-    _process_dataconfig_file,
     is_pretokenized_dataset,
     process_dataargs,
+    process_dataconfig_file,
 )
 from tuning.data.utils import try_concatenate_datasets
 
@@ -769,7 +769,7 @@ def test_process_dataconfig_file_with_streaming(data_config_path, data_path):
         output_dir="tmp",  # Not needed but positional
     )
 
-    (train_set, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+    (train_set, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
     assert isinstance(train_set, IterableDataset)
     if datasets_name == "text_dataset_input_output_masking":
         column_names = set(["input_ids", "attention_mask", "labels"])
@@ -873,7 +873,7 @@ def test_process_dataconfig_file_with_streaming_no_max_steps_errors(
     )
 
     with pytest.raises(ValueError):
-        (_, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+        (_, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
 
 
 @pytest.mark.parametrize(
@@ -935,7 +935,7 @@ def test_process_dataconfig_file_with_streaming_and_multipack_throws_error(
     is_multipack = attention_and_distributed_packing_config.is_multipack
 
     with pytest.raises(ValueError):
-        (_, _, _) = _process_dataconfig_file(
+        (_, _, _) = process_dataconfig_file(
             data_args, TRAIN_ARGS, tokenizer, is_multipack=is_multipack
         )
 
@@ -1014,7 +1014,7 @@ def test_process_dataconfig_file(data_config_path, data_path):
         output_dir="tmp",  # Not needed but positional
     )
 
-    (train_set, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+    (train_set, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
     assert isinstance(train_set, Dataset)
     if datasets_name == "text_dataset_input_output_masking":
         column_names = set(["input_ids", "attention_mask", "labels"])
@@ -1104,7 +1104,7 @@ def test_process_datahandler_eos_token(data_config_path, data_path, add_eos_toke
         output_dir="tmp",  # Not needed but positional
     )
 
-    (train_set, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+    (train_set, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
     assert isinstance(train_set, Dataset)
     if datasets_name == "text_dataset_input_output_masking":
         column_names = set(["input_ids", "attention_mask", "labels"])
@@ -1255,7 +1255,7 @@ def test_process_dataconfig_multiple_files(data_config_path, data_path_list):
         output_dir="tmp",  # Not needed but positional
     )
 
-    (train_set, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+    (train_set, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
     assert isinstance(train_set, Dataset)
     if datasets_name == "text_dataset_input_output_masking":
         column_names = set(["input_ids", "attention_mask", "labels"])
@@ -1327,7 +1327,7 @@ def test_process_dataconfig_multiple_files_folders_with_globbing(
         output_dir="tmp",  # Not needed but positional
     )
 
-    (train_set, _, _) = _process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
+    (train_set, _, _) = process_dataconfig_file(data_args, TRAIN_ARGS, tokenizer)
     assert isinstance(train_set, Dataset)
     assert set(["input_ids", "attention_mask", "labels"]).issubset(
         set(train_set.column_names)


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
offline script can now work with just a data config and no need to pass things like `response_template`.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass