### PR TITLE
fix: add default optim arg in training arg

### DIFF
--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -251,6 +251,13 @@ class TrainingArguments(transformers.TrainingArguments):
             Other possible values are 'debug', 'info', 'warning', 'error' and 'critical'"
         },
     )
+    optim: str = field(
+        default="adamw_torch",
+        metadata={
+            "help": "Pass optimizer name to use during training. \
+                Please only use the optimizers that are supported with HF transformers"
+        },
+    )
     enable_reduce_loss_sum: bool = field(
         default=False,
         metadata={


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
The change defaults the optimizer argument to `adamw_torch` as default for fms-hf-tuning.

The default for hf trainer is `adamw_torch_fused` which wont be compatible with mixed precision, given that we push for mixed precision ="bf16" for performance, I propose we should make `adamw_torch` as default for our stack..
[hf optim](https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.TrainingArguments.optim)
### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->
