### PR TITLE
fix: use default dataprocessor if one is not provided

### DIFF
--- a/tests/artifacts/predefined_data_configs/pretokenized_data.yaml
+++ b/tests/artifacts/predefined_data_configs/pretokenized_data.yaml
@@ -1,5 +1,3 @@
-dataprocessor:
-    type: default
 datasets:
   - name: pretokenized_dataset
     data_paths:

--- a/tuning/data/data_config.py
+++ b/tuning/data/data_config.py
@@ -188,11 +188,21 @@ def load_and_validate_data_config(data_config_file: str) -> DataConfig:
     assert isinstance(
         raw_data["datasets"], list
     ), "datasets should be provided as a list"
+
     datasets = []
+    dataprocessor = None
+
     for d in raw_data["datasets"]:
         datasets.append(_validate_dataset_config(d))
     if "dataprocessor" in raw_data:
         dataprocessor = _validate_dataprocessor_config(raw_data["dataprocessor"])
+
+    if dataprocessor is None:
+        logging.info(
+            "`dataprocessor` filed is absent from data config. Using default dataprocessor"
+        )
+        dataprocessor = DataPreProcessorConfig()
+        logging.info("Default datapreprocessor is %s", str(dataprocessor))
 
     data_config = DataConfig(dataprocessor=dataprocessor, datasets=datasets)
     return data_config


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

if no `datapreprocessor` is provided in data config then the data pre processor fails with an error rather than falling back to default...this change fixes that.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass