### PR TITLE
fix: only trigger on_save if the output checkpoint path actually contains files

### DIFF
--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -576,10 +576,36 @@ def save(path: str, trainer: SFTTrainer, tc_callback, log_level="WARNING", args=
 
     logger.info("Saving tuned model to path: %s", path)
     trainer.save_model(path)
+    actually_saved = False
     if tc_callback and args:
-        tc_callback.on_save(
-            args, trainer.state, trainer.control, path=path, is_final=True
-        )
+        if os.path.exists(path):
+            try:
+                saved_files = os.listdir(path)
+                logger.info(
+                    "sanity check, we found %d files at checkpoint path '%s'",
+                    len(saved_files),
+                    path,
+                )
+                actually_saved = len(saved_files) > 0
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logger.error(
+                    "sanity check, failed to list files in checkpoint path '%s' , error: %s",
+                    path,
+                    e,
+                )
+        else:
+            logger.warning(
+                "sanity check, failed because checkpoint path '%s' doesn't exist", path
+            )
+        if actually_saved:
+            tc_callback.on_save(
+                args, trainer.state, trainer.control, path=path, is_final=True
+            )
+        else:
+            logger.warning(
+                "skip triggering on_save event since checkpoint path is empty: '%s'",
+                path,
+            )
 
 
 def get_parser():


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

Trigger `on_save` event only if anything was actually saved in the output checkpoint directory.
This simplifies the use of trainer_controller for triggering subsequent steps (like artifact upload)

### Related issue number

Internal issue in our pipeline

### How to verify the PR

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass