### PR TITLE
fix: change logging level to info and print flat arguments

### DIFF
--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -36,9 +36,9 @@ def test_set_log_level_for_logger_default():
 
     with mock.patch.dict(os.environ, {}, clear=True):
         train_args = copy.deepcopy(TRAIN_ARGS)
-        training_args, logger = set_log_level(train_args)
-        assert logger.getEffectiveLevel() == logging.WARNING
-        assert training_args.log_level == "passive"
+        logger, log_level = set_log_level(level=train_args.log_level)
+        assert logger.getEffectiveLevel() == logging.INFO
+        assert log_level == "info"
 
 
 def test_set_log_level_for_logger_with_env_var():
@@ -48,10 +48,10 @@ def test_set_log_level_for_logger_with_env_var():
     """
 
     with mock.patch.dict(os.environ, {"LOG_LEVEL": "info"}, clear=True):
-        train_args_env = copy.deepcopy(TRAIN_ARGS)
-        training_args, logger = set_log_level(train_args_env)
+        train_args = copy.deepcopy(TRAIN_ARGS)
+        logger, log_level = set_log_level(level=train_args.log_level)
         assert logger.getEffectiveLevel() == logging.INFO
-        assert training_args.log_level == "info"
+        assert log_level == "info"
 
 
 def test_set_log_level_for_logger_with_set_verbosity_and_cli():
@@ -64,9 +64,9 @@ def test_set_log_level_for_logger_with_set_verbosity_and_cli():
     with mock.patch.dict(os.environ, {"TRANSFORMERS_VERBOSITY": "info"}, clear=True):
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.log_level = "error"
-        training_args, logger = set_log_level(train_args)
+        logger, log_level = set_log_level(level=train_args.log_level)
         assert logger.getEffectiveLevel() == logging.ERROR
-        assert training_args.log_level == "error"
+        assert log_level == "error"
 
 
 def test_set_log_level_for_logger_with_env_var_and_cli():
@@ -79,6 +79,6 @@ def test_set_log_level_for_logger_with_env_var_and_cli():
     with mock.patch.dict(os.environ, {"LOG_LEVEL": "info"}, clear=True):
         train_args = copy.deepcopy(TRAIN_ARGS)
         train_args.log_level = "error"
-        training_args, logger = set_log_level(train_args)
+        logger, log_level = set_log_level(level=train_args.log_level)
         assert logger.getEffectiveLevel() == logging.ERROR
-        assert training_args.log_level == "error"
+        assert log_level == "error"

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -63,7 +63,7 @@ from tuning.utils.error_logging import (
     USER_ERROR_EXIT_CODE,
     write_termination_log,
 )
-from tuning.utils.logging import set_log_level
+from tuning.utils.logging import pretty_print_args, set_log_level
 
 
 def train(
@@ -120,7 +120,9 @@ def train(
         Tuple: Instance of SFTTrainer , some metadata in a dict
             Metadata contains information on number of added tokens while tuning.
     """
-    train_args, logger = set_log_level(train_args, "sft_trainer_train")
+    logger, train_args.log_level = set_log_level(
+        logger_name="sft_trainer_train", level=train_args.log_level
+    )
     USE_ALORA = False
     try:
         # Third Party
@@ -529,7 +531,6 @@ def get_parser():
         choices=["pt", "lora", "alora", None, "none"],
         default="none",
     )
-
     parser.add_argument(
         "--exp_metadata",
         type=str,
@@ -603,7 +604,6 @@ def parse_arguments(parser, json_config=None):
                 raise ValueError(
                     "invocation_string is not passed required for aLoRA usage"
                 )
-
     else:
         (
             model_args,
@@ -687,26 +687,28 @@ def main():
         ) = parse_arguments(parser, job_config)
 
         # Function to set log level for python native logger and transformers training logger
-        training_args, logger = set_log_level(training_args, __name__)
-
-        logger.info(
-            "Flat arguments parsed: \
-            model_args %s, data_args %s, training_args %s, trainer_controller_args %s, \
-            tune_config %s, quantized_lora_config %s, fusedops_kernels_config %s, \
-            attention_and_distributed_packing_config, %s,\
-            fast_moe_config %s, tracker_config %s, exp_metadata %s",
-            model_args,
-            data_args,
-            training_args,
-            trainer_controller_args,
-            tune_config,
-            quantized_lora_config,
-            fusedops_kernels_config,
-            attention_and_distributed_packing_config,
-            fast_moe_config,
-            tracker_configs,
-            exp_metadata,
+        logger, training_args.log_level = set_log_level(
+            logger_name=__name__, level=training_args.log_level
         )
+
+        logger.info("fms-hf-tuning execution start")
+        args_dump = pretty_print_args(
+            {
+                "Model Arguments": model_args,
+                "Data Arguments": data_args,
+                "Training Arguments": training_args,
+                "Tune Config": tune_config,
+                "QLoRA Config": quantized_lora_config,
+                "Tracker Config": tracker_configs,
+                "AADP (fms-acceleration) Config": attention_and_distributed_packing_config,
+                "Fused Ops Kernels Config": fusedops_kernels_config,
+                "Fast MoE Config": fast_moe_config,
+                "Trainer Controller Config": trainer_controller_args,
+                "Extra Metadata": exp_metadata,
+            }
+        )
+        logger.info(args_dump)
+
     except Exception as e:  # pylint: disable=broad-except
         logger.error(traceback.format_exc())
         write_termination_log(

--- a/tuning/utils/logging.py
+++ b/tuning/utils/logging.py
@@ -13,24 +13,33 @@
 # limitations under the License.
 
 # Standard
+from typing import Dict
 import logging
 import os
 
+# Third Party
+from accelerate.state import PartialState
+import datasets
+import transformers
 
-def set_log_level(train_args, logger_name=None):
+DEFAULT_LOG_LEVEL_MAIN = "INFO"
+DEFAULT_LOG_LEVEL_WORKERS = "WARNING"
+
+
+def set_log_level(logger_name="fms-hf-tuning", level=None):
     """Set log level of python native logger and TF logger via argument from CLI or env variable.
 
     Args:
-        train_args
-            Training arguments for training model.
         logger_name
             Logger name with which the logger is instantiated.
+        level
+            Requested level of the logger
 
     Returns:
-        train_args
-            Updated training arguments for training model.
         train_logger
             Logger with updated effective log level
+        level
+            Level of the logger initialized
     """
 
     # Clear any existing handlers if necessary
@@ -39,26 +48,58 @@ def set_log_level(train_args, logger_name=None):
 
     # Configure Python native logger and transformers log level
     # If CLI arg is passed, assign same log level to python native logger
-    log_level = "WARNING"
-    if train_args.log_level != "passive":
-        log_level = train_args.log_level
-
-    # If CLI arg not is passed and env var LOG_LEVEL is set,
-    # assign same log level to both logger
+    lowest_log_level = DEFAULT_LOG_LEVEL_MAIN
+    if level != "passive":
+        lowest_log_level = level
     elif os.environ.get("LOG_LEVEL"):
-        log_level = os.environ.get("LOG_LEVEL")
-        train_args.log_level = (
-            log_level.lower()
+        # If CLI arg not is passed and env var LOG_LEVEL is set,
+        # assign same log level to both logger
+        lowest_log_level = (
+            os.environ.get("LOG_LEVEL").lower()
             if not os.environ.get("TRANSFORMERS_VERBOSITY")
             else os.environ.get("TRANSFORMERS_VERBOSITY")
         )
 
+    state = PartialState()
+    rank = state.process_index
+
+    log_on_all = os.environ.get("LOG_ON_ALL_PROCESSES")
+    if log_on_all:
+        log_level = lowest_log_level or DEFAULT_LOG_LEVEL_MAIN
+    else:
+        if state.is_local_main_process:
+            log_level = lowest_log_level or DEFAULT_LOG_LEVEL_MAIN
+            datasets.utils.logging.set_verbosity_warning()
+            transformers.utils.logging.set_verbosity_info()
+        else:
+            log_level = DEFAULT_LOG_LEVEL_WORKERS
+            datasets.utils.logging.set_verbosity_error()
+            transformers.utils.logging.set_verbosity_error()
+
+    log_format = f"Rank-{rank} [%(levelname)s]:%(filename)s:%(funcName)s: %(message)s"
+
     logging.basicConfig(
-        format="%(levelname)s:%(filename)s:%(message)s", level=log_level.upper()
+        format=log_format,
+        level=log_level.upper(),
     )
 
     if logger_name:
         train_logger = logging.getLogger(logger_name)
     else:
         train_logger = logging.getLogger()
-    return train_args, train_logger
+
+    return train_logger, log_level.lower()
+
+
+def pretty_print_args(args: Dict):
+    dump = "\n========================= Flat Arguments =========================\n"
+    for name, arg in args.items():
+        if arg:
+            dump += f"---------------------------- {name} -----------------------\n"
+            if hasattr(arg, "__dict__"):
+                arg = vars(arg)
+            max_len = max(len(k) for k in arg.keys())
+            for k, v in sorted(arg.items()):
+                dump += f"  {k:<{max_len}} : {v}\n"
+    dump += "========================= Arguments Done =========================\n"
+    return dump


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

<!-- Please summarize the changes -->

fms-hf-tuning logs have been very problematic in finding an issue due to default level of `warning` 
This PR changes the level to warning. Changes the logging API slightly to incorporate rank based logging to not clobber the logs with all node logs.

Finally adds a function to nicely print the arguments to console.

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

```
(.python3.12-venv) ➜  fms-hf-tuning git:(main) rm -rf /tmp/test-train && python3 -m tuning.sft_trainer \
--model_name_or_path "Maykeye/TinyLLama-v0" \
--output_dir /tmp/test-train/ \
--gradient_accumulation_steps 1 \                                                                                                               
--torch_dtype bfloat16 \                                                                                       
--learning_rate 2e-06 \                              
--max_seq_length 2048 \
--logging_strategy steps \
--save_steps 100 \
--use_flash_attn False \
--logging_steps 1 \
--training_data_path '/Volumes/Projects/Projects/ai-platform-engg/fms-hf-tuning/tests/artifacts/testdata/jsonl/twitter_complaints_small.jsonl' \
--data_formatter_template "### Input: {{ element['Tweet text'] }} \n\n ### Response: {{ element['output'] }}" \
--response_template "\n### Label:"                                                                                              
Rank-0 [INFO]:sft_trainer.py:main: fms-hf-tuning execution start
Rank-0 [INFO]:sft_trainer.py:main: 
========================= Flat Arguments =========================
---------------------------- Model Arguments -----------------------
  embedding_size_multiple_of : 1
  model_name_or_path         : Maykeye/TinyLLama-v0
  tokenizer_name_or_path     : None
  torch_dtype                : bfloat16
  use_flash_attn             : False
---------------------------- Data Arguments -----------------------
  add_special_tokens         : None
  chat_template              : None
  data_config_path           : None
  data_formatter_template    : ### Input: {{ element['Tweet text'] }} 

 ### Response: {{ element['output'] }}
  dataset_conversation_field : None
  dataset_image_field        : None
  dataset_text_field         : None
  do_dataprocessing_only     : False
  instruction_template       : None
  num_eval_dataset_shards    : 1
  num_train_dataset_shards   : 1
  response_template          : 
### Label:
  training_data_path         : /Volumes/Projects/Projects/ai-platform-engg/fms-hf-tuning/tests/artifacts/testdata/jsonl/twitter_complaints_small.jsonl
  validation_data_path       : None
---------------------------- Training Arguments -----------------------
  __cached__setup_devices                 : mps
  _n_gpu                                  : 1
  accelerator_config                      : AcceleratorConfig(split_batches=False, dispatch_batches=None, even_batches=True, use_seedable_sampler=True, non_blocking=False, gradient_accumulation_kwargs=None, use_configured_state=False)
  adafactor                               : False
  adam_beta1                              : 0.9
  adam_beta2                              : 0.999
  adam_epsilon                            : 1e-08
  auto_find_batch_size                    : False
  average_tokens_across_devices           : False
  batch_eval_metrics                      : False
  bf16                                    : False
  bf16_full_eval                          : False
  cache_dir                               : None
  data_seed                               : None
  dataloader_drop_last                    : False
  dataloader_num_workers                  : 0
  dataloader_persistent_workers           : False
  dataloader_pin_memory                   : True
  dataloader_prefetch_factor              : None
  ddp_backend                             : None
  ddp_broadcast_buffers                   : None
  ddp_bucket_cap_mb                       : None
  ddp_find_unused_parameters              : None
  ddp_timeout                             : 1800
  debug                                   : []
  deepspeed                               : None
  deepspeed_plugin                        : None
  disable_tqdm                            : False
  dispatch_batches                        : None
  distributed_state                       : Distributed environment: DistributedType.NO
Num processes: 1
Process index: 0
Local process index: 0
Device: mps

  do_eval                                 : False
  do_predict                              : False
  do_train                                : False
  enable_reduce_loss_sum                  : False
  eval_accumulation_steps                 : None
  eval_delay                              : 0
  eval_do_concat_batches                  : True
  eval_on_start                           : False
  eval_steps                              : None
  eval_strategy                           : IntervalStrategy.NO
  eval_use_gather_object                  : False
  evaluation_strategy                     : None
  fp16                                    : False
  fp16_backend                            : auto
  fp16_full_eval                          : False
  fp16_opt_level                          : O1
  fsdp                                    : []
  fsdp_config                             : {'min_num_params': 0, 'xla': False, 'xla_fsdp_v2': False, 'xla_fsdp_grad_ckpt': False}
  fsdp_min_num_params                     : 0
  fsdp_transformer_layer_cls_to_wrap      : None
  full_determinism                        : False
  gradient_accumulation_steps             : 1
  gradient_checkpointing                  : False
  gradient_checkpointing_kwargs           : None
  greater_is_better                       : None
  group_by_length                         : False
  half_precision_backend                  : auto
  hub_always_push                         : False
  hub_model_id                            : None
  hub_private_repo                        : None
  hub_strategy                            : HubStrategy.EVERY_SAVE
  hub_token                               : None
  ignore_data_skip                        : False
  include_for_metrics                     : []
  include_inputs_for_metrics              : False
  include_num_input_tokens_seen           : False
  include_tokens_per_second               : False
  jit_mode_eval                           : False
  label_names                             : None
  label_smoothing_factor                  : 0.0
  learning_rate                           : 2e-06
  length_column_name                      : length
  load_best_model_at_end                  : False
  local_rank                              : 0
  log_level                               : info
  log_level_replica                       : warning
  log_on_each_node                        : True
  logging_dir                             : /tmp/test-train/runs/Jul11_19-58-18_Mac
  logging_first_step                      : False
  logging_nan_inf_filter                  : True
  logging_steps                           : 1.0
  logging_strategy                        : IntervalStrategy.STEPS
  lr_scheduler_kwargs                     : {}
  lr_scheduler_type                       : SchedulerType.LINEAR
  max_grad_norm                           : 1.0
  max_seq_length                          : 2048
  max_steps                               : -1
  metric_for_best_model                   : None
  mp_parameters                           : 
  neftune_noise_alpha                     : None
  no_cuda                                 : False
  num_train_epochs                        : 3.0
  optim                                   : OptimizerNames.ADAMW_TORCH
  optim_args                              : None
  optim_target_modules                    : None
  output_dir                              : /tmp/test-train/
  overwrite_output_dir                    : False
  packing                                 : False
  past_index                              : -1
  per_device_eval_batch_size              : 8
  per_device_train_batch_size             : 8
  per_gpu_eval_batch_size                 : None
  per_gpu_train_batch_size                : None
  prediction_loss_only                    : False
  push_to_hub                             : False
  push_to_hub_model_id                    : None
  push_to_hub_organization                : None
  push_to_hub_token                       : None
  ray_scope                               : last
  remove_unused_columns                   : True
  report_to                               : []
  restore_callback_states_from_checkpoint : False
  resume_from_checkpoint                  : None
  run_name                                : /tmp/test-train/
  save_model_dir                          : None
  save_on_each_node                       : False
  save_only_model                         : False
  save_safetensors                        : True
  save_steps                              : 100.0
  save_strategy                           : SaveStrategy.EPOCH
  save_total_limit                        : None
  seed                                    : 42
  skip_memory_metrics                     : True
  split_batches                           : None
  tf32                                    : None
  torch_compile                           : False
  torch_compile_backend                   : None
  torch_compile_mode                      : None
  torch_empty_cache_steps                 : None
  torchdynamo                             : None
  tp_size                                 : 0
  tpu_metrics_debug                       : False
  tpu_num_cores                           : None
  trackers                                : ['file_logger']
  use_cpu                                 : False
  use_ipex                                : False
  use_legacy_prediction_loop              : False
  use_liger_kernel                        : False
  use_mps_device                          : False
  warmup_ratio                            : 0.0
  warmup_steps                            : 0
  weight_decay                            : 0.0
---------------------------- QLoRA Config -----------------------
  auto_gptq : None
  bnb_qlora : None
---------------------------- Tracker Config -----------------------
  aim_experiment          : fms-hf-tuning
  aim_remote_server_ip    : None
  aim_remote_server_port  : None
  aim_repo                : None
  aim_url                 : None
  clearml_project         : fms-hf-tuning
  clearml_task            : SFTTrainer
  experiment              : fms-hf-tuning
  mlflow_experiment       : fms-hf-tuning
  mlflow_tracking_uri     : None
  run_uri_export_path     : None
  scanner_output_filename : scanner_output.json
  training_logs_filename  : training_logs.jsonl
---------------------------- AADP (fms-acceleration) Config -----------------------
  multipack    : None
  padding_free : None
---------------------------- Fused Ops Kernels Config -----------------------
  fast_kernels : None
  fused_lora   : None
---------------------------- Fast MoE Config -----------------------
  fast_moe : None
---------------------------- Trainer Controller Config -----------------------
  trainer_controller_config_file : None
========================= Arguments Done =========================

Rank-0 [INFO]:sft_trainer.py:main: using the output directory at /tmp/test-train/
Rank-0 [INFO]:tracker_factory.py:_register_trackers: Registering trackers
Rank-0 [INFO]:tracker_factory.py:_register_aim_tracker: Registered aimstack tracker
Rank-0 [INFO]:tracker_factory.py:_register_file_logging_tracker: Registered file logging tracker
Rank-0 [INFO]:tracker_factory.py:_register_mlflow_tracker: Registered mlflow tracker
Rank-0 [INFO]:tracker_factory.py:_register_hf_resource_scanner_tracker: Registered HFResourceScanner tracker
Rank-0 [INFO]:tracker_factory.py:_register_clearml_tracker: Registered clearml tracker
loading configuration file config.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/config.json
Model config LlamaConfig {
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 1,
  "eos_token_id": 2,
  "head_dim": 4,
  "hidden_act": "silu",
  "hidden_size": 64,
  "initializer_range": 0.02,
  "intermediate_size": 256,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 16,
  "num_hidden_layers": 8,
  "num_key_value_heads": 16,
  "pad_token_id": 0,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.50.3",
  "use_cache": true,
  "vocab_size": 32000
}

loading configuration file config.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/config.json
Model config LlamaConfig {
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 1,
  "eos_token_id": 2,
  "head_dim": 4,
  "hidden_act": "silu",
  "hidden_size": 64,
  "initializer_range": 0.02,
  "intermediate_size": 256,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 16,
  "num_hidden_layers": 8,
  "num_key_value_heads": 16,
  "pad_token_id": 0,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.50.3",
  "use_cache": true,
  "vocab_size": 32000
}

loading weights file model.safetensors from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/model.safetensors
Instantiating LlamaForCausalLM model under default dtype torch.bfloat16.
Generate config GenerationConfig {
  "bos_token_id": 1,
  "eos_token_id": 2,
  "pad_token_id": 0
}

All model checkpoint weights were used when initializing LlamaForCausalLM.

All the weights of LlamaForCausalLM were initialized from the model checkpoint at Maykeye/TinyLLama-v0.
If your task is similar to the task the model of the checkpoint was trained on, you can already use LlamaForCausalLM for predictions without further training.
loading configuration file generation_config.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/generation_config.json
Generate config GenerationConfig {
  "bos_token_id": 1,
  "eos_token_id": 2,
  "pad_token_id": 0
}

loading file tokenizer.model from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/tokenizer.model
loading file tokenizer.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/tokenizer.json
loading file added_tokens.json from cache at None
loading file special_tokens_map.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/special_tokens_map.json
loading file tokenizer_config.json from cache at /Users/dushyantbehl/.cache/huggingface/hub/models--Maykeye--TinyLLama-v0/snapshots/298338802ab94432b917bcce11382aa151aee50f/tokenizer_config.json
loading file chat_template.jinja from cache at None
Rank-0 [WARNING]:tokenizer_utils.py:get_special_tokens_dict: PAD token set to default, missing in tokenizer
You are resizing the embedding layer without providing a `pad_to_multiple_of` parameter. This means that the new embedding dimension will be 32001. This might induce some performance reduction as *Tensor Cores* will not be available. For more details about this, or help on choosing the correct value for resizing, refer to this guide: https://docs.nvidia.com/deeplearning/performance/dl-performance-matrix-multiplication/index.html#requirements-tc
The new embeddings will be initialized from a multivariate normal distribution that has old embeddings' mean and covariance. As described in this article: https://nlp.stanford.edu/~johnhew/vocab-expansion.html. To disable this, use `mean_resizing=False`
The new lm_head weights will be initialized from a multivariate normal distribution that has old embeddings' mean and covariance. As described in this article: https://nlp.stanford.edu/~johnhew/vocab-expansion.html. To disable this, use `mean_resizing=False`
Rank-0 [INFO]:sft_trainer.py:train: Packing is set to False 
Rank-0 [INFO]:setup_dataprocessor.py:process_dataargs: Max sequence length is 2048
Rank-0 [INFO]:data_processors.py:_process_dataset_configs: Sampling is not specified; if multiple datasets are provided, the given datasets will be concatenated.
Rank-0 [INFO]:data_processors.py:_process_dataset_configs: Starting DataPreProcessor...
Rank-0 [INFO]:data_processors.py:_process_dataset_configs: Loading training_data
Rank-0 [INFO]:data_processors.py:_process_dataset_configs: Loaded raw dataset : DatasetDict({
    train: Dataset({
        features: ['Tweet text', 'ID', 'Label', 'text_label', 'output'],
        num_rows: 10
    })
})
Rank-0 [INFO]:data_processors.py:_execute_data_handlers: setting num_proc to 16
Rank-0 [INFO]:data_processors.py:_execute_data_handlers: Applying Handler: DataHandler(op=apply_custom_jinja_template, handler_type=MAP, allows_batching=False) Args: {'fn_kwargs': {'formatted_text_column_name': 'text', 'template': "### Input: {{ element['Tweet text'] }} \n\n ### Response: {{ element['output'] }}"}, 'batched': False, 'remove_columns': 'all', 'num_proc': 16}
num_proc must be <= 10. Reducing num_proc to 10 for dataset of size 10.
Rank-0 [WARNING]:arrow_dataset.py:map: num_proc must be <= 10. Reducing num_proc to 10 for dataset of size 10.
PyTorch: setting up devices
/Users/dushyantbehl/.python3.12-venv/lib/python3.12/site-packages/trl/trainer/sft_trainer.py:300: UserWarning: You passed a processing_class with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `processing_class.padding_side = 'right'` to your code.
  warnings.warn(
***** Running training *****
  Num examples = 10
  Num Epochs = 3
  Instantaneous batch size per device = 8
  Total train batch size (w. parallel, distributed & accumulation) = 8
  Gradient Accumulation steps = 1
  Total optimization steps = 6
  Number of trainable parameters = 4,621,504
{'loss': 8.9587, 'grad_norm': 60.75, 'learning_rate': 1.6666666666666667e-06, 'epoch': 0.5}                                                                                                                                                          
{'loss': 12.4824, 'grad_norm': 95.5, 'learning_rate': 1.3333333333333332e-06, 'epoch': 1.0}                                                                                                                                                          
 33%|██████████████████████████████████████████████████████████████████████                                                                                                                                            | 2/6 [00:00<00:00,  5.04it/s]Saving model checkpoint to /tmp/test-train/checkpoint-2
Configuration saved in /tmp/test-train/checkpoint-2/config.json
Configuration saved in /tmp/test-train/checkpoint-2/generation_config.json
Model weights saved in /tmp/test-train/checkpoint-2/model.safetensors
tokenizer config file saved in /tmp/test-train/checkpoint-2/tokenizer_config.json
Special tokens file saved in /tmp/test-train/checkpoint-2/special_tokens_map.json
{'loss': 8.9945, 'grad_norm': 56.0, 'learning_rate': 1e-06, 'epoch': 1.5}                                                                                                                                                                            
{'loss': 12.2642, 'grad_norm': 100.5, 'learning_rate': 6.666666666666666e-07, 'epoch': 2.0}                                                                                                                                                          
 67%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████                                                                      | 4/6 [00:00<00:00,  5.48it/s]Saving model checkpoint to /tmp/test-train/checkpoint-4
Configuration saved in /tmp/test-train/checkpoint-4/config.json
Configuration saved in /tmp/test-train/checkpoint-4/generation_config.json
Model weights saved in /tmp/test-train/checkpoint-4/model.safetensors
tokenizer config file saved in /tmp/test-train/checkpoint-4/tokenizer_config.json
Special tokens file saved in /tmp/test-train/checkpoint-4/special_tokens_map.json
{'loss': 9.7239, 'grad_norm': 48.5, 'learning_rate': 3.333333333333333e-07, 'epoch': 2.5}                                                                                                                                                            
{'loss': 8.4539, 'grad_norm': 76.0, 'learning_rate': 0.0, 'epoch': 3.0}                                                                                                                                                                              
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  6.35it/s]Saving model checkpoint to /tmp/test-train/checkpoint-6
Configuration saved in /tmp/test-train/checkpoint-6/config.json
Configuration saved in /tmp/test-train/checkpoint-6/generation_config.json
Model weights saved in /tmp/test-train/checkpoint-6/model.safetensors
tokenizer config file saved in /tmp/test-train/checkpoint-6/tokenizer_config.json
Special tokens file saved in /tmp/test-train/checkpoint-6/special_tokens_map.json


Training completed. Do not forget to share your model on huggingface.co/models =)


{'train_runtime': 1.1786, 'train_samples_per_second': 25.453, 'train_steps_per_second': 5.091, 'train_loss': 10.146263917287191, 'epoch': 3.0}                                                                                                       
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  5.09it/s]
(.python3.12-venv) ➜  fms-hf-tuning git:(main) 
```

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass