### PR TITLE
feat: add error handling for split dataset feat

### DIFF
--- a/tests/data/test_data_preprocessing.py
+++ b/tests/data/test_data_preprocessing.py
@@ -774,6 +774,10 @@ def test_process_dataconfig_file_with_streaming(data_config_path, data_path):
         assert set(["input_ids", "labels"]).issubset(set(train_set.column_names))
     elif datasets_name == "apply_custom_data_template":
         assert formatted_dataset_field in set(train_set.column_names)
+    with pytest.raises(ValueError):
+        _ = process_dataconfig_file(
+            data_args, TRAIN_ARGS, tokenizer, is_padding_free=True
+        )
 
 
 def test_concatenate_dict_with_multi_keys():
@@ -1453,6 +1457,11 @@ def test_process_dataconfig_multiple_datasets_datafiles_sampling(
     if eval_set:
         assert set(["input_ids", "attention_mask", "labels"]).issubset(
             set(eval_set.column_names)
+        )
+    TRAIN_ARGS.eval_strategy = "epoch"
+    with pytest.raises(ValueError):
+        train_set, eval_set, _, _, _, _ = process_dataargs(
+            data_args=data_args, tokenizer=tokenizer, train_args=TRAIN_ARGS
         )
 
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Added error handling for the dataset splitting and streaming configurations in the `process_dataargs` flow. Specifically:
- Raise `ValueError` if `eval_strategy` is set to anything other than `"no"` but no evaluation dataset is provided.
- Raise `ValueError` if `padding_free` is enabled while streaming is also enabled, which is not supported.

### Related issue number

<!-- For example: "Closes #1234" -->
N/A

### How to verify the PR

- Try setting `eval_strategy="epoch"` or `"steps"` without providing an eval set → should raise an error.
- Try enabling `padding_free=huggingface` while using streaming dataset → should raise an error.

### Was the PR tested

- [x] I have added ≥1 unit test for each new case I handled.
- [x] I have ensured all unit tests pass.

added screenshot for Error handling when train_set is None using the attached dataconfig:
```
dataprocessor:
    type: default
    sampling_stopping_strategy: first_exhausted
    seed: 66
datasets:
  - name: dataset_1
    split:
      train: 0.0
      validation: 1.0
    sampling: 0.3
    data_paths:
      - "FILE_PATH"
    data_handlers:
      - name: tokenize_and_apply_input_masking
        arguments:
          remove_columns: all
          batched: false
          fn_kwargs:
            input_column_name: input
            output_column_name: output
  - name: dataset_2
    split:
      train: 0.0
      validation: 1.0
    sampling: 0.4
    data_paths:
      - "FILE_PATH"
    data_handlers:
      - name: tokenize_and_apply_input_masking
        arguments:
          remove_columns: all
          batched: false
          fn_kwargs:
            input_column_name: input
            output_column_name: output
  - name: dataset_3
    split:
      train: 0.0
      validation: 1.0
    sampling: 0.3
    data_paths:
      - "FILE_PATH"
    data_handlers:
      - name: tokenize_and_apply_input_masking
        arguments:
          remove_columns: all
          batched: false
          fn_kwargs:
            input_column_name: input
            output_column_name: output
```
<img width="2656" height="1314" alt="image" src="https://github.com/user-attachments/assets/7bcbcaaa-96e2-4d2a-90a7-37e891293114" />
