### PR TITLE
fix: Disable caching in transformers via `use_cache` flag to avoid unncessary memory overhead

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -61,16 +61,6 @@ class ModelArguments:
                 tokenizer classes."
         },
     )
-    use_cache: bool = field(
-        default=False,
-        metadata={
-            "help": "This enables/disables the KV cache for model generation."
-            "This should be set to False in most cases, unless you are doing a finetuning"
-            "which specifically requires KV cache (for eg: prefix tuning)."
-            "`use_cache=True` is not compatible with `gradient_checkpointing=True`"
-            "and will be explicitly set to `False` in case `gradient_checkpointing=True`."
-        }
-    )
 
 
 @dataclass

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -61,6 +61,16 @@ class ModelArguments:
                 tokenizer classes."
         },
     )
+    use_cache: bool = field(
+        default=False,
+        metadata={
+            "help": "This enables/disables the KV cache for model generation."
+            "This should be set to False in most cases, unless you are doing a finetuning"
+            "which specifically requires KV cache (for eg: prefix tuning)."
+            "`use_cache=True` is not compatible with `gradient_checkpointing=True`"
+            "and will be explicitly set to `False` in case `gradient_checkpointing=True`."
+        }
+    )
 
 
 @dataclass

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -295,6 +295,11 @@ def train(
             else:
                 model_loader = AutoModelForCausalLM.from_pretrained
 
+            # avoid warning that use_cache is incompatible with gradient checkpointing
+            if model_args.use_cache and train_args.gradient_checkpointing:
+                logger.warning("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.")
+                model_args.use_cache = False
+
             model = model_loader(
                 model_args.model_name_or_path,
                 cache_dir=train_args.cache_dir,
@@ -302,8 +307,7 @@ def train(
                 attn_implementation="flash_attention_2"
                 if model_args.use_flash_attn
                 else None,
-                # avoid warning that use_cache is incompatible with gradient checkpointing
-                use_cache=(not train_args.gradient_checkpointing),
+                use_cache=model_args.use_cache,
             )
 
             # TODO: Move these to a config as well

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -269,9 +269,7 @@ def train(
             try:
                 if "use_cache" in model.language_model.config:
                     # avoid warning that use_cache is incompatible with gradient checkpointing
-                    model.language_model.config.use_cache = (
-                        not train_args.gradient_checkpointing
-                    )
+                    model.language_model.config.use_cache = False
             except AttributeError as e:
                 # When the model doesn't have the use_cache attribute
                 logger.warning("Couldn't update use_cache for vision model: %s", e)

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -295,11 +295,6 @@ def train(
             else:
                 model_loader = AutoModelForCausalLM.from_pretrained
 
-            # avoid warning that use_cache is incompatible with gradient checkpointing
-            if model_args.use_cache and train_args.gradient_checkpointing:
-                logger.warning("`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.")
-                model_args.use_cache = False
-
             model = model_loader(
                 model_args.model_name_or_path,
                 cache_dir=train_args.cache_dir,
@@ -307,7 +302,7 @@ def train(
                 attn_implementation="flash_attention_2"
                 if model_args.use_flash_attn
                 else None,
-                use_cache=model_args.use_cache,
+                use_cache=False,
             )
 
             # TODO: Move these to a config as well


### PR DESCRIPTION
### Description of the change

Sets the `use_cache=False`, disabling the model's KV cache while fine-tuning the model.

### Related issue number

Solves https://github.com/huggingface/transformers/issues/39795 for our stack.

### How to verify the PR
--

### Was the PR tested

Since this was a bug fix, I have tested multiple settings of the flags to verify that the memory usage has dropped for FSDP+LoRA use case.

In my toy example, with 4 GPUs on an 8b model with BF16 datatype, memory dropped from 28GB per GPU to 12GB per GPU.

- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass