### PR TITLE
fix: data processing job exiting with failure even though successful

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -374,7 +374,7 @@ def train(
         logger.info(
             "Only data processing was requested. Exiting Process.",
         )
-        return None, None
+        return None, None, None
 
     if framework is not None and framework.requires_augmentation:
         model, (peft_config,) = framework.augmentation(


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

With the experimental Trainer Controller changes in https://github.com/foundation-model-stack/fms-hf-tuning/pull/558 the `data processing only` mode was broken and it failed with an error due to missing argument even though the execution was correct. 

This patch fixes that.

Before - 
```
(.python3.12-venv) ➜  checkpoint rm -rf /tmp/test-train && python3 -m tuning.sft_trainer \
--model_name_or_path "/Volumes/Projects/Projects/ai-platform-engg/granitebuild/checkpoint/basemodel/" \
--output_dir /tmp/test-train/ \
--use_flash_attn False \
--do_dataprocessing_only --num_train_dataset_shards 1 --data_config /Volumes/Projects/Projects/ai-platform-engg/finetuning-defense/data_config.yml
Rank-0 [INFO]:sft_trainer.py:main: fms-hf-tuning execution start
Rank-0 [INFO]:sft_trainer.py:main: 
....
Rank-0 [INFO]:data_processors.py:process_dataset_configs: Processed eval dataset None
Flattening the indices: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1910/1910 [00:00<00:00, 27856.73 examples/s]
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Dumping processesd dataaset train_dataset at /tmp/test-train/train_dataset in 1 shards
Creating parquet from Arrow format: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.90ba/s]
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Dumped 1 shards of train_dataset
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Saved dataset train_dataset to /tmp/test-train/train_dataset
Rank-0 [INFO]:setup_dataprocessor.py:process_dataargs: Data Processing execution completed. Datasets saved in /tmp/test-train/ directory.
Rank-0 [INFO]:sft_trainer.py:train: Only data processing was requested. Exiting Process.
Rank-0 [ERROR]:sft_trainer.py:main: Traceback (most recent call last):
  File "/Volumes/Projects/Projects/ai-platform-engg/fms-hf-tuning/tuning/sft_trainer.py", line 762, in main
    trainer, additional_train_info, tc_callback = train(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 3, got 2)
```

After - 

```

(.python3.12-venv) ➜  checkpoint rm -rf /tmp/test-train && python3 -m tuning.sft_trainer \
--model_name_or_path "/Volumes/Projects/Projects/ai-platform-engg/granitebuild/checkpoint/basemodel/" \
--output_dir /tmp/test-train/ \
--use_flash_attn False \
--do_dataprocessing_only --num_train_dataset_shards 1 --data_config /Volumes/Projects/Projects/ai-platform-engg/finetuning-defense/data_config.yml
Rank-0 [INFO]:sft_trainer.py:main: fms-hf-tuning execution start
Rank-0 [INFO]:sft_trainer.py:main: 
========================= Flat Arguments =========================
...
Rank-0 [INFO]:data_processors.py:process_dataset_configs: Processed eval dataset None
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Dumping processesd dataaset train_dataset at /tmp/test-train/train_dataset in 1 shards
Creating parquet from Arrow format: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.95ba/s]
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Dumped 1 shards of train_dataset
Rank-0 [INFO]:setup_dataprocessor.py:dump_dataset: Saved dataset train_dataset to /tmp/test-train/train_dataset
Rank-0 [INFO]:setup_dataprocessor.py:process_dataargs: Data Processing execution completed. Datasets saved in /tmp/test-train/ directory.
Rank-0 [INFO]:sft_trainer.py:train: Only data processing was requested. Exiting Process.
```

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass