### PR TITLE
fix: fix Dockerfile ubi9 base

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,7 +27,7 @@ ARG ENABLE_SCANNER=false
 ARG ENABLE_CLEARML=false
 
 ## Base Layer ##################################################################
-FROM registry.access.redhat.com/ubi9/ubi:${BASE_UBI_IMAGE_TAG} AS base
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1758184894 AS base
 
 ARG PYTHON_VERSION
 ARG USER


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change
Default to use : `ubi9/ubi:9.6-1758184894` in Dockerfile
https://catalog.redhat.com/en/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?image=68cc233126a59a51953ccb56#get-this-image

The latest base image: `ubi9/ubi:9.6-1760340943` has issue while building image test which we are having trouble to replicate on vm as the same Dockerfile builds fine without any error.
```
> [python-installations  8/14] RUN --mount=type=cache,target=/home/tuning/.cache/pip,uid=1000     python -m pip install --user wheel &&     python -m pip install --user "$(head bdist_name)" &&     python -m pip install --user "$(head bdist_name)[flash-attn]" &&     python -m pip install --user --no-build-isolation "$(head bdist_name)[mamba]":
#33 442.7         File "/tmp/pip-build-env-zejlth0s/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
#33 442.7           super().run_setup(setup_script=setup_script)
#33 442.7         File "/tmp/pip-build-env-zejlth0s/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
#33 442.7           exec(code, locals())
#33 442.7         File "<string>", line 22, in <module>
#33 442.7       ModuleNotFoundError: No module named 'torch'
#33 442.7       [end of output]
#33 442.7   
#33 442.7   note: This error originates from a subprocess, and is likely not a problem with pip.
#33 442.7 ERROR: Failed to build 'flash-attn' when getting requirements to build wheel
```
<!-- Please summarize the changes -->

### Related issue number

<!-- For example: "Closes #1234" -->

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [x] I have added >=1 unit test(s) for every new method I have added.
- [x] I have ensured all unit tests pass