### PR TITLE
fix: Rollback trl to a version which doesn't overwrite labels and attention masks.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 "sentencepiece>=0.1.99,<0.3",
 "tokenizers>=0.13.3,<1.0",
 "tqdm>=4.66.2,<5.0",
-"trl>=0.13,<0.18",
+"trl>=0.13,<0.17",
 "peft>=0.15.0,<=0.15.2",
 "protobuf>=5.28.0,<6.0.0",
 "datasets>=3.5.0,<4.0",

--- a/tuning/data/data_preprocessing_utils.py
+++ b/tuning/data/data_preprocessing_utils.py
@@ -98,10 +98,9 @@ def get_data_collator(
         # was removed from tokenized data processing, should eventually
         # be added back in with support directly in fms-hf-tuning, not
         # dependent on trl.
-        # return DataCollatorForSeq2Seq(
-        #     tokenizer=tokenizer, padding=True, max_length=max_seq_length
-        # )
-        return None
+        return DataCollatorForSeq2Seq(
+            tokenizer=tokenizer, padding=True, max_length=max_seq_length
+        )
 
     # TODO: near term - how response template ids are parsed out needs to be cleaned.
     # The [2:] here applies if response template has \n prefix, it is needed to strip \n,


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
<!-- Please summarize the changes -->

This PR rolbacks trl to v16.1 to solve https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1913

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass