### PR TITLE
feat: Adopt resumption feature of online data mixing

### DIFF
--- a/tuning/config/acceleration_configs/odm.py
+++ b/tuning/config/acceleration_configs/odm.py
@@ -27,6 +27,7 @@ class ODM:
     reward_type: str = None
     gamma: float = 0.1
     eta: float = 0.1
+    resume_from_checkpoint: Union[bool, str] = False
 
 
 @dataclass


### PR DESCRIPTION
## Changes

In this PR, we move construction of the `resume_from_checkpoint` to the top of the function so that it can used in odm_config. Further depends on merge of https://github.com/foundation-model-stack/fms-acceleration/pull/155