### PR TITLE
fix: Rank is set to zero by default

### DIFF
--- a/tuning/trainercontroller/controllermetrics/per_process_state.py
+++ b/tuning/trainercontroller/controllermetrics/per_process_state.py
@@ -74,4 +74,4 @@ class PerProcessState(MetricHandler):
         """
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             return {"rank": torch.distributed.get_rank()}
-        return {"rank": None}
+        return {"rank": 0}


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

The rank is set to zero when the distributed mode is not initialized.

<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->
Use **accelerate** and this trainer controller [configuration](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/examples/trainercontroller_configs/logging_controller_with_rank.yaml). The info log should show the Rank to 0 when a single-gpu is used.

### Was the PR tested

<!-- Describe how PR was tested -->
- [X] I have added >=1 unit test(s) for every new method I have added.
- [X] I have ensured all unit tests pass